### PR TITLE
♻️ centralize child runtime transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - made installed distribution metadata the runtime version source and added
   release tag/build verification;
 - retained the non-root local Docker build while remote image publication is paused.
+- centralized child-runtime handshake, heartbeat, serialized writes, and cleanup
+  in a reusable protocol-v1 client shared by all built-in child hosts.
 
 ## 7.0.0a1 - 2026-08-04
 

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -48,6 +48,11 @@ Protocol v1 covers hello/welcome, config, ready, heartbeat, event acceptance,
 actions/results, shutdown, and errors. Abnormal exits use bounded exponential
 restart; clean exits do not restart.
 
+All built-in child hosts use one async `RuntimeClient` for environment identity,
+handshake validation, negotiated heartbeat, serialized writes, receive, and
+idempotent connection cleanup. Framework hosts retain ownership of event and
+action dispatch; the supervisor remains the sole restart-policy owner.
+
 NoneBot is hosted through its official initialization, driver, plugin-loading,
 event-preprocessor, `Bot.send`, and `Bot.call_api` surfaces. Event forwarding is
 observational and never suppresses NoneBot matcher dispatch.

--- a/src/liteyukibot/runtime/__init__.py
+++ b/src/liteyukibot/runtime/__init__.py
@@ -1,5 +1,6 @@
 """Child runtime protocol and supervision."""
 
