### PR TITLE
🧪 add plugin contract coverage

### DIFF
--- a/src/liteyukibot/plugins.py
+++ b/src/liteyukibot/plugins.py
@@ -65,8 +65,19 @@ class PluginManifest(BaseModel):
     @field_validator("id")
     @classmethod
     def validate_id(cls, value: str) -> str:
-        if not value or value.strip("abcdefghijklmnopqrstuvwxyz0123456789-_."):
+        if (
+            not value
+            or value.strip("abcdefghijklmnopqrstuvwxyz0123456789-_.")
+            or any(not part for part in value.split("."))
+        ):
             raise ValueError("plugin id must use lowercase ASCII letters, digits, '-', '_' or '.'")
+        return value
+
+    @field_validator("name", "version")
+    @classmethod
+    def validate_required_metadata(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("plugin manifest metadata must not be blank")
         return value
 
 

--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -144,6 +144,86 @@ async def test_startup_failure_stops_plugins_already_set_up(
 
 
 @pytest.mark.asyncio
+async def test_partial_plugin_startup_stops_handles_in_reverse_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = ServiceKey("test.partial-start")
+    calls: list[str] = []
+
+    async def provider_setup(context: Any) -> PluginHandle:
+        context.services.provide(service, "ready")
+        calls.append("provider.setup")
+
+        async def start() -> None:
+            calls.append("provider.start")
+
+        async def stop() -> None:
+            calls.append("provider.stop")
+
+        return PluginHandle(start=start, stop=stop)
+
+    async def consumer_setup(context: Any) -> PluginHandle:
+        assert context.services.require(service) == "ready"
+        calls.append("consumer.setup")
+
+        async def start() -> None:
+            calls.append("consumer.start")
+            raise RuntimeError("consumer start failed")
+
+        async def stop() -> None:
+            calls.append("consumer.stop")
+
+        return PluginHandle(start=start, stop=stop)
+
+    provider = ModuleType("test_v7_partial_provider")
+    cast(Any, provider).plugin = PluginDefinition(
+        PluginManifest(
+            id="provider",
+            name="Provider",
+            version="1",
+            provides=(service,),
+        ),
+        provider_setup,
+    )
+    consumer = ModuleType("test_v7_partial_consumer")
+    cast(Any, consumer).plugin = PluginDefinition(
+        PluginManifest(
+            id="consumer",
+            name="Consumer",
+            version="1",
+            requires=(ServiceRequirement(service),),
+        ),
+        consumer_setup,
+    )
+    monkeypatch.setitem(sys.modules, provider.__name__, provider)
+    monkeypatch.setitem(sys.modules, consumer.__name__, consumer)
+
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
+        plugins=PluginSettings(
+            enabled=("provider", "consumer"),
+            local_modules=(provider.__name__, consumer.__name__),
+        ),
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="consumer start failed"):
+        await app.start()
+
+    assert app.state is AppState.FAILED
+    assert calls == [
+        "provider.setup",
+        "consumer.setup",
+        "provider.start",
+        "consumer.start",
+        "consumer.stop",
+        "provider.stop",
+    ]
+    assert app.services.get(service) is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(importlib.util.find_spec("fastapi") is None, reason="HTTP extra is not installed")
 async def test_optional_http_status_is_loopback_and_read_only(tmp_path: Path) -> None:
     with socket.socket() as listener:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from typing import Any, cast
@@ -51,12 +52,124 @@ class FakeLogger:
         pass
 
 
+class RecordingLogger(FakeLogger):
+    def __init__(self) -> None:
+        self.failures: list[tuple[str, tuple[Any, ...]]] = []
+        self.failure_reported = asyncio.Event()
+
+    def error(self, message: str, *args: Any, **kwargs: Any) -> None:
+        self.failures.append((message, args))
+        self.failure_reported.set()
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, candidate: object) -> None:
+        self.name = name
+        self._candidate = candidate
+
+    def load(self) -> object:
+        return self._candidate
+
+
+def make_manager(tmp_path: Path, *, logger: FakeLogger | None = None) -> PluginManager:
+    return PluginManager(
+        services=ServiceRegistry(),
+        events=cast(EventBus, object()),
+        actions=cast(ActionServiceLike, object()),
+        logger=logger or FakeLogger(),
+        data_dir=tmp_path / "data",
+        cache_dir=tmp_path / "cache",
+    )
+
+
 def test_service_registry_rejects_duplicate_provider() -> None:
     registry = ServiceRegistry()
     key = ServiceKey("example.clock")
     registry.provide(key, object(), provider="first")
     with pytest.raises(ServiceError, match="already provided"):
         registry.provide(key, object(), provider="second")
