### PR TITLE
📝 freeze v1 contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,6 @@ uv run pytest
 uv build
 ```
 
-The architecture contract is documented in `docs/architecture/v7.md`; the v6
-compatibility boundary is documented in `docs/migration-v6.md`.
+The architecture overview is documented in `docs/architecture/v7.md`; accepted
+v1 contracts are indexed in `docs/adr/README.md`; the v6 compatibility boundary
+is documented in `docs/migration-v6.md`.

--- a/docs/adr/0001-event-and-action-contracts.md
+++ b/docs/adr/0001-event-and-action-contracts.md
@@ -1,0 +1,63 @@
+# ADR 0001: Freeze Event And Action Contracts At Schema Version 1
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+Native plugins and child runtimes need a portable event and action surface. The
+surface must preserve adapter-specific data without allowing mutable or
+non-serializable values to cross an ownership boundary.
+
+## Decision
+
+`liteyukibot.events` defines the v1 public data contract. Every model is frozen,
+forbids unknown fields, rejects NaN and infinity, and accepts JSON-safe payloads
+only. Serialization uses Pydantic JSON mode.
+
+`EventEnvelope` has schema version `1` and these required fields:
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Globally unique event identifier. |
+| `timestamp`, `received_at` | Timezone-aware source and core receipt times. |
+| `runtime_id`, `adapter`, `bot_id` | Origin identity. |
+| `type` | Adapter-neutral event type. |
+| `conversation` | `ConversationRef`; used with runtime and bot for ordering. |
+
+`actor`, `message`, `reply_token`, and `raw` are optional. Messages are tuples
+of normalized `Segment` values. The initial segment kinds are `text`, `media`,
+`mention`, `reply`, and `adapter`; text segments require `data.text` to be a
+string. `raw` and segment data retain adapter-specific JSON-safe values.
+
+The only v1 actions are discriminated by `action.type`:
+
+| Action | Required payload |
+| --- | --- |
+| `send_message` | `message` plus `conversation` or `reply_token`. |
+| `call_api` | Non-empty `api` and JSON-safe `params`. |
+
+`ActionEnvelope` carries `schema_version`, `action_id`, optional `event_id`,
+`runtime_id`, `bot_id`, and one action. `ActionResult` correlates by `action_id`.
+A successful result cannot contain error fields; a failed result requires
+`error_code` and may include `error_message` and JSON-safe `data`.
+
+`EventBus` is part of the contract rather than an implementation detail:
+
+- FIFO order is preserved per `(runtime_id, bot_id, conversation.ordering_key)`.
+- Different ordering keys may run concurrently, subject to configured capacity.
+- Handlers return `HandlerResult` or `None`; returned actions execute in handler
+  order, and `stop_propagation` stops later handlers for that event.
+- Handler timeouts, exceptions, and invalid return values become
+  `HandlerFailure` entries. Queue saturation and closure return an explicit
+  `DispatchResult` status.
+
+## Consequences
+
+Plugins may depend on the fields and outcomes above for v1. They must not depend
+on adapter-private object identity or mutate received mappings.
+
+Because v1 models reject unknown fields, additions to an existing envelope,
+action, result, or segment shape require a new schema version or an explicitly
+versioned parallel type. Removing fields or changing field semantics requires a
+new major API generation.

--- a/docs/adr/0002-runtime-ipc-protocol-v1.md
+++ b/docs/adr/0002-runtime-ipc-protocol-v1.md
@@ -1,0 +1,52 @@
+# ADR 0002: Freeze The Local Runtime IPC Protocol At Version 1
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+NoneBot, v6 compatibility, and custom adapters run as supervised child
+processes. Their control plane needs a small, bounded local protocol with clear
+authentication and failure behavior.
+
+## Decision
+
+The runtime protocol is loopback TCP only. A supervisor generates one random
+token per runtime launch and validates it during the handshake. Each frame is a
+four-byte unsigned big-endian length followed by UTF-8 JSON. Empty frames and
+frames larger than 8 MiB are invalid.
+
+All v1 messages are frozen Pydantic models with `type` as a discriminator,
+`protocol = 1` where applicable, and unknown fields forbidden.
+
+| Type | Direction | Required v1 fields |
+| --- | --- | --- |
+| `hello` | child -> core | `protocol`, `runtime_id`, `kind`, `token` |
+| `welcome` | core -> child | `protocol`, `heartbeat_interval` |
+| `config` | core -> child | JSON-safe `options` |
+| `ready` | child -> core | optional `capabilities` |
+| `heartbeat` | child -> core | `monotonic` |
+| `event` | child -> core | `correlation_id`, JSON-safe `payload` |
+| `event_accepted` | core -> child | `correlation_id`, `accepted|overloaded|invalid` status, optional detail |
+| `action` | core -> child | `correlation_id`, JSON-safe `payload` |
+| `action_result` | child -> core | `correlation_id`, `ok`, optional data or error |
+| `shutdown` | core -> child | optional `reason` |
+| `error` | either direction | `code`, `message`, optional `correlation_id` |
+
+The child sends `hello` first. The core replies with `welcome` and `config`; the
+child then sends `ready` and periodic `heartbeat` messages. Event and action
+correlation identifiers are opaque strings supplied by the requester.
+
+Malformed JSON, invalid message shapes, invalid frame sizes, and truncated
+frames are protocol failures. Authentication or duplicate-connection failures
+close the offending connection without replacing a healthy runtime connection.
+
+## Consequences
+
+Child runtimes must treat protocol validation errors as fatal to the current
+connection. The supervisor owns reconnect, timeout, restart, and terminal
+failure policy; children do not retry by creating competing connections.
+
+No field or message-type additions are silently compatible with v1 because
+wire models reject extras. Such a change requires protocol version negotiation
+and a new `hello`/`welcome` version, or a separately negotiated capability.

--- a/docs/adr/0003-native-plugin-api-v1.md
+++ b/docs/adr/0003-native-plugin-api-v1.md
@@ -1,0 +1,52 @@
+# ADR 0003: Freeze The Native Plugin API At Version 1
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+v7 supports native plugins in the core process while retaining NoneBot and v6
+as child-runtime compatibility paths. The native surface must be explicit,
+dependency ordered, and safe to clean up after partial startup.
+
+## Decision
+
+Native discovery uses the `liteyukibot.plugins` entry-point group and explicitly
+listed local module names. Entry points must resolve to `PluginDefinition`.
+Local modules expose either `plugin` or `get_plugin()`. No recursive directory
+scanning or import-time registration is part of the native API.
+
+`PluginDefinition` contains a `PluginManifest` and an async
+`setup(context)` callable. The v1 manifest contains:
+
+| Field | Contract |
+| --- | --- |
+| `id` | Lowercase ASCII letters, digits, `-`, `_`, and `.`; dotted segments cannot be empty. |
+| `name`, `version` | Non-blank metadata. |
+| `api_version` | Literal `1`. |
+| `provides`, `requires` | `ServiceKey` and `ServiceRequirement` declarations. |
+| `storage` | `none` or `private`. |
+
+Unknown manifest fields are rejected. A `setup` function returns `None` or a
+`PluginHandle` with optional async `start` and `stop` callbacks.
+
+`PluginContext` supplies the immutable plugin configuration, bound logger,
+event bus, action service, `PluginServices`, managed tasks, and optional private
+data/cache paths. A plugin may provide or require only services declared in its
+manifest. Services use `name@major` keys, have exactly one provider, and form a
+startup dependency graph. Missing required services, conflicting providers, and
+cycles are startup errors.
+
+Setup occurs in dependency order. Stop callbacks and managed task cleanup occur
+in reverse dependency order, including after partial startup. If setup fails,
+services already provided by that plugin are removed and its tasks are stopped.
+Task failures are reported through the plugin-bound logger.
+
+## Consequences
+
+Plugins are trusted in-process code, not sandboxed code. They own only declared
+private paths and should use managed tasks instead of untracked background work.
+
+Changing the manifest shape, context surface, lifecycle ordering, or service
+semantics requires a new plugin API version. A v1 core must reject unsupported
+future manifests rather than guessing compatibility.

--- a/docs/adr/0004-configuration-and-error-contracts.md
+++ b/docs/adr/0004-configuration-and-error-contracts.md
@@ -1,0 +1,58 @@
+# ADR 0004: Freeze Configuration Precedence And Error Taxonomy
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+Configuration is supplied by files, environment variables, and CLI overrides.
+Plugins and operators need deterministic precedence and diagnostics that do not
+echo secret values. Runtime and plugin boundaries also need predictable failure
+categories.
+
+## Decision
+
+`load_settings()` produces one immutable `AppSettings` snapshot. The precedence
+order, from lowest to highest, is:
+
+1. Pydantic model defaults.
+2. Includes declared by the primary file, in list order; an included file applies
+   its own includes before its own values.
+3. Values in the primary file.
+4. Repeated CLI `--config` files, in command-line order, each with the same
+   include-before-own-values rule.
+5. `LITEYUKI__SECTION__FIELD` environment values.
+6. CLI `--set section.field=JSON_VALUE` overrides.
+
+Mappings deep-merge. Scalars and arrays replace earlier values. Paths declared
+in a configuration file resolve relative to that file; paths supplied through
+environment or CLI layers resolve relative to the current working directory.
+Duplicate includes, include cycles, malformed documents, unsupported formats,
+invalid override syntax, and unknown model fields are configuration errors.
+
+Configuration errors are aggregated as `ConfigurationError.issues`, a tuple of
+`ConfigIssue(source, message, location)`. Diagnostics identify source and field
+location but never include a supplied secret value.
+
+The framework error taxonomy is:
+
+| Type | Boundary |
+| --- | --- |
+| `ConfigurationError` | Loading or validating settings. |
+| `PluginError` | Plugin discovery, manifest coercion, or setup. |
+| `ServiceError` | Undeclared, missing, or conflicting service use. |
+| `RuntimeProtocolError` | Invalid local child-runtime frame or message. |
+| `LegacyUnsupportedError` | A v6 API outside the compatibility contract. |
+| `ControlError` | Invalid or unavailable authenticated local CLI control channel. |
+
+`ActionResult`, `DispatchResult`, and `HandlerFailure` represent expected data
+plane outcomes and are not exception replacements. Lifecycle state violations
+remain `RuntimeError` until a public lifecycle-specific error type is introduced
+in a future major API.
+
+## Consequences
+
+Operators can reproduce an effective configuration from its ordered sources.
+Plugins receive a stable read-only configuration view. Future precedence changes
+or error reclassification require a major configuration/API version decision and
+a migration note.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,10 @@
+# LiteyukiBot v7 ADRs
+
+These accepted records freeze public v1 contracts. New behavior must either fit
+one of these records without changing its semantics or introduce a new,
+explicitly versioned decision.
+
+1. [Event and action contracts](0001-event-and-action-contracts.md)
+2. [Local runtime IPC protocol](0002-runtime-ipc-protocol-v1.md)
+3. [Native plugin API](0003-native-plugin-api-v1.md)
+4. [Configuration precedence and error taxonomy](0004-configuration-and-error-contracts.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -52,6 +52,14 @@ NoneBot is hosted through its official initialization, driver, plugin-loading,
 event-preprocessor, `Bot.send`, and `Bot.call_api` surfaces. Event forwarding is
 observational and never suppresses NoneBot matcher dispatch.
 
+## Stable v1 Contracts
+
+The public v1 contracts are frozen in the accepted
+[architecture decision records](../adr/README.md): event/action schemas, local
+runtime IPC, native plugins, configuration precedence, and error taxonomy.
+Changes to these surfaces require an explicit versioned decision rather than an
+unannounced compatible-looking edit.
+
 ## Operations
 
 The `liteyuki` command (`ly` alias) validates configuration and plugin topology,


### PR DESCRIPTION
## Summary
- freeze v1 event/action and local runtime IPC contracts
- freeze native plugin and configuration/error contracts
- link accepted ADRs from the architecture overview and README

## Validation
- uv run ruff check src tests scripts
- uv run mypy
- uv run pytest -q
- uv build
- uv lock --check