### PR TITLE
🔒 harden kernel lifecycle and protocol boundaries

### DIFF
--- a/src/liteyukibot/cli.py
+++ b/src/liteyukibot/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import signal
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -90,10 +91,51 @@ def _list_plugins(settings: AppSettings) -> None:
 
 def _run(settings: AppSettings) -> int:
     try:
-        asyncio.run(LiteyukiApp(settings).run())
+        asyncio.run(_run_until_signal(settings))
     except KeyboardInterrupt:
         return 130
     return 0
+
+
+async def _run_until_signal(settings: AppSettings) -> None:
+    """Run the app until SIGINT/SIGTERM and always perform graceful cleanup."""
+
+    app = LiteyukiApp(settings)
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    async_handlers: list[signal.Signals] = []
+    fallback_handlers: dict[signal.Signals, Any] = {}
+
+    def request_stop() -> None:
+        loop.call_soon_threadsafe(stop_event.set)
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(signum, request_stop)
+        except (NotImplementedError, RuntimeError, ValueError):
+            try:
+                previous = signal.getsignal(signum)
+                signal.signal(signum, lambda _signum, _frame: request_stop())
+            except (OSError, RuntimeError, ValueError):
+                continue
+            fallback_handlers[signum] = previous
+        else:
+            async_handlers.append(signum)
+
+    started = False
+    try:
+        await app.start()
+        started = True
+        await stop_event.wait()
+    finally:
+        try:
+            if started:
+                await app.stop()
+        finally:
+            for signum in async_handlers:
+                loop.remove_signal_handler(signum)
+            for signum, previous in fallback_handlers.items():
+                signal.signal(signum, previous)
 
 
 async def _runtime_command(settings: AppSettings, command: str, args: argparse.Namespace) -> int:

--- a/src/liteyukibot/control.py
+++ b/src/liteyukibot/control.py
@@ -7,6 +7,7 @@ import json
 import os
 import secrets
 from collections.abc import Awaitable, Callable, Mapping
+from ipaddress import ip_address
 from pathlib import Path
 from typing import Any
 
