### PR TITLE
🧪 cover lifecycle contracts

### DIFF
--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -14,7 +14,7 @@ import pytest
 
 from liteyukibot.app import AppState, LiteyukiApp
 from liteyukibot.config import AppSettings, CoreSettings, HttpSettings, PluginSettings
-from liteyukibot.control import ControlError, request_control
+from liteyukibot.control import ControlError, ControlServer, request_control
 from liteyukibot.exceptions import PluginError
 from liteyukibot.plugins import PluginDefinition, PluginHandle, PluginManifest
 from liteyukibot.services import ServiceKey, ServiceRequirement
@@ -61,6 +61,93 @@ async def test_app_lifecycle_and_local_control(tmp_path: Path) -> None:
     assert not descriptor.exists()
     with pytest.raises(ControlError, match="cannot read control descriptor"):
         await request_control(descriptor, "status")
+
+
+@pytest.mark.asyncio
+async def test_app_rejects_restart_and_repeated_stop_is_safe(tmp_path: Path) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache")
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+    descriptor = settings.core.data_dir / "control.json"
+
+    await app.start()
+    with pytest.raises(RuntimeError, match="cannot start from state ready"):
+        await app.start()
+    assert descriptor.is_file()
+
+    await app.stop()
+    await app.stop()
+
+    assert app.state is AppState.STOPPED
+    assert not descriptor.exists()
+    with pytest.raises(RuntimeError, match="cannot start from state stopped"):
+        await app.start()
+
+
+@pytest.mark.asyncio
+async def test_startup_preserves_primary_error_when_cleanup_also_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache")
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+
+    async def fail_start() -> None:
+        raise RuntimeError("startup failed")
+
+    async def fail_cleanup() -> None:
+        raise RuntimeError("cleanup failed")
+
+    monkeypatch.setattr(app.events, "start", fail_start)
+    monkeypatch.setattr(app.events, "aclose", fail_cleanup)
+
+    with pytest.raises(RuntimeError, match="startup failed") as raised:
+        await app.start()
+
+    assert app.state is AppState.FAILED
+    assert any(
+        "startup cleanup also failed: application cleanup failed" in note
+        for note in getattr(raised.value, "__notes__", ())
+    )
+
+
+@pytest.mark.asyncio
+async def test_control_descriptor_replacement_is_owner_safe(tmp_path: Path) -> None:
+    descriptor = tmp_path / "data" / "control.json"
+
+    async def restart(_runtime_id: str) -> None:
+        return None
+
+    first = ControlServer(
+        descriptor,
+        status_provider=lambda: {"instance": "first"},
+        runtime_restarter=restart,
+    )
+    second = ControlServer(
+        descriptor,
+        status_provider=lambda: {"instance": "second"},
+        runtime_restarter=restart,
+    )
+
+    await first.start()
+    try:
+        first_descriptor = json.loads(descriptor.read_text(encoding="utf-8"))
+        await second.start()
+        try:
+            second_descriptor = json.loads(descriptor.read_text(encoding="utf-8"))
+            assert second_descriptor["token"] != first_descriptor["token"]
+
+            await first.stop()
+
+            assert json.loads(descriptor.read_text(encoding="utf-8")) == second_descriptor
+        finally:
+            await second.stop()
+    finally:
+        await first.stop()
+
+    assert not descriptor.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_v7.py
+++ b/tests/test_cli_v7.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import signal
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+import pytest
+
+import liteyukibot.cli as cli_module
+from liteyukibot.config import AppSettings
+
+
+class StubApp:
+    calls: ClassVar[list[str]] = []
+
+    def __init__(self, _settings: AppSettings) -> None:
+        pass
+
+    async def start(self) -> None:
+        self.calls.append("start")
+
+    async def stop(self) -> None:
+        self.calls.append("stop")
+
+
+class FakeSignalLoop:
+    def __init__(self, *, supports_async_handlers: bool) -> None:
+        self.supports_async_handlers = supports_async_handlers
+        self.added: list[signal.Signals] = []
+        self.removed: list[signal.Signals] = []
+
+    def add_signal_handler(self, signum: signal.Signals, callback: Callable[[], None]) -> None:
+        if not self.supports_async_handlers:
+            raise NotImplementedError
+        self.added.append(signum)
+        callback()
+
+    def remove_signal_handler(self, signum: signal.Signals) -> bool:
+        self.removed.append(signum)
+        return True
+
+    def call_soon_threadsafe(self, callback: Callable[[], None]) -> None:
+        callback()
+
+
+@pytest.mark.asyncio
+async def test_run_until_signal_uses_event_loop_signal_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
+    loop = FakeSignalLoop(supports_async_handlers=True)
+    StubApp.calls = []
+    monkeypatch.setattr(cli_module, "LiteyukiApp", StubApp)
+    monkeypatch.setattr("liteyukibot.cli.asyncio.get_running_loop", lambda: loop)
+
+    await cli_module._run_until_signal(AppSettings())
+
+    assert StubApp.calls == ["start", "stop"]
+    assert loop.added == [signal.SIGINT, signal.SIGTERM]
+    assert loop.removed == [signal.SIGINT, signal.SIGTERM]
+
+
+@pytest.mark.asyncio
+async def test_run_until_signal_uses_windows_signal_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    loop = FakeSignalLoop(supports_async_handlers=False)
+    previous = object()
+    assignments: list[tuple[signal.Signals, Any]] = []
+    StubApp.calls = []
+
+    def get_signal(_signum: signal.Signals) -> object:
+        return previous
+
+    def set_signal(signum: signal.Signals, handler: Any) -> object:
+        assignments.append((signum, handler))
+        if callable(handler):
+            handler(signum, None)
+        return previous
+
+    monkeypatch.setattr(cli_module, "LiteyukiApp", StubApp)
+    monkeypatch.setattr("liteyukibot.cli.asyncio.get_running_loop", lambda: loop)
+    monkeypatch.setattr("liteyukibot.cli.signal.getsignal", get_signal)
+    monkeypatch.setattr("liteyukibot.cli.signal.signal", set_signal)
+
+    await cli_module._run_until_signal(AppSettings())
+
+    assert StubApp.calls == ["start", "stop"]
+    assert loop.added == []
+    assert loop.removed == []
+    assert [signum for signum, _handler in assignments] == [
+        signal.SIGINT,
+        signal.SIGTERM,
+        signal.SIGINT,
+        signal.SIGTERM,
+    ]
+    assert assignments[-2:] == [(signal.SIGINT, previous), (signal.SIGTERM, previous)]


### PR DESCRIPTION
## Summary
- cover single-use startup, idempotent stop, and startup cleanup diagnostics
- verify ownership-safe control descriptor replacement
- cover event-loop and Windows signal-handler cleanup paths

## Validation
- uv run ruff check src tests scripts
- uv run mypy
- uv run pytest -q
- uv build
- uv lock --check