### PR TITLE
🔖 enforce release integrity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Quality checks
         working-directory: LiteyukiBot
         run: |
+          uv run python scripts/check_release.py
           uv run ruff check src tests scripts
           uv run mypy
           uv run pytest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,23 +11,14 @@ on:
       - pyproject.toml
       - src/**
       - uv.lock
-  push:
-    tags: ["v7.*"]
   workflow_dispatch:
 
 permissions:
   contents: read
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Check out source
         uses: actions/checkout@v6
@@ -35,29 +26,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract image metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=tag
-            type=sha,prefix=sha-
-
-      - name: Build and publish image
+      - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
+          tags: liteyukibot:v7-ci
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,11 @@ on:
   push:
     tags: ["v7.*"]
   workflow_dispatch:
+    inputs:
+      version:
+        description: Exact project version to publish
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,6 +17,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', inputs.version) || github.ref_name }}
     environment: pypi
     steps:
       - uses: actions/checkout@v6
@@ -20,7 +27,13 @@ jobs:
           version: "0.11.16"
       - name: Require published Yukilog 1.x
         run: uv run --no-project --with "yukilog>=1,<2" python -c "import yukilog"
-      - name: Build and publish
+      - name: Validate release identity
+        run: uv run python scripts/check_release.py --tag "$RELEASE_TAG"
+      - name: Build distribution
         run: |
           uv build
+          wheel="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          uv run --no-project --with "$wheel" python scripts/verify_published_install.py --expected-version "${RELEASE_TAG#v}"
+      - name: Publish distribution
+        run: |
           uv publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- completed Phase 2 kernel stabilization with accepted v1 ADRs, deterministic
+  runtime failure coverage, and cross-platform published-install verification;
+- recorded informational alpha performance references on Linux, macOS, and Windows;
+- made installed distribution metadata the runtime version source and added
+  release tag/build verification;
+- retained the non-root local Docker build while remote image publication is paused.
+
 ## 7.0.0a1 - 2026-08-04
 
 The first v7 pre-release provides the kernel foundation for a protocol-neutral,
@@ -12,7 +21,7 @@ single-host chatbot runtime:
 - authenticated framed IPC, runtime supervision, heartbeat, restart, and local control;
 - isolated NoneBot2 hosting and an explicit LiteyukiBot v6 compatibility boundary;
 - `liteyuki`/`ly` CLI, optional loopback HTTP status API, and cross-platform CI baselines;
-- Python 3.14, uv, PyPI packaging, and a non-root GHCR Docker image.
+- Python 3.14, uv, PyPI packaging, and a non-root local Docker image.
 
 The PyPI distribution is named `liteyukibot-v7`; the import namespaces remain
 `liteyukibot` and `liteyuki`.

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ uv run liteyuki --config local.toml --set logging.level=DEBUG check
 
 ## Docker
 
-The v7 pre-release image is published to GHCR as
-`ghcr.io/liteyukistudio/liteyukibot:v7.0.0a1`. It includes the optional YAML,
-HTTP, NoneBot2, OneBot, and Satori integrations, and runs as a non-root user.
+The v7 image can be built locally with the optional YAML, HTTP, NoneBot2,
+OneBot, and Satori integrations. It runs as a non-root user. GHCR publication
+is currently paused; the Docker workflow validates builds without pushing.
 
 ```bash
-docker pull ghcr.io/liteyukistudio/liteyukibot:v7.0.0a1
-docker run --rm ghcr.io/liteyukistudio/liteyukibot:v7.0.0a1 version
+docker build -t liteyukibot:v7-local .
+docker run --rm liteyukibot:v7-local version
 ```
 
 Mount a `liteyuki.toml` at `/app/liteyuki.toml` and persistent volumes at

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -82,8 +82,13 @@ and published-install matrix are documented in
 
 ## Pre-release Delivery
 
-Phase 1 is distributed as `7.0.0a1` on PyPI and as a non-root image at
-`ghcr.io/liteyukistudio/liteyukibot:v7.0.0a1`. The Docker image is built from
-the locked uv environment and includes all current optional integrations. Pull
-requests build the image without publishing; version tags publish both the
-package and the GHCR image.
+Phase 1 is distributed as `7.0.0a1` on PyPI. The non-root Docker image is built
+from the locked uv environment and includes all current optional integrations;
+local builds are validated, while GHCR publication is paused. The Docker
+workflow only builds images. Package publication requires an exact match among
+the `pyproject.toml` version, the release tag, and the built wheel metadata.
+
+Phase 2 kernel stabilization is complete. The runtime failure matrix, accepted
+v1 ADRs, three-platform kernel suite, isolated public-PyPI installation checks,
+and informational alpha performance reference now form the baseline for the
+next compatibility phase.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance scripts."""

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -1,0 +1,61 @@
+"""Validate the source release identity before building or publishing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tomllib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import cast
+
+EXPECTED_DISTRIBUTION = "liteyukibot-v7"
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseIdentity:
+    distribution: str
+    version: str
+
+
+def read_release_identity(project_file: Path) -> ReleaseIdentity:
+    document = tomllib.loads(project_file.read_text(encoding="utf-8"))
+    project_value: object = document.get("project")
+    if not isinstance(project_value, dict):
+        raise RuntimeError(f"{project_file} does not contain a [project] table")
+    project = cast(dict[str, object], project_value)
+    distribution = project.get("name")
+    version = project.get("version")
+    if not isinstance(distribution, str) or not distribution:
+        raise RuntimeError("project.name must be a non-empty string")
+    if not isinstance(version, str) or not version:
+        raise RuntimeError("project.version must be a non-empty string")
+    return ReleaseIdentity(distribution=distribution, version=version)
+
+
+def validate_release(identity: ReleaseIdentity, *, tag: str | None = None) -> None:
+    if identity.distribution != EXPECTED_DISTRIBUTION:
+        raise RuntimeError(
+            f"expected project.name={EXPECTED_DISTRIBUTION!r}, got {identity.distribution!r}"
+        )
+    if tag is not None:
+        expected_tag = f"v{identity.version}"
+        if tag != expected_tag:
+            raise RuntimeError(f"expected release tag {expected_tag!r}, got {tag!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", type=Path, default=PROJECT_ROOT / "pyproject.toml")
+    parser.add_argument("--tag")
+    args = parser.parse_args()
+
+    identity = read_release_identity(args.project)
+    validate_release(identity, tag=args.tag)
+    print(json.dumps(asdict(identity), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/liteyuki/__init__.py
+++ b/src/liteyuki/__init__.py
@@ -1,5 +1,7 @@
 """LiteyukiBot v6 compatibility API hosted by the v7 runtime."""
 
+from liteyukibot import __version__
+
 from .bot import LiteyukiBot, get_bot, get_config, get_config_with_compat
 from .log import init_log, logger
 from .plugin import Plugin, PluginMetadata, PluginType, get_loaded_plugins, load_plugin, load_plugins
@@ -17,6 +19,5 @@ __all__ = [
     "load_plugin",
     "load_plugins",
     "logger",
+    "__version__",
 ]
-
-__version__ = "7.0.0a1"

--- a/src/liteyukibot/__init__.py
+++ b/src/liteyukibot/__init__.py
@@ -1,5 +1,6 @@
 """LiteyukiBot v7 public API."""
 
+from ._version import __version__
 from .app import LiteyukiApp
 from .plugins import PluginContext, PluginDefinition, PluginHandle, PluginManifest
 from .services import ServiceKey, ServiceRegistry, ServiceRequirement
@@ -13,6 +14,5 @@ __all__ = [
     "ServiceKey",
     "ServiceRegistry",
     "ServiceRequirement",
+    "__version__",
 ]
-
-__version__ = "7.0.0a1"

--- a/src/liteyukibot/_version.py
+++ b/src/liteyukibot/_version.py
@@ -1,0 +1,10 @@
+"""Distribution-backed version information."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+DISTRIBUTION_NAME = "liteyukibot-v7"
+
+try:
+    __version__ = version(DISTRIBUTION_NAME)
+except PackageNotFoundError:
+    __version__ = "0+unknown"

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+from scripts.check_release import ReleaseIdentity, read_release_identity, validate_release
+
+import liteyuki
+import liteyukibot
+
+
+def test_import_namespaces_use_distribution_version() -> None:
+    expected = importlib.metadata.version("liteyukibot-v7")
+
+    assert liteyukibot.__version__ == expected
+    assert liteyuki.__version__ == expected
+
+
+def test_current_release_identity_accepts_matching_tag() -> None:
+    identity = read_release_identity(Path("pyproject.toml"))
+
+    validate_release(identity, tag=f"v{identity.version}")
+    assert identity.distribution == "liteyukibot-v7"
+
+
+@pytest.mark.parametrize(
+    ("identity", "tag", "message"),
+    [
+        (ReleaseIdentity("liteyukibot", "7.0.0a2"), None, "project.name"),
+        (ReleaseIdentity("liteyukibot-v7", "7.0.0a2"), "v7.0.0a1", "release tag"),
+    ],
+)
+def test_release_identity_rejects_mismatches(
+    identity: ReleaseIdentity,
+    tag: str | None,
+    message: str,
+) -> None:
+    with pytest.raises(RuntimeError, match=message):
+        validate_release(identity, tag=tag)


### PR DESCRIPTION
## Summary

- derive both public namespace versions from installed `liteyukibot-v7` metadata
- validate distribution/version/tag identity and verify the built wheel before PyPI publication
- keep Docker CI build-only while GHCR publication is paused
- record Phase 2 completion and correct release documentation

## Validation

- `uv run ruff check src tests scripts`
- `uv run mypy`
- `uv run pytest` (62 passed)
- `uv lock --check`
- `uv build`
- isolated wheel import/version verification
- local Docker build plus `version`, `check`, and non-root user smoke tests