### PR TITLE
✨ prepare v7.0.0a1 and GHCR image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.venv
+__pycache__
+.mypy_cache
+.pytest_cache
+.ruff_cache
+dist
+tmp
+tests
+docs
+scripts
+data
+cache
+plugins
+*.pyc
+*.pyo

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,63 @@
+name: v7 Docker
+
+on:
+  pull_request:
+    branches: [v7]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - .github/workflows/docker.yaml
+      - liteyuki.example.toml
+      - pyproject.toml
+      - src/**
+      - uv.lock
+  push:
+    tags: ["v7.*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=sha-
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 7.0.0a1 - 2026-08-04
+
+The first v7 pre-release provides the kernel foundation for a protocol-neutral,
+single-host chatbot runtime:
+
+- immutable configuration with ordered includes and environment/CLI overrides;
+- Yukilog 1.x integration with structured child-runtime logs;
+- native plugin entry points, services, lifecycle hooks, managed tasks, and private storage;
+- bounded event/action dispatch with per-conversation ordering and backpressure;
+- authenticated framed IPC, runtime supervision, heartbeat, restart, and local control;
+- isolated NoneBot2 hosting and an explicit LiteyukiBot v6 compatibility boundary;
+- `liteyuki`/`ly` CLI, optional loopback HTTP status API, and cross-platform CI baselines;
+- Python 3.14, uv, PyPI packaging, and a non-root GHCR Docker image.
+
+This is an integration pre-release. Public contracts, compatibility coverage, and
+operational behavior remain subject to the Phase 2 stabilization work described
+in `docs/architecture/v7.md`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM python:3.14-slim-bookworm AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    UV_NO_CACHE=1 \
+    UV_PROJECT_ENVIRONMENT=/opt/venv
+
+WORKDIR /build
+
+RUN pip install --no-cache-dir uv==0.11.16
+
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY src ./src
+
+RUN uv sync --locked --no-dev --no-editable \
+    --extra yaml \
+    --extra http \
+    --extra nonebot \
+    --extra onebot \
+    --extra satori \
+    && /opt/venv/bin/liteyuki version
+
+FROM python:3.14-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:${PATH}" \
+    LITEYUKI__CORE__DATA_DIR=/app/data \
+    LITEYUKI__CORE__CACHE_DIR=/app/cache
+
+WORKDIR /app
+
+RUN groupadd --system --gid 10001 liteyuki \
+    && useradd --system --uid 10001 --gid liteyuki --home-dir /app --no-create-home liteyuki \
+    && mkdir -p /app/data /app/cache /app/plugins \
+    && chown -R liteyuki:liteyuki /app
+
+COPY --from=builder /opt/venv /opt/venv
+COPY --chown=liteyuki:liteyuki liteyuki.example.toml /app/liteyuki.example.toml
+
+VOLUME ["/app/data", "/app/cache", "/app/plugins"]
+
+USER liteyuki
+
+ENTRYPOINT ["liteyuki"]
+CMD ["run"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ precede the subcommand, for example:
 uv run liteyuki --config local.toml --set logging.level=DEBUG check
 ```
 
+## Docker
+
+The v7 pre-release image is published to GHCR as
+`ghcr.io/liteyukistudio/liteyukibot:v7.0.0a1`. It includes the optional YAML,
+HTTP, NoneBot2, OneBot, and Satori integrations, and runs as a non-root user.
+
+```bash
+docker pull ghcr.io/liteyukistudio/liteyukibot:v7.0.0a1
+docker run --rm ghcr.io/liteyukistudio/liteyukibot:v7.0.0a1 version
+```
+
+Mount a `liteyuki.toml` at `/app/liteyuki.toml` and persistent volumes at
+`/app/data`, `/app/cache`, and `/app/plugins` for a configured deployment.
+
 ## Development
 
 ```bash

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -66,3 +66,11 @@ dispatch latency, and peak RSS. CI uploads one baseline per operating system.
 After the first stable release fixes reference values, a regression over 20%
 requires an explicit performance review; noisy pre-release snapshots are not
 used as an automatic pass/fail threshold.
+
+## Pre-release Delivery
+
+Phase 1 is distributed as `7.0.0a1` on PyPI and as a non-root image at
+`ghcr.io/liteyukistudio/liteyukibot:v7.0.0a1`. The Docker image is built from
+the locked uv environment and includes all current optional integrations. Pull
+requests build the image without publishing; version tags publish both the
+package and the GHCR image.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot"
-version = "7.0.0.dev0"
+version = "7.0.0a1"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/liteyuki/__init__.py
+++ b/src/liteyuki/__init__.py
@@ -19,4 +19,4 @@ __all__ = [
     "logger",
 ]
 
-__version__ = "7.0.0.dev0"
+__version__ = "7.0.0a1"

--- a/src/liteyukibot/__init__.py
+++ b/src/liteyukibot/__init__.py
@@ -15,4 +15,4 @@ __all__ = [
     "ServiceRequirement",
 ]
 
-__version__ = "7.0.0.dev0"
+__version__ = "7.0.0a1"

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot"
-version = "7.0.0.dev0"
+version = "7.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- bump the package and compatibility namespace to 7.0.0a1\n- add release notes and pre-release delivery documentation\n- add a locked, non-root Docker image with the current optional integrations\n- build Docker images on v7 PRs and publish tagged images to GHCR\n\n## Release path\nAfter merge, create tag v7.0.0a1. The existing PyPI workflow publishes the package and the new Docker workflow publishes ghcr.io/liteyukistudio/liteyukibot:v7.0.0a1.\n\n## Validation\n- uv sync --locked --extra nonebot --extra http\n- Ruff, strict Mypy, 27 tests, uv lock --check, and uv build pass locally\n- Docker build is validated by the PR workflow because the local Docker daemon is unavailable\n\n## Scope\nThis is the Phase 1 pre-release artifact. PyO3, hot reload, runtime package installation, multi-node operation, and hostile-plugin sandboxing remain deferred by design.