### PR TITLE
✅ add release verification matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,25 @@ jobs:
           name: v7-baseline-${{ matrix.os }}
           path: LiteyukiBot/benchmark.json
 
+  published-install:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: LiteyukiBot
+      - uses: astral-sh/setup-uv@v8.3.2
+        with:
+          version: "0.11.16"
+      - name: Verify published wheel in isolation
+        working-directory: LiteyukiBot
+        run: |
+          uv python install 3.14
+          uv run --no-project --python 3.14 --with "liteyukibot-v7==7.0.0a1" python scripts/verify_published_install.py --expected-version 7.0.0a1
+
   nonebot-contract:
     runs-on: ubuntu-latest
     steps:

--- a/benchmarks/v7-alpha-reference.json
+++ b/benchmarks/v7-alpha-reference.json
@@ -1,0 +1,38 @@
+{
+  "schema": 1,
+  "status": "provisional-alpha-reference",
+  "python": "3.14.5",
+  "event_count": 5000,
+  "aggregation": "median of three GitHub-hosted runner samples per metric",
+  "source_run_ids": [
+    31300636600,
+    31300865414,
+    31301376697
+  ],
+  "platforms": {
+    "macos-latest": {
+      "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+      "startup_ms": 2.913,
+      "throughput_events_per_second": 31690,
+      "median_latency_ms": 1.776,
+      "p95_latency_ms": 2.359,
+      "peak_rss_mib": 46.3
+    },
+    "ubuntu-latest": {
+      "platform": "Linux-6.17.0-1020-azure-x86_64-with-glibc2.39",
+      "startup_ms": 2.333,
+      "throughput_events_per_second": 24400,
+      "median_latency_ms": 2.311,
+      "p95_latency_ms": 2.665,
+      "peak_rss_mib": 51.5
+    },
+    "windows-latest": {
+      "platform": "Windows-2025Server-10.0.26100-SP0",
+      "startup_ms": 6.916,
+      "throughput_events_per_second": 18011,
+      "median_latency_ms": 3.337,
+      "p95_latency_ms": 4.532,
+      "peak_rss_mib": 45.6
+    }
+  }
+}

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -76,7 +76,9 @@ costs are lower than its measured gain.
 dispatch latency, and peak RSS. CI uploads one baseline per operating system.
 After the first stable release fixes reference values, a regression over 20%
 requires an explicit performance review; noisy pre-release snapshots are not
-used as an automatic pass/fail threshold.
+used as an automatic pass/fail threshold. The current three-run alpha reference
+and published-install matrix are documented in
+[`performance-v7.md`](../performance-v7.md).
 
 ## Pre-release Delivery
 

--- a/docs/performance-v7.md
+++ b/docs/performance-v7.md
@@ -1,0 +1,46 @@
+# LiteyukiBot v7 Performance Reference
+
+## Published Install Contract
+
+CI installs `liteyukibot-v7==7.0.0a1` from PyPI in an isolated uv environment
+on Ubuntu, Windows, and macOS. It verifies the distribution metadata and imports
+both `liteyukibot` and the `liteyuki` v6 compatibility namespace. The check does
+not use the repository virtual environment or install the source checkout.
+
+Run the same contract locally with:
+
+```bash
+uv run --no-project --python 3.14 --with "liteyukibot-v7==7.0.0a1" python scripts/verify_published_install.py --expected-version 7.0.0a1
+```
+
+## Alpha Reference
+
+The first reference set is stored in
+`benchmarks/v7-alpha-reference.json`. Each value is the median of three samples
+from successful `v7` push workflows after PRs #96, #97, and #98. All samples
+used CPython 3.14.5 and 5,000 independently ordered events.
+
+| Runner | Startup ms | Events/s | Median latency ms | p95 latency ms | Peak RSS MiB |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `macos-latest` | 2.913 | 31,690 | 1.776 | 2.359 | 46.3 |
+| `ubuntu-latest` | 2.333 | 24,400 | 2.311 | 2.665 | 51.5 |
+| `windows-latest` | 6.916 | 18,011 | 3.337 | 4.532 | 45.6 |
+
+Source workflow runs:
+
+- [31300636600](https://github.com/LiteyukiStudio/LiteyukiBot/actions/runs/31300636600)
+- [31300865414](https://github.com/LiteyukiStudio/LiteyukiBot/actions/runs/31300865414)
+- [31301376697](https://github.com/LiteyukiStudio/LiteyukiBot/actions/runs/31301376697)
+
+## Interpretation
+
+This alpha reference is auditable but not an automatic performance gate.
+GitHub-hosted runner load remains visible in the individual artifacts; for
+example, one macOS startup sample was 20.8 ms while the other two were below
+3 ms. Median aggregation limits a single outlier without hiding the raw runs.
+
+After the first stable v7 release, replace this file with a stable reference
+captured from three clean runs per platform. A regression review is required
+when startup, latency, or RSS rises by more than 20%, or throughput falls by more
+than 20%. The comparison must use the same Python minor version, event count,
+runner architecture, and benchmark schema.

--- a/scripts/verify_published_install.py
+++ b/scripts/verify_published_install.py
@@ -1,0 +1,42 @@
+"""Verify the published distribution without importing the source checkout."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata
+import json
+
+
+def _module_version(module_name: str) -> str:
+    module = importlib.import_module(module_name)
+    version = getattr(module, "__version__", None)
+    if not isinstance(version, str):
+        raise RuntimeError(f"{module_name} does not expose a string __version__")
+    return version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--distribution", default="liteyukibot-v7")
+    parser.add_argument("--expected-version", required=True)
+    args = parser.parse_args()
+
+    observed = {
+        args.distribution: importlib.metadata.version(args.distribution),
+        "liteyukibot": _module_version("liteyukibot"),
+        "liteyuki": _module_version("liteyuki"),
+    }
+    mismatches = {
+        name: version for name, version in observed.items() if version != args.expected_version
+    }
+    if mismatches:
+        rendered = ", ".join(f"{name}={version}" for name, version in mismatches.items())
+        raise RuntimeError(f"expected {args.expected_version}; observed {rendered}")
+
+    print(json.dumps({"expected": args.expected_version, "observed": observed}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- verify liteyukibot-v7 7.0.0a1 from public PyPI on Ubuntu, Windows, and macOS
- check both liteyukibot and liteyuki import namespaces in an isolated uv environment
- record a three-run per-platform alpha performance reference with auditable workflow sources

## Validation
- uv run ruff check src tests scripts
- uv run mypy
- uv run pytest -q
- uv build
- uv lock --check
- isolated PyPI install verification
- local 5,000-event benchmark