@@ -109,9 +110,7 @@ async def request_control(
     try:
         raw_descriptor = await asyncio.to_thread(descriptor_path.read_text, encoding="utf-8")
         descriptor = json.loads(raw_descriptor)
-        host = str(descriptor["host"])
-        port = int(descriptor["port"])
-        token = str(descriptor["token"])
+        host, port, token = _validate_descriptor(descriptor)
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         raise ControlError(f"cannot read control descriptor {descriptor_path}: {error}") from error
 
@@ -136,6 +135,35 @@ async def request_control(
     finally:
         writer.close()
         await writer.wait_closed()
+
+
+def _validate_descriptor(value: Any) -> tuple[str, int, str]:
+    if not isinstance(value, dict):
+        raise ControlError("control descriptor must be an object")
+    protocol = value.get("protocol")
+    if type(protocol) is not int or protocol != 1:
+        raise ControlError("unsupported control descriptor protocol")
+
+    host = value.get("host")
+    if not isinstance(host, str) or not host.strip():
+        raise ControlError("control descriptor host must be a non-empty string")
+    host = host.strip()
+    is_loopback = host.lower() == "localhost"
+    if not is_loopback:
+        try:
+            is_loopback = ip_address(host).is_loopback
+        except ValueError:
+            is_loopback = False
+    if not is_loopback:
+        raise ControlError("control descriptor host must be loopback")
+
+    port = value.get("port")
+    if type(port) is not int or not 1 <= port <= 65535:
+        raise ControlError("control descriptor port must be between 1 and 65535")
+    token = value.get("token")
+    if not isinstance(token, str) or not token:
+        raise ControlError("control descriptor token must be a non-empty string")
+    return host, port, token
 
 
 __all__ = ["ControlError", "ControlServer", "request_control"]

--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -64,6 +64,25 @@ async def test_app_lifecycle_and_local_control(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("descriptor", "message"),
+    [
+        ({"protocol": 1, "host": "192.0.2.1", "port": 1, "token": "secret"}, "loopback"),
+        ({"protocol": 2, "host": "127.0.0.1", "port": 1, "token": "secret"}, "protocol"),
+        ({"protocol": 1, "host": "127.0.0.1", "port": 0, "token": "secret"}, "port"),
+    ],
+)
+async def test_control_rejects_untrusted_descriptor(
+    tmp_path: Path, descriptor: dict[str, object], message: str
+) -> None:
+    path = tmp_path / "control.json"
+    path.write_text(json.dumps(descriptor), encoding="utf-8")
+
+    with pytest.raises(ControlError, match=message):
+        await request_control(path, "status")
+
+
+@pytest.mark.asyncio
 async def test_startup_failure_stops_plugins_already_set_up(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_protocol_v7.py
+++ b/tests/test_protocol_v7.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+from typing import Any, cast
+
+import pytest
+
+from liteyukibot.exceptions import RuntimeProtocolError
+from liteyukibot.runtime.protocol import (
+    MAX_FRAME_SIZE,
+    ConfigMessage,
+    Ready,
+    json_mapping,
+    read_message,
+    write_message,
+)
+
+
+class MemoryWriter:
+    def __init__(self) -> None:
+        self.chunks: list[bytes] = []
+
+    def write(self, value: bytes) -> None:
+        self.chunks.append(value)
+
+    async def drain(self) -> None:
+        return None
+
+
+def _reader(payload: bytes) -> asyncio.StreamReader:
+    reader = asyncio.StreamReader()
+    reader.feed_data(payload)
+    reader.feed_eof()
+    return reader
+
+
+@pytest.mark.asyncio
+async def test_protocol_round_trip_preserves_message_shape() -> None:
+    message = ConfigMessage(options={"nested": {"enabled": True}})
+    writer = MemoryWriter()
+
+    await write_message(cast(asyncio.StreamWriter, writer), message)
+
+    frame = b"".join(writer.chunks)
+    assert struct.unpack(">I", frame[:4])[0] == len(frame) - 4
+    assert await read_message(_reader(frame)) == message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        struct.pack(">I", 0),
+        struct.pack(">I", MAX_FRAME_SIZE + 1),
+        struct.pack(">I", 3) + b"{}?",
+        struct.pack(">I", len(json.dumps({"type": "ready", "unexpected": True}).encode()))
+        + json.dumps({"type": "ready", "unexpected": True}).encode(),
+    ],
+)
+async def test_protocol_rejects_invalid_frames(payload: bytes) -> None:
+    with pytest.raises(RuntimeProtocolError):
+        await read_message(_reader(payload))
+
+
+@pytest.mark.asyncio
+async def test_protocol_rejects_truncated_frame() -> None:
+    with pytest.raises(EOFError, match="during frame"):
+        await read_message(_reader(struct.pack(">I", 10) + b"{}"))
+
+
+def test_json_mapping_rejects_non_json_values() -> None:
+    with pytest.raises((TypeError, ValueError)):
+        json_mapping({"invalid": object()})
+
+
+def test_json_mapping_returns_mutable_json_object() -> None:
+    value: dict[str, Any] = {"items": (1, 2), "nested": {"ok": True}}
+
+    result = json_mapping(value)
+
+    assert result == {"items": [1, 2], "nested": {"ok": True}}
+
+
+@pytest.mark.asyncio
+async def test_protocol_accepts_discriminated_ready_message() -> None:
+    payload = json.dumps(Ready(capabilities=("events",)).model_dump(mode="json")).encode()
+    frame = struct.pack(">I", len(payload)) + payload
+
+    assert await read_message(_reader(frame)) == Ready(capabilities=("events",))

--- a/tests/test_runtime_v7.py
+++ b/tests/test_runtime_v7.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import importlib.util
+import time
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from liteyukibot.runtime import RuntimeSpec, RuntimeState, RuntimeSupervisor
+from liteyukibot.runtime.protocol import Hello, write_message
+from liteyukibot.runtime.supervisor import RuntimeRecord
 
 
 class FakeLogger:
@@ -77,6 +82,65 @@ async def test_runtime_spawn_failure_is_reported_without_waiting_for_ready_timeo
 
     with pytest.raises(RuntimeError, match="failed before becoming ready"):
         await supervisor.start()
+
+
+@pytest.mark.asyncio
+async def test_runtime_rejects_bad_and_duplicate_connections() -> None:
+    supervisor = RuntimeSupervisor(logger=FakeLogger())
+    supervisor.add(
+        RuntimeSpec(
+            id="echo",
+            kind="noop",
+            ready_timeout=5,
+            heartbeat_interval=0.05,
+            stale_after=1,
+        )
+    )
+
+    await supervisor.start()
+    record = supervisor.records["echo"]
+    for token in ("wrong", record.token):
+        reader, writer = await asyncio.open_connection("127.0.0.1", supervisor._port)
+        await write_message(writer, Hello(runtime_id="echo", kind="noop", token=token))
+        assert await asyncio.wait_for(reader.read(), timeout=1) == b""
+        writer.close()
+        await writer.wait_closed()
+        assert record.state is RuntimeState.READY
+
+    await supervisor.stop()
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_timeout_terminates_stale_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeProcess:
+        terminated = False
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+    supervisor = RuntimeSupervisor(logger=FakeLogger())
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="stale", kind="noop", heartbeat_interval=0.05, stale_after=0.1),
+        token="token",
+        state=RuntimeState.READY,
+        last_heartbeat=time.monotonic() - 1,
+    )
+    process = FakeProcess()
+    record.process = process  # type: ignore[assignment]
+    supervisor.records[record.spec.id] = record
+    sleeps = 0
+
+    async def fake_sleep(_seconds: float) -> None:
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps > 1:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    with suppress(asyncio.CancelledError):
+        await supervisor._watch_heartbeats()
+
+    assert process.terminated is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_tasks_v7.py
+++ b/tests/test_tasks_v7.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from liteyukibot.tasks import ManagedTasks
+
+
+@pytest.mark.asyncio
+async def test_managed_task_failure_is_reported() -> None:
+    failures: list[tuple[str, BaseException]] = []
+    tasks = ManagedTasks("plugin", lambda name, error: failures.append((name, error)))
+
+    async def fail() -> None:
+        raise RuntimeError("broken worker")
+
+    task = tasks.start(fail(), name="worker")
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+
+    assert task.done()
+    assert len(failures) == 1
+    assert failures[0][0] == "plugin:worker"
+    assert isinstance(failures[0][1], RuntimeError)
+    assert str(failures[0][1]) == "broken worker"
+    await tasks.stop()
+
+
+@pytest.mark.asyncio
+async def test_managed_tasks_cancel_on_stop_and_reject_new_work() -> None:
+    started = asyncio.Event()
+    tasks = ManagedTasks("plugin")
+
+    async def worker() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    task = tasks.start(worker(), name="worker")
+    await started.wait()
+    await tasks.stop()
+
+    assert task.cancelled()
+    pending = asyncio.sleep(0)
+    try:
+        with pytest.raises(RuntimeError, match="stopping"):
+            tasks.start(pending, name="late")
+    finally:
+        pending.close()


### PR DESCRIPTION
## Summary\n- handle SIGINT/SIGTERM through a graceful application stop path\n- validate control descriptor protocol, loopback host, port, and token before connecting\n- add framed protocol boundary tests for round trips, malformed/oversized/truncated frames, extra fields, and JSON safety\n- add runtime authentication, duplicate connection, heartbeat expiry, and managed-task failure/cancellation coverage\n\n## Validation\n- Ruff\n- strict Mypy (57 source files)\n- 43 Pytest tests\n- uv lock --check\n- uv build\n\nThe architecture draft remains in ignored 	mp/v7-architecture-draft.md and records the Phase 2 exit criteria.