+from .client import RuntimeClient
 from .protocol import (
     MAX_FRAME_SIZE,
     ActionRequest,
@@ -27,6 +28,7 @@ __all__ = [
     "Heartbeat",
     "Hello",
     "Ready",
+    "RuntimeClient",
     "RuntimeSpec",
     "RuntimeState",
     "RuntimeSupervisor",

--- a/src/liteyukibot/runtime/__main__.py
+++ b/src/liteyukibot/runtime/__main__.py
@@ -4,52 +4,28 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import os
-import time
 
+from .client import RuntimeClient
 from .protocol import (
     ActionRequest,
     ActionResponse,
-    ConfigMessage,
-    Heartbeat,
-    Hello,
-    Ready,
     Shutdown,
-    Welcome,
-    read_message,
-    write_message,
 )
 
 
 async def run_noop(kind: str) -> None:
-    host = os.environ["LITEYUKI_RUNTIME_HOST"]
-    port = int(os.environ["LITEYUKI_RUNTIME_PORT"])
-    token = os.environ["LITEYUKI_RUNTIME_TOKEN"]
-    runtime_id = os.environ["LITEYUKI_RUNTIME_ID"]
-    reader, writer = await asyncio.open_connection(host, port)
-    await write_message(writer, Hello(runtime_id=runtime_id, kind=kind, token=token))
-    welcome = await read_message(reader)
-    config = await read_message(reader)
-    if not isinstance(welcome, Welcome) or not isinstance(config, ConfigMessage):
-        raise RuntimeError("invalid supervisor handshake")
-    if kind != "noop":
-        raise RuntimeError(f"runtime kind {kind!r} is not installed")
-    await write_message(writer, Ready(capabilities=("noop",)))
-
-    async def heartbeat() -> None:
-        while True:
-            await asyncio.sleep(welcome.heartbeat_interval)
-            await write_message(writer, Heartbeat(monotonic=time.monotonic()))
-
-    heartbeat_task = asyncio.create_task(heartbeat(), name="runtime-heartbeat")
+    client = RuntimeClient.from_environment(kind)
     try:
+        await client.connect()
+        if kind != "noop":
+            raise RuntimeError(f"runtime kind {kind!r} is not installed")
+        await client.ready(("noop",))
         while True:
-            message = await read_message(reader)
+            message = await client.receive()
             if isinstance(message, Shutdown):
                 return
             if isinstance(message, ActionRequest):
-                await write_message(
-                    writer,
+                await client.send(
                     ActionResponse(
                         correlation_id=message.correlation_id,
                         ok=True,
@@ -57,10 +33,7 @@ async def run_noop(kind: str) -> None:
                     ),
                 )
     finally:
-        heartbeat_task.cancel()
-        await asyncio.gather(heartbeat_task, return_exceptions=True)
-        writer.close()
-        await writer.wait_closed()
+        await client.close()
 
 
 def main() -> None:

--- a/src/liteyukibot/runtime/client.py
+++ b/src/liteyukibot/runtime/client.py
@@ -1,0 +1,140 @@
+"""Reusable protocol-v1 client for supervised child runtimes."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections.abc import Mapping, Sequence
+
+from ..exceptions import RuntimeProtocolError
+from .protocol import (
+    ConfigMessage,
+    Heartbeat,
+    Hello,
+    JsonValue,
+    Ready,
+    Welcome,
+    WireMessage,
+    read_message,
+    write_message,
+)
+
+
+class RuntimeClient:
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        runtime_id: str,
+        kind: str,
+        token: str,
+    ) -> None:
+        if not host or not runtime_id or not kind or not token:
+            raise ValueError("runtime connection identity must not be empty")
+        if not 1 <= port <= 65535:
+            raise ValueError("runtime port must be between 1 and 65535")
+        self.host = host
+        self.port = port
+        self.runtime_id = runtime_id
+        self.kind = kind
+        self.token = token
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._send_lock = asyncio.Lock()
+        self._heartbeat_interval: float | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    @classmethod
+    def from_environment(
+        cls,
+        kind: str,
+        environment: Mapping[str, str] | None = None,
+    ) -> RuntimeClient:
+        values = os.environ if environment is None else environment
+        return cls(
+            host=values["LITEYUKI_RUNTIME_HOST"],
+            port=int(values["LITEYUKI_RUNTIME_PORT"]),
+            runtime_id=values["LITEYUKI_RUNTIME_ID"],
+            kind=kind,
+            token=values["LITEYUKI_RUNTIME_TOKEN"],
+        )
+
+    @property
+    def connected(self) -> bool:
+        return self._writer is not None and not self._closed
+
+    async def connect(self) -> Mapping[str, JsonValue]:
+        if self._reader is not None or self._writer is not None or self._closed:
+            raise RuntimeError("runtime client connection is single-use")
+        self._reader, self._writer = await asyncio.open_connection(self.host, self.port)
+        try:
+            await self.send(
+                Hello(
+                    runtime_id=self.runtime_id,
+                    kind=self.kind,
+                    token=self.token,
+                )
+            )
+            welcome = await self.receive()
+            if not isinstance(welcome, Welcome):
+                raise RuntimeProtocolError("expected welcome during runtime handshake")
+            config = await self.receive()
+            if not isinstance(config, ConfigMessage):
+                raise RuntimeProtocolError("expected config during runtime handshake")
+            if welcome.heartbeat_interval <= 0:
+                raise RuntimeProtocolError("runtime heartbeat interval must be positive")
+            self._heartbeat_interval = welcome.heartbeat_interval
+            return config.options
+        except BaseException:
+            await self.close()
+            raise
+
+    async def ready(self, capabilities: Sequence[str] = ()) -> None:
+        if self._heartbeat_task is not None:
+            raise RuntimeError("runtime client is already ready")
+        await self.send(Ready(capabilities=tuple(capabilities)))
+        assert self._heartbeat_interval is not None
+        self._heartbeat_task = asyncio.create_task(
+            self._heartbeat(self._heartbeat_interval),
+            name=f"runtime-heartbeat:{self.runtime_id}",
+        )
+
+    async def receive(self) -> WireMessage:
+        if self._reader is None or self._closed:
+            raise ConnectionError("runtime client is not connected")
+        return await read_message(self._reader)
+
+    async def send(self, message: WireMessage) -> None:
+        writer = self._writer
+        if writer is None or self._closed:
+            raise ConnectionError("runtime client is not connected")
+        async with self._send_lock:
+            if self._writer is not writer or self._closed:
+                raise ConnectionError("runtime client is not connected")
+            await write_message(writer, message)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        heartbeat, self._heartbeat_task = self._heartbeat_task, None
+        if heartbeat is not None:
+            heartbeat.cancel()
+            await asyncio.gather(heartbeat, return_exceptions=True)
+        async with self._send_lock:
+            writer, self._writer = self._writer, None
+            self._reader = None
+            if writer is not None:
+                writer.close()
+                await writer.wait_closed()
+
+    async def _heartbeat(self, interval: float) -> None:
+        while True:
+            await asyncio.sleep(interval)
+            await self.send(Heartbeat(monotonic=time.monotonic()))
+
+
+__all__ = ["RuntimeClient"]

--- a/src/liteyukibot/runtime/nonebot.py
+++ b/src/liteyukibot/runtime/nonebot.py
@@ -25,20 +25,14 @@ from ..events import (
     Segment,
     SendMessage,
 )
+from .client import RuntimeClient
 from .protocol import (
     ActionRequest,
     ActionResponse,
-    ConfigMessage,
     EventMessage,
-    Heartbeat,
-    Hello,
-    Ready,
     Shutdown,
-    Welcome,
     WireMessage,
     json_mapping,
-    read_message,
-    write_message,
 )
 
 logger = get_logger(component="nonebot", runtime=os.environ.get("LITEYUKI_RUNTIME_ID"))
@@ -54,8 +48,7 @@ class SupervisorBridge:
         self._configured = threading.Event()
         self._thread = threading.Thread(target=self._thread_main, name="liteyuki-nonebot-ipc", daemon=True)
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._writer: asyncio.StreamWriter | None = None
-        self._send_lock: asyncio.Lock | None = None
+        self._client: RuntimeClient | None = None
         self._action_handler: ActionHandler | None = None
         self._shutdown: Callable[[], None] | None = None
         self._main_loop: asyncio.AbstractEventLoop | None = None
@@ -77,8 +70,11 @@ class SupervisorBridge:
         self._main_loop = main_loop
 
     def ready(self) -> None:
-        message = Ready(capabilities=("nonebot.plugins", "nonebot.events", "nonebot.actions"))
-        self._submit(self._send(message)).result(10)
+        if self._client is None:
+            raise RuntimeError("NoneBot supervisor bridge is not connected")
+        self._submit(
+            self._client.ready(("nonebot.plugins", "nonebot.events", "nonebot.actions"))
+        ).result(10)
 
     def emit_event(self, event: EventEnvelope) -> None:
         future = self._submit(
@@ -105,23 +101,13 @@ class SupervisorBridge:
 
     async def _run(self) -> None:
         self._loop = asyncio.get_running_loop()
-        host = os.environ["LITEYUKI_RUNTIME_HOST"]
-        port = int(os.environ["LITEYUKI_RUNTIME_PORT"])
-        runtime_id = os.environ["LITEYUKI_RUNTIME_ID"]
-        token = os.environ["LITEYUKI_RUNTIME_TOKEN"]
-        reader, self._writer = await asyncio.open_connection(host, port)
-        self._send_lock = asyncio.Lock()
-        await self._send(Hello(runtime_id=runtime_id, kind="nonebot", token=token))
-        welcome = await read_message(reader)
-        config = await read_message(reader)
-        if not isinstance(welcome, Welcome) or not isinstance(config, ConfigMessage):
-            raise RuntimeError("invalid supervisor handshake")
-        self.options = config.options
+        client = RuntimeClient.from_environment("nonebot")
+        self._client = client
+        self.options = await client.connect()
         self._configured.set()
-        heartbeat = asyncio.create_task(self._heartbeat(welcome.heartbeat_interval))
         try:
             while True:
-                message = await read_message(reader)
+                message = await client.receive()
                 if isinstance(message, Shutdown):
                     if self._shutdown is not None:
                         self._shutdown()
@@ -129,11 +115,7 @@ class SupervisorBridge:
                 if isinstance(message, ActionRequest):
                     await self._handle_action(message)
         finally:
-            heartbeat.cancel()
-            await asyncio.gather(heartbeat, return_exceptions=True)
-            if self._writer is not None:
-                self._writer.close()
-                await self._writer.wait_closed()
+            await client.close()
 
     async def _handle_action(self, request: ActionRequest) -> None:
         if self._action_handler is None or self._main_loop is None:
@@ -164,15 +146,9 @@ class SupervisorBridge:
         await self._send(response)
 
     async def _send(self, message: WireMessage) -> None:
-        if self._writer is None or self._send_lock is None:
+        if self._client is None:
             raise ConnectionError("NoneBot supervisor bridge is not connected")
-        async with self._send_lock:
-            await write_message(self._writer, message)
-
-    async def _heartbeat(self, interval: float) -> None:
-        while True:
-            await asyncio.sleep(interval)
-            await self._send(Heartbeat(monotonic=asyncio.get_running_loop().time()))
+        await self._client.send(message)
 
 
 class NoneBotHost:

--- a/src/liteyukibot/runtime/v6.py
+++ b/src/liteyukibot/runtime/v6.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import time
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -13,102 +12,69 @@ from yukilog import configure_child_runtime, get_logger
 from liteyuki.bot import _emit_lifecycle, _install_runtime, _reset_runtime
 from liteyuki.plugin import load_plugin, load_plugins
 
-from .protocol import (
-    ActionRequest,
-    ActionResponse,
-    ConfigMessage,
-    Heartbeat,
-    Hello,
-    Ready,
-    Shutdown,
-    Welcome,
-    read_message,
-    write_message,
-)
+from .client import RuntimeClient
+from .protocol import ActionRequest, ActionResponse, Shutdown
 
 
 async def run() -> None:
     configure_child_runtime()
     logger = get_logger(component="legacy", runtime=os.environ.get("LITEYUKI_RUNTIME_ID", "v6"))
-    host = os.environ["LITEYUKI_RUNTIME_HOST"]
-    port = int(os.environ["LITEYUKI_RUNTIME_PORT"])
-    token = os.environ["LITEYUKI_RUNTIME_TOKEN"]
     runtime_id = os.environ["LITEYUKI_RUNTIME_ID"]
-    reader, writer = await asyncio.open_connection(host, port)
-    await write_message(writer, Hello(runtime_id=runtime_id, kind="v6", token=token))
-    welcome = await read_message(reader)
-    config_message = await read_message(reader)
-    if not isinstance(welcome, Welcome) or not isinstance(config_message, ConfigMessage):
-        raise RuntimeError("invalid supervisor handshake")
-
-    options = config_message.options
-    legacy_config = _mapping_option(options, "config")
-    restart_requested = asyncio.Event()
-    loop = asyncio.get_running_loop()
-
-    def request_restart(_name: str | None) -> None:
-        loop.call_soon_threadsafe(restart_requested.set)
-
-    _install_runtime(legacy_config, request_restart)
+    client = RuntimeClient.from_environment("v6")
+    runtime_installed = False
     restarting = False
     try:
+        options = await client.connect()
+        legacy_config = _mapping_option(options, "config")
+        restart_requested = asyncio.Event()
+        loop = asyncio.get_running_loop()
+
+        def request_restart(_name: str | None) -> None:
+            loop.call_soon_threadsafe(restart_requested.set)
+
+        _install_runtime(legacy_config, request_restart)
+        runtime_installed = True
         _load_configured_plugins(options)
         await _emit_lifecycle("before_start")
         await _emit_lifecycle("after_start")
         if int(os.environ.get("LITEYUKI_RUNTIME_RESTART_COUNT", "0")) > 0:
             await _emit_lifecycle("after_restart")
-        await write_message(writer, Ready(capabilities=("v6.plugins", "v6.lifecycle")))
+        await client.ready(("v6.plugins", "v6.lifecycle"))
 
-        heartbeat_task = asyncio.create_task(
-            _heartbeat(writer, welcome.heartbeat_interval),
-            name="v6-runtime-heartbeat",
-        )
-        try:
-            while True:
-                incoming = asyncio.create_task(read_message(reader), name="v6-runtime-receive")
-                restart = asyncio.create_task(restart_requested.wait(), name="v6-runtime-restart")
-                done, pending = await asyncio.wait(
-                    (incoming, restart),
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                for task in pending:
-                    task.cancel()
-                await asyncio.gather(*pending, return_exceptions=True)
-                if restart in done and restart.result():
-                    restarting = True
-                    await _emit_lifecycle("before_process_restart", runtime_id)
-                    break
-                message = incoming.result()
-                if isinstance(message, Shutdown):
-                    await _emit_lifecycle("before_process_shutdown", runtime_id)
-                    break
-                if isinstance(message, ActionRequest):
-                    await write_message(
-                        writer,
-                        ActionResponse(
-                            correlation_id=message.correlation_id,
-                            ok=False,
-                            error="v6 compatibility plugins do not expose a protocol adapter",
-                        ),
+        while True:
+            incoming = asyncio.create_task(client.receive(), name="v6-runtime-receive")
+            restart = asyncio.create_task(restart_requested.wait(), name="v6-runtime-restart")
+            done, pending = await asyncio.wait(
+                (incoming, restart),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            if restart in done and restart.result():
+                restarting = True
+                await _emit_lifecycle("before_process_restart", runtime_id)
+                break
+            message = incoming.result()
+            if isinstance(message, Shutdown):
+                await _emit_lifecycle("before_process_shutdown", runtime_id)
+                break
+            if isinstance(message, ActionRequest):
+                await client.send(
+                    ActionResponse(
+                        correlation_id=message.correlation_id,
+                        ok=False,
+                        error="v6 compatibility plugins do not expose a protocol adapter",
                     )
-        finally:
-            heartbeat_task.cancel()
-            await asyncio.gather(heartbeat_task, return_exceptions=True)
+                )
         await _emit_lifecycle("after_shutdown")
     finally:
-        _reset_runtime()
-        writer.close()
-        await writer.wait_closed()
+        if runtime_installed:
+            _reset_runtime()
+        await client.close()
     if restarting:
         logger.info("v6 compatibility runtime requested restart")
         raise RuntimeError("v6 compatibility runtime requested restart")
-
-
-async def _heartbeat(writer: asyncio.StreamWriter, interval: float) -> None:
-    while True:
-        await asyncio.sleep(interval)
-        await write_message(writer, Heartbeat(monotonic=time.monotonic()))
-
 
 def _mapping_option(options: Mapping[str, Any], key: str) -> Mapping[str, Any]:
     value = options.get(key, {})

--- a/tests/test_runtime_client_v7.py
+++ b/tests/test_runtime_client_v7.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from liteyukibot.exceptions import RuntimeProtocolError
+from liteyukibot.runtime import RuntimeClient
+from liteyukibot.runtime.protocol import (
+    ConfigMessage,
+    ErrorMessage,
+    Heartbeat,
+    Hello,
+    Ready,
+    Welcome,
+    read_message,
+    write_message,
+)
+
+type ServerHandler = Callable[[asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]]
+
+
+async def _server(handler: ServerHandler) -> tuple[asyncio.Server, int, asyncio.Future[None]]:
+    done: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+
+    async def wrapped(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await handler(reader, writer)
+        except BaseException as error:
+            if not done.done():
+                done.set_exception(error)
+        else:
+            if not done.done():
+                done.set_result(None)
+
+    server = await asyncio.start_server(wrapped, "127.0.0.1", 0)
+    port = int(server.sockets[0].getsockname()[1])
+    return server, port, done
+
+
+def _client(port: int) -> RuntimeClient:
+    return RuntimeClient(
+        host="127.0.0.1",
+        port=port,
+        runtime_id="fixture",
+        kind="test",
+        token="secret",
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_handshake_ready_heartbeat_and_close() -> None:
+    observed: list[object] = []
+    heartbeat_seen = asyncio.Event()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        observed.append(await read_message(reader))
+        await write_message(writer, Welcome(heartbeat_interval=0.01))
+        await write_message(writer, ConfigMessage(options={"enabled": True}))
+        observed.append(await read_message(reader))
+        observed.append(await read_message(reader))
+        heartbeat_seen.set()
+        assert await reader.read() == b""
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        assert await client.connect() == {"enabled": True}
+        assert client.connected is True
+        await client.ready(("events",))
+        await asyncio.wait_for(heartbeat_seen.wait(), timeout=1)
+        await client.close()
+        await client.close()
+        await server_done
+    finally:
+        await client.close()
+        server.close()
+        await server.wait_closed()
+
+    assert isinstance(observed[0], Hello)
+    assert observed[1] == Ready(capabilities=("events",))
+    assert isinstance(observed[2], Heartbeat)
+    assert client.connected is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_serializes_concurrent_writes() -> None:
+    responses: list[object] = []
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, Welcome())
+        await write_message(writer, ConfigMessage())
+        responses.extend([await read_message(reader), await read_message(reader)])
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        await client.connect()
+        await asyncio.gather(
+            client.send(ErrorMessage(code="first", message="one")),
+            client.send(ErrorMessage(code="second", message="two")),
+        )
+        await server_done
+    finally:
+        await client.close()
+        server.close()
+        await server.wait_closed()
+
+    assert {message.code for message in responses if isinstance(message, ErrorMessage)} == {
+        "first",
+        "second",
+    }
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_rejects_invalid_handshake_and_closes() -> None:
+    peer_closed = asyncio.Event()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, ConfigMessage())
+        assert await reader.read() == b""
+        peer_closed.set()
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        with pytest.raises(RuntimeProtocolError, match="expected welcome"):
+            await client.connect()
+        await asyncio.wait_for(peer_closed.wait(), timeout=1)
+        await server_done
+    finally:
+        await client.close()
+        server.close()
+        await server.wait_closed()
+
+    assert client.connected is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_reports_eof_after_handshake() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, Welcome())
+        await write_message(writer, ConfigMessage())
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        await client.connect()
+        with pytest.raises(EOFError, match="connection closed"):
+            await client.receive()
+        await server_done
+    finally:
+        await client.close()
+        server.close()
+        await server.wait_closed()


### PR DESCRIPTION
## Summary

- add one async `RuntimeClient` for child identity, protocol-v1 handshake, READY/heartbeat, serialized writes, receive, and idempotent cleanup
- migrate noop, NoneBot, and v6 child hosts away from duplicated transport ownership
- close the v6 connection and reset installed compatibility state on initialization failures
- document the internal ownership boundary without changing protocol schemas or restart policy

## Validation

- `uv run ruff check src tests scripts`
- `uv run mypy`
- `uv run pytest` (66 passed)
- `uv lock --check`
- `uv build`
- local Docker build plus `version`, `check`, and non-root user smoke tests