+
+
+def test_plugin_manifest_rejects_invalid_identity_and_metadata() -> None:
+    with pytest.raises(ValueError, match="plugin id"):
+        PluginManifest(id="invalid..id", name="Example", version="1.0.0")
+    with pytest.raises(ValueError, match="metadata must not be blank"):
+        PluginManifest(id="example", name="   ", version="1.0.0")
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        PluginManifest.model_validate(
+            {"id": "example", "name": "Example", "version": "1.0.0", "unknown": True}
+        )
+
+
+def test_plugin_manager_discovers_enabled_entry_point(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def setup(_context: PluginContext) -> None:
+        return None
+
+    definition = PluginDefinition(
+        PluginManifest(id="entry-point", name="Entry point", version="1.0.0"), setup
+    )
+
+    def entry_points(*, group: str) -> tuple[FakeEntryPoint, ...]:
+        assert group == PluginManager.ENTRY_POINT_GROUP
+        return (FakeEntryPoint("entry-point", definition),)
+
+    monkeypatch.setattr("liteyukibot.plugins.metadata.entry_points", entry_points)
+
+    assert make_manager(tmp_path).discover(("entry-point",)) == {"entry-point": definition}
+
+
+def test_plugin_manager_reports_local_module_import_failure(tmp_path: Path) -> None:
+    with pytest.raises(PluginError, match="local plugin module .* could not be imported"):
+        make_manager(tmp_path).discover(("missing",), ("v7_test_missing_plugin",))
+
+
+@pytest.mark.asyncio
+async def test_plugin_setup_failure_removes_its_provided_services(tmp_path: Path) -> None:
+    service = ServiceKey("example.transient")
+    manager = make_manager(tmp_path)
+
+    async def setup(context: PluginContext) -> None:
+        context.services.provide(service, object())
+        raise RuntimeError("setup failed")
+
+    definition = PluginDefinition(
+        PluginManifest(id="transient", name="Transient", version="1.0.0", provides=(service,)),
+        setup,
+    )
+
+    with pytest.raises(PluginError, match="transient setup failed"):
+        await manager.setup({"transient": definition}, {})
+
+    assert manager.services.get(service) is None
+    assert manager.loaded == {}
+
+
+@pytest.mark.asyncio
+async def test_plugin_managed_task_failure_is_logged(tmp_path: Path) -> None:
+    logger = RecordingLogger()
+    manager = make_manager(tmp_path, logger=logger)
+
+    async def setup(context: PluginContext) -> PluginHandle:
+        async def fail() -> None:
+            raise RuntimeError("broken worker")
+
+        context.tasks.start(fail(), name="worker")
+        return PluginHandle()
+
+    definition = PluginDefinition(
+        PluginManifest(id="worker", name="Worker", version="1.0.0"),
+        setup,
+    )
+
+    await manager.setup({"worker": definition}, {})
+    await asyncio.wait_for(logger.failure_reported.wait(), timeout=1)
+
+    assert logger.failures[0][0] == "task {} failed: {}"
+    assert logger.failures[0][1][0] == "worker:worker"
+    assert str(logger.failures[0][1][1]) == "broken worker"
+    await manager.stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- cover entry-point discovery and local-module import failures
- validate plugin manifest identity and required metadata
- verify provider rollback, plugin task failure logging, and partial-start reverse cleanup

## Validation
- uv run ruff check src tests scripts
- uv run mypy
- uv run pytest -q
- uv build
- uv lock --check