### PR TITLE
🔖 use v7-specific PyPI distribution name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ single-host chatbot runtime:
 - `liteyuki`/`ly` CLI, optional loopback HTTP status API, and cross-platform CI baselines;
 - Python 3.14, uv, PyPI packaging, and a non-root GHCR Docker image.
 
+The PyPI distribution is named `liteyukibot-v7`; the import namespaces remain
+`liteyukibot` and `liteyuki`.
+
 This is an integration pre-release. Public contracts, compatibility coverage, and
 operational behavior remain subject to the Phase 2 stabilization work described
 in `docs/architecture/v7.md`.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ line for v6 and is not merged wholesale into v7.
 - network access for uv to resolve PyPI dependencies
 
 Yukilog 1.x is installed from PyPI; no sibling checkout is required.
+The v7 distribution on PyPI is named `liteyukibot-v7`; Python imports remain
+`liteyukibot` and `liteyuki` for the native and v6 compatibility namespaces.
 
 ```bash
 uv sync --locked

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -11,6 +11,9 @@ is a lifecycle and dependency boundary, not a hostile-code sandbox.
 The runtime dependency budget is intentionally small: Pydantic and Yukilog.
 YAML, HTTP, NoneBot, and adapters are opt-in extras. uv exclusively owns project
 resolution and locking; runtime package installation is not part of the core.
+The published distribution is `liteyukibot-v7`; the import namespaces remain
+`liteyukibot` and `liteyuki` so plugin source compatibility is independent of
+the PyPI project name.
 
 ## Lifecycle
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "liteyukibot"
+name = "liteyukibot-v7"
 version = "7.0.0a1"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"

--- a/src/liteyukibot/config/loader.py
+++ b/src/liteyukibot/config/loader.py
@@ -254,7 +254,7 @@ class _FileLoader:
             self.issues.append(
                 ConfigIssue(
                     path,
-                    "YAML support is not installed; run `uv add 'liteyukibot[yaml]'` or use TOML/JSON",
+                    "YAML support is not installed; run `uv add 'liteyukibot-v7[yaml]'` or use TOML/JSON",
                 )
             )
             return None

--- a/src/liteyukibot/http.py
+++ b/src/liteyukibot/http.py
@@ -24,7 +24,7 @@ class HttpServer:
             uvicorn = importlib.import_module("uvicorn")
         except ModuleNotFoundError as error:
             raise RuntimeError(
-                "HTTP status API is enabled but not installed; run `uv add 'liteyukibot[http]'`"
+                "HTTP status API is enabled but not installed; run `uv add 'liteyukibot-v7[http]'`"
             ) from error
 
         app = fastapi.FastAPI(title="LiteyukiBot", docs_url=None, redoc_url=None, openapi_url=None)

--- a/src/liteyukibot/runtime/nonebot.py
+++ b/src/liteyukibot/runtime/nonebot.py
@@ -284,7 +284,7 @@ def run() -> None:
         nonebot = importlib.import_module("nonebot")
     except ModuleNotFoundError as error:
         raise RuntimeError(
-            "NoneBot runtime is not installed; run `uv add 'liteyukibot[nonebot]'`"
+            "NoneBot runtime is not installed; run `uv add 'liteyukibot-v7[nonebot]'`"
         ) from error
     configure_child_runtime()
     bridge = SupervisorBridge()

--- a/tests/test_config_v7.py
+++ b/tests/test_config_v7.py
@@ -185,7 +185,7 @@ def test_yaml_support_is_lazy_and_has_an_actionable_missing_extra_error(
         return real_import_module(name)
 
     monkeypatch.setattr(importlib, "import_module", fail_yaml_import)
-    with pytest.raises(ConfigurationError, match=r"liteyukibot\[yaml\]"):
+    with pytest.raises(ConfigurationError, match=r"liteyukibot-v7\[yaml\]"):
         load_settings(yaml_path, environ={})
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 ]
 
 [[package]]
-name = "liteyukibot"
+name = "liteyukibot-v7"
 version = "7.0.0a1"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary\n- rename the published distribution from liteyukibot to liteyukibot-v7 because the v6 project owns liteyukibot on PyPI\n- keep the liteyukibot and liteyuki import namespaces unchanged\n- update uv lock metadata, optional-extra diagnostics, docs, and regression assertions\n\n## Validation\n- uv sync --locked --extra nonebot --extra http\n- Ruff, strict Mypy, 27 tests, uv lock --check, and uv build pass\n- built liteyukibot_v7-7.0.0a1 and verified both import namespaces plus CLI version\n\n## Release\nThe existing pending publisher liteyukibot-v7 will match this project name after merge. Docker/GHCR publication remains deferred while local Docker Desktop validation is performed.