### PR TITLE
✨ negotiate runtime protocol v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
   release tag/build verification;
 - retained the non-root local Docker build while remote image publication is paused.
 - centralized child-runtime handshake, heartbeat, serialized writes, and cleanup
-  in a reusable protocol-v1 client shared by all built-in child hosts.
+  in a reusable versioned client shared by all built-in child hosts.
+- added negotiated runtime protocol v2 with capability-gated core-to-child event
+  delivery while retaining concurrent v1 child support.
 
 ## 7.0.0a1 - 2026-08-04
 

--- a/docs/adr/0005-runtime-ipc-protocol-v2.md
+++ b/docs/adr/0005-runtime-ipc-protocol-v2.md
@@ -1,0 +1,62 @@
+# ADR 0005: Negotiate Runtime IPC Version 2 And Bidirectional Events
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+Protocol v1 only sends events from a child runtime to the core. Useful
+LiteyukiBot v6 message-plugin compatibility requires the core to deliver a
+normalized event to a supervised compatibility runtime without adding a second
+transport or exposing framework objects across the process boundary.
+
+ADR 0002 freezes every v1 message shape and direction. The existing `hello` and
+`welcome` messages already carry a protocol number, so a new direction must be
+selected explicitly through those fields.
+
+## Decision
+
+The supervisor accepts runtime protocol versions 1 and 2. A child requests one
+exact version in `hello.protocol`; the supervisor confirms that same version in
+`welcome.protocol`. A different confirmation, an unsupported version, or an
+invalid handshake order is fatal to the connection. Children do not retry with
+a lower version because reconnect and restart policy remain supervisor-owned.
+
+Version 1 retains the complete contract in ADR 0002. Version 2 retains the same
+framing, authentication, frame limit, JSON validation, message fields, and
+Action directions. It changes only the allowed directions of the existing event
+request/response pair:
+
+| Type | v1 direction | v2 direction |
+| --- | --- | --- |
+| `event` | child -> core | either direction |
+| `event_accepted` | core -> child | either direction |
+
+A v2 child opts into core-to-child events by including the exact capability
+`runtime.events.receive` in `ready.capabilities`. Capabilities are scoped to the
+current authenticated connection and are cleared on disconnect.
+
+`RuntimeSupervisor.dispatch_event()` sends an `event` only when the runtime is
+READY, negotiated v2, and declared that capability. It validates the payload as
+JSON-safe, requires a unique in-flight correlation identifier, and waits for the
+matching `event_accepted`. The existing `accepted`, `overloaded`, and `invalid`
+statuses and optional detail retain their v1 meanings.
+
+Timeout removes the pending request. Disconnect fails it with
+`ConnectionError`. Duplicate in-flight correlation identifiers are rejected
+before another frame is sent. An unmatched or late `event_accepted` has no
+effect.
+
+## Consequences
+
+V1 and v2 children may connect to the same supervisor concurrently. Existing v1
+children remain valid but cannot receive core events, even if they advertise the
+v2 capability string.
+
+Framework runtimes own conversion from a received `EventEnvelope` schema-v1
+payload to their local matcher/event model. This decision does not add that
+conversion, change EventBus ordering, or make NoneBot and v6 runtimes advertise
+event reception automatically.
+
+Future protocol changes must use a new negotiated version or a capability whose
+semantics are fully expressible by the selected protocol version.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,10 +1,11 @@
 # LiteyukiBot v7 ADRs
 
-These accepted records freeze public v1 contracts. New behavior must either fit
-one of these records without changing its semantics or introduce a new,
-explicitly versioned decision.
+These accepted records freeze public versioned contracts. New behavior must
+either fit one of these records without changing its semantics or introduce a
+new, explicitly versioned decision.
 
 1. [Event and action contracts](0001-event-and-action-contracts.md)
 2. [Local runtime IPC protocol](0002-runtime-ipc-protocol-v1.md)
 3. [Native plugin API](0003-native-plugin-api-v1.md)
 4. [Configuration precedence and error taxonomy](0004-configuration-and-error-contracts.md)
+5. [Runtime IPC v2 and bidirectional events](0005-runtime-ipc-protocol-v2.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -44,9 +44,12 @@ runtime rather than leaking into the core.
 
 Each runtime gets a random token and connects to a loopback TCP listener. Frames
 use a four-byte big-endian length followed by UTF-8 JSON, capped at 8 MiB.
-Protocol v1 covers hello/welcome, config, ready, heartbeat, event acceptance,
-actions/results, shutdown, and errors. Abnormal exits use bounded exponential
-restart; clean exits do not restart.
+Protocol v1 covers hello/welcome, config, ready, heartbeat, child-originated
+events, actions/results, shutdown, and errors. Protocol v2 is selected by an
+exact hello/welcome version match and permits event/event-accepted pairs in
+either direction. Core-to-child delivery additionally requires the
+`runtime.events.receive` READY capability. V1 and v2 children may run together.
+Abnormal exits use bounded exponential restart; clean exits do not restart.
 
 All built-in child hosts use one async `RuntimeClient` for environment identity,
 handshake validation, negotiated heartbeat, serialized writes, receive, and
@@ -57,13 +60,16 @@ NoneBot is hosted through its official initialization, driver, plugin-loading,
 event-preprocessor, `Bot.send`, and `Bot.call_api` surfaces. Event forwarding is
 observational and never suppresses NoneBot matcher dispatch.
 
-## Stable v1 Contracts
+## Versioned Contracts
 
-The public v1 contracts are frozen in the accepted
+The public v1 contracts remain frozen in the accepted
 [architecture decision records](../adr/README.md): event/action schemas, local
 runtime IPC, native plugins, configuration precedence, and error taxonomy.
 Changes to these surfaces require an explicit versioned decision rather than an
 unannounced compatible-looking edit.
+
+ADR 0005 adds the negotiated protocol-v2 event direction while ADR 0002 remains
+the frozen v1 contract.
 
 ## Operations
 

--- a/src/liteyukibot/runtime/__init__.py
+++ b/src/liteyukibot/runtime/__init__.py
@@ -3,6 +3,8 @@
 from .client import RuntimeClient
 from .protocol import (
     MAX_FRAME_SIZE,
+    PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
     ActionRequest,
     ActionResponse,
     ConfigMessage,
@@ -10,6 +12,7 @@ from .protocol import (
     EventMessage,
     Heartbeat,
     Hello,
+    ProtocolVersion,
     Ready,
     Shutdown,
     Welcome,
@@ -20,6 +23,8 @@ from .supervisor import RuntimeSpec, RuntimeState, RuntimeSupervisor
 
 __all__ = [
     "MAX_FRAME_SIZE",
+    "PROTOCOL_VERSION",
+    "SUPPORTED_PROTOCOL_VERSIONS",
     "ActionRequest",
     "ActionResponse",
     "ConfigMessage",
@@ -27,6 +32,7 @@ __all__ = [
     "EventMessage",
     "Heartbeat",
     "Hello",
+    "ProtocolVersion",
     "Ready",
     "RuntimeClient",
     "RuntimeSpec",

--- a/src/liteyukibot/runtime/__main__.py
+++ b/src/liteyukibot/runtime/__main__.py
@@ -9,6 +9,8 @@ from .client import RuntimeClient
 from .protocol import (
     ActionRequest,
     ActionResponse,
+    EventAccepted,
+    EventMessage,
     Shutdown,
 )
 
@@ -19,7 +21,7 @@ async def run_noop(kind: str) -> None:
         await client.connect()
         if kind != "noop":
             raise RuntimeError(f"runtime kind {kind!r} is not installed")
-        await client.ready(("noop",))
+        await client.ready(("noop", "runtime.events.receive"))
         while True:
             message = await client.receive()
             if isinstance(message, Shutdown):
@@ -31,6 +33,13 @@ async def run_noop(kind: str) -> None:
                         ok=True,
                         data={"echo": message.payload},
                     ),
+                )
+            if isinstance(message, EventMessage):
+                await client.send(
+                    EventAccepted(
+                        correlation_id=message.correlation_id,
+                        status="accepted",
+                    )
                 )
     finally:
         await client.close()

--- a/src/liteyukibot/runtime/client.py
+++ b/src/liteyukibot/runtime/client.py
@@ -1,4 +1,4 @@
-"""Reusable protocol-v1 client for supervised child runtimes."""
+"""Reusable versioned client for supervised child runtimes."""
 
 from __future__ import annotations
 
@@ -9,10 +9,13 @@ from collections.abc import Mapping, Sequence
 
 from ..exceptions import RuntimeProtocolError
 from .protocol import (
+    PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
     ConfigMessage,
     Heartbeat,
     Hello,
     JsonValue,
+    ProtocolVersion,
     Ready,
     Welcome,
     WireMessage,
@@ -30,16 +33,21 @@ class RuntimeClient:
         runtime_id: str,
         kind: str,
         token: str,
+        protocol_version: ProtocolVersion = PROTOCOL_VERSION,
     ) -> None:
         if not host or not runtime_id or not kind or not token:
             raise ValueError("runtime connection identity must not be empty")
         if not 1 <= port <= 65535:
             raise ValueError("runtime port must be between 1 and 65535")
+        if protocol_version not in SUPPORTED_PROTOCOL_VERSIONS:
+            raise ValueError(f"unsupported runtime protocol version: {protocol_version}")
         self.host = host
         self.port = port
         self.runtime_id = runtime_id
         self.kind = kind
         self.token = token
+        self.protocol_version = protocol_version
+        self.negotiated_protocol: ProtocolVersion | None = None
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._send_lock = asyncio.Lock()
@@ -52,6 +60,8 @@ class RuntimeClient:
         cls,
         kind: str,
         environment: Mapping[str, str] | None = None,
+        *,
+        protocol_version: ProtocolVersion = PROTOCOL_VERSION,
     ) -> RuntimeClient:
         values = os.environ if environment is None else environment
         return cls(
@@ -60,6 +70,7 @@ class RuntimeClient:
             runtime_id=values["LITEYUKI_RUNTIME_ID"],
             kind=kind,
             token=values["LITEYUKI_RUNTIME_TOKEN"],
+            protocol_version=protocol_version,
         )
 
     @property
@@ -76,17 +87,23 @@ class RuntimeClient:
                     runtime_id=self.runtime_id,
                     kind=self.kind,
                     token=self.token,
+                    protocol=self.protocol_version,
                 )
             )
             welcome = await self.receive()
             if not isinstance(welcome, Welcome):
                 raise RuntimeProtocolError("expected welcome during runtime handshake")
+            if welcome.protocol != self.protocol_version:
+                raise RuntimeProtocolError(
+                    "supervisor confirmed a different runtime protocol version"
+                )
             config = await self.receive()
             if not isinstance(config, ConfigMessage):
                 raise RuntimeProtocolError("expected config during runtime handshake")
             if welcome.heartbeat_interval <= 0:
                 raise RuntimeProtocolError("runtime heartbeat interval must be positive")
             self._heartbeat_interval = welcome.heartbeat_interval
+            self.negotiated_protocol = welcome.protocol
             return config.options
         except BaseException:
             await self.close()
@@ -127,6 +144,7 @@ class RuntimeClient:
         async with self._send_lock:
             writer, self._writer = self._writer, None
             self._reader = None
+            self.negotiated_protocol = None
             if writer is not None:
                 writer.close()
                 await writer.wait_closed()

--- a/src/liteyukibot/runtime/protocol.py
+++ b/src/liteyukibot/runtime/protocol.py
@@ -12,11 +12,13 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from ..exceptions import RuntimeProtocolError
 
-PROTOCOL_VERSION = 1
-MAX_FRAME_SIZE = 8 * 1024 * 1024
-
+type ProtocolVersion = Literal[1, 2]
 type JsonScalar = str | int | float | bool | None
 type JsonValue = JsonScalar | list[JsonValue] | dict[str, JsonValue]
+
+PROTOCOL_VERSION: ProtocolVersion = 2
+SUPPORTED_PROTOCOL_VERSIONS: tuple[ProtocolVersion, ...] = (1, 2)
+MAX_FRAME_SIZE = 8 * 1024 * 1024
 
 
 class WireModel(BaseModel):
@@ -25,7 +27,7 @@ class WireModel(BaseModel):
 
 class Hello(WireModel):
     type: Literal["hello"] = "hello"
-    protocol: Literal[1] = 1
+    protocol: ProtocolVersion = PROTOCOL_VERSION
     runtime_id: str
     kind: str
     token: str
@@ -33,7 +35,7 @@ class Hello(WireModel):
 
 class Welcome(WireModel):
     type: Literal["welcome"] = "welcome"
-    protocol: Literal[1] = 1
+    protocol: ProtocolVersion = PROTOCOL_VERSION
     heartbeat_interval: float = 10.0
 
 

--- a/src/liteyukibot/runtime/supervisor.py
+++ b/src/liteyukibot/runtime/supervisor.py
@@ -26,6 +26,7 @@ from .protocol import (
     Heartbeat,
     Hello,
     JsonValue,
+    ProtocolVersion,
     Ready,
     Shutdown,
     Welcome,
@@ -89,6 +90,9 @@ class RuntimeRecord:
     runner: asyncio.Task[None] | None = None
     output_tasks: tuple[asyncio.Task[None], ...] = ()
     pending_actions: dict[str, asyncio.Future[ActionResponse]] = field(default_factory=dict)
+    pending_events: dict[str, asyncio.Future[EventAccepted]] = field(default_factory=dict)
+    protocol_version: ProtocolVersion | None = None
+    capabilities: frozenset[str] = frozenset()
     send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     launch_count: int = 0
 
@@ -241,7 +245,14 @@ class RuntimeSupervisor:
             record.writer = writer
             record.connected.set()
             record.last_heartbeat = time.monotonic()
-            await self._send(record, Welcome(heartbeat_interval=record.spec.heartbeat_interval))
+            record.protocol_version = message.protocol
+            await self._send(
+                record,
+                Welcome(
+                    protocol=message.protocol,
+                    heartbeat_interval=record.spec.heartbeat_interval,
+                ),
+            )
             await self._send(record, ConfigMessage(options=json_mapping(record.spec.options)))
             await self._receive_loop(record)
         except (EOFError, ConnectionError):
@@ -263,6 +274,7 @@ class RuntimeSupervisor:
 
     async def _handle_message(self, record: RuntimeRecord, message: WireMessage) -> None:
         if isinstance(message, Ready):
+            record.capabilities = frozenset(message.capabilities)
             record.state = RuntimeState.READY
             record.ready.set()
         elif isinstance(message, Heartbeat):
@@ -280,10 +292,14 @@ class RuntimeSupervisor:
                 record,
                 EventAccepted(correlation_id=message.correlation_id, status=normalized),
             )
+        elif isinstance(message, EventAccepted):
+            event_future = record.pending_events.pop(message.correlation_id, None)
+            if event_future is not None and not event_future.done():
+                event_future.set_result(message)
         elif isinstance(message, ActionResponse):
-            future = record.pending_actions.pop(message.correlation_id, None)
-            if future is not None and not future.done():
-                future.set_result(message)
+            action_future = record.pending_actions.pop(message.correlation_id, None)
+            if action_future is not None and not action_future.done():
+                action_future.set_result(message)
         elif isinstance(message, ErrorMessage):
             self.logger.error("runtime {} error {}: {}", record.spec.id, message.code, message.message)
         else:
@@ -310,6 +326,34 @@ class RuntimeSupervisor:
                 return await future
         finally:
             record.pending_actions.pop(correlation_id, None)
+
+    async def dispatch_event(
+        self,
+        runtime_id: str,
+        correlation_id: str,
+        payload: Mapping[str, Any],
+        timeout_seconds: float = 30.0,
+    ) -> EventAccepted:
+        record = self.records[runtime_id]
+        if record.state is not RuntimeState.READY:
+            raise RuntimeError(f"runtime {runtime_id} is not ready")
+        if record.protocol_version != 2:
+            raise RuntimeError(f"runtime {runtime_id} did not negotiate protocol v2")
+        if "runtime.events.receive" not in record.capabilities:
+            raise RuntimeError(f"runtime {runtime_id} does not accept core events")
+        if correlation_id in record.pending_events:
+            raise ValueError(f"duplicate event correlation id: {correlation_id}")
+        future: asyncio.Future[EventAccepted] = asyncio.get_running_loop().create_future()
+        record.pending_events[correlation_id] = future
+        try:
+            await self._send(
+                record,
+                EventMessage(correlation_id=correlation_id, payload=json_mapping(payload)),
+            )
+            async with asyncio.timeout(timeout_seconds):
+                return await future
+        finally:
+            record.pending_events.pop(correlation_id, None)
 
     async def restart(self, runtime_id: str) -> None:
         record = self.records[runtime_id]
@@ -388,10 +432,20 @@ class RuntimeSupervisor:
         record.reader = None
         record.connected.clear()
         record.ready.clear()
-        for future in record.pending_actions.values():
-            if not future.done():
-                future.set_exception(ConnectionError(f"runtime {record.spec.id} disconnected"))
+        record.protocol_version = None
+        record.capabilities = frozenset()
+        for action_future in record.pending_actions.values():
+            if not action_future.done():
+                action_future.set_exception(
+                    ConnectionError(f"runtime {record.spec.id} disconnected")
+                )
         record.pending_actions.clear()
+        for event_future in record.pending_events.values():
+            if not event_future.done():
+                event_future.set_exception(
+                    ConnectionError(f"runtime {record.spec.id} disconnected")
+                )
+        record.pending_events.clear()
         if writer is not None:
             writer.close()
             await writer.wait_closed()

--- a/tests/test_protocol_v7.py
+++ b/tests/test_protocol_v7.py
@@ -11,6 +11,7 @@ from liteyukibot.exceptions import RuntimeProtocolError
 from liteyukibot.runtime.protocol import (
     MAX_FRAME_SIZE,
     ConfigMessage,
+    Hello,
     Ready,
     json_mapping,
     read_message,
@@ -89,3 +90,39 @@ async def test_protocol_accepts_discriminated_ready_message() -> None:
     frame = struct.pack(">I", len(payload)) + payload
 
     assert await read_message(_reader(frame)) == Ready(capabilities=("events",))
+
+
+@pytest.mark.parametrize("protocol", [1, 2])
+@pytest.mark.asyncio
+async def test_protocol_accepts_negotiated_hello_versions(protocol: int) -> None:
+    payload = json.dumps(
+        {
+            "type": "hello",
+            "protocol": protocol,
+            "runtime_id": "fixture",
+            "kind": "custom",
+            "token": "secret",
+        }
+    ).encode()
+    frame = struct.pack(">I", len(payload)) + payload
+
+    message = await read_message(_reader(frame))
+    assert isinstance(message, Hello)
+    assert message.protocol == protocol
+
+
+@pytest.mark.asyncio
+async def test_protocol_rejects_unsupported_hello_version() -> None:
+    payload = json.dumps(
+        {
+            "type": "hello",
+            "protocol": 3,
+            "runtime_id": "fixture",
+            "kind": "custom",
+            "token": "secret",
+        }
+    ).encode()
+    frame = struct.pack(">I", len(payload)) + payload
+
+    with pytest.raises(RuntimeProtocolError):
+        await read_message(_reader(frame))

--- a/tests/test_runtime_client_v7.py
+++ b/tests/test_runtime_client_v7.py
@@ -12,6 +12,7 @@ from liteyukibot.runtime.protocol import (
     ErrorMessage,
     Heartbeat,
     Hello,
+    ProtocolVersion,
     Ready,
     Welcome,
     read_message,
@@ -39,14 +40,27 @@ async def _server(handler: ServerHandler) -> tuple[asyncio.Server, int, asyncio.
     return server, port, done
 
 
-def _client(port: int) -> RuntimeClient:
+def _client(port: int, protocol_version: ProtocolVersion = 2) -> RuntimeClient:
     return RuntimeClient(
         host="127.0.0.1",
         port=port,
         runtime_id="fixture",
         kind="test",
         token="secret",
+        protocol_version=protocol_version,
     )
+
+
+def test_runtime_client_rejects_unsupported_protocol_before_connecting() -> None:
+    with pytest.raises(ValueError, match="unsupported runtime protocol version"):
+        RuntimeClient(
+            host="127.0.0.1",
+            port=1,
+            runtime_id="fixture",
+            kind="test",
+            token="secret",
+            protocol_version=3,  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.asyncio
@@ -160,6 +174,53 @@ async def test_runtime_client_reports_eof_after_handshake() -> None:
         await client.connect()
         with pytest.raises(EOFError, match="connection closed"):
             await client.receive()
+        await server_done
+    finally:
+        await client.close()
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_can_negotiate_protocol_v1() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        hello = await read_message(reader)
+        assert isinstance(hello, Hello)
+        assert hello.protocol == 1
+        await write_message(writer, Welcome(protocol=1))
+        await write_message(writer, ConfigMessage())
+        assert await reader.read() == b""
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port, protocol_version=1)
+    try:
+        assert await client.connect() == {}
+        assert client.negotiated_protocol == 1
+    finally:
+        await client.close()
+        await server_done
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_rejects_protocol_version_mismatch() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        hello = await read_message(reader)
+        assert isinstance(hello, Hello)
+        assert hello.protocol == 2
+        await write_message(writer, Welcome(protocol=1))
+        assert await reader.read() == b""
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        with pytest.raises(RuntimeProtocolError, match="different runtime protocol"):
+            await client.connect()
         await server_done
     finally:
         await client.close()

--- a/tests/test_runtime_v7.py
+++ b/tests/test_runtime_v7.py
@@ -10,7 +10,16 @@ from typing import Any
 import pytest
 
 from liteyukibot.runtime import RuntimeSpec, RuntimeState, RuntimeSupervisor
-from liteyukibot.runtime.protocol import Hello, write_message
+from liteyukibot.runtime.protocol import (
+    ConfigMessage,
+    EventAccepted,
+    EventMessage,
+    Hello,
+    Ready,
+    Welcome,
+    read_message,
+    write_message,
+)
 from liteyukibot.runtime.supervisor import RuntimeRecord
 
 
@@ -29,6 +38,20 @@ class FakeLogger:
 
     def error(self, message: str, *args: Any, **kwargs: Any) -> None:
         pass
+
+
+class NullWriter:
+    def write(self, _value: bytes) -> None:
+        return None
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+    async def wait_closed(self) -> None:
+        return None
 
 
 @pytest.mark.asyncio
@@ -50,6 +73,9 @@ async def test_noop_runtime_handshake_action_and_shutdown() -> None:
     result = await supervisor.execute_action("echo", "action-1", {"message": "hello"})
     assert result.ok is True
     assert result.data == {"echo": {"message": "hello"}}
+
+    event_result = await supervisor.dispatch_event("echo", "event-1", {"message": "hello"})
+    assert event_result == EventAccepted(correlation_id="event-1", status="accepted")
 
     await supervisor.restart("echo")
     assert supervisor.records["echo"].state.value == RuntimeState.READY
@@ -108,6 +134,65 @@ async def test_runtime_rejects_bad_and_duplicate_connections() -> None:
         assert record.state is RuntimeState.READY
 
     await supervisor.stop()
+
+
+@pytest.mark.asyncio
+async def test_runtime_negotiates_v1_and_v2_connections_concurrently() -> None:
+    supervisor = RuntimeSupervisor(logger=FakeLogger())
+    supervisor.add(RuntimeSpec(id="legacy", kind="custom"))
+    supervisor.add(RuntimeSpec(id="modern", kind="custom"))
+    legacy = supervisor.records["legacy"]
+    modern = supervisor.records["modern"]
+    server = await asyncio.start_server(supervisor._accept, "127.0.0.1", 0)
+    port = int(server.sockets[0].getsockname()[1])
+    legacy_reader, legacy_writer = await asyncio.open_connection("127.0.0.1", port)
+    modern_reader, modern_writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        await write_message(
+            legacy_writer,
+            Hello(protocol=1, runtime_id="legacy", kind="custom", token=legacy.token),
+        )
+        assert await read_message(legacy_reader) == Welcome(protocol=1)
+        assert isinstance(await read_message(legacy_reader), ConfigMessage)
+        await write_message(legacy_writer, Ready(capabilities=("runtime.events.receive",)))
+
+        await write_message(
+            modern_writer,
+            Hello(protocol=2, runtime_id="modern", kind="custom", token=modern.token),
+        )
+        assert await read_message(modern_reader) == Welcome(protocol=2)
+        assert isinstance(await read_message(modern_reader), ConfigMessage)
+        await write_message(modern_writer, Ready(capabilities=("runtime.events.receive",)))
+        await asyncio.wait_for(
+            asyncio.gather(legacy.ready.wait(), modern.ready.wait()),
+            timeout=1,
+        )
+
+        assert legacy.protocol_version == 1
+        assert modern.protocol_version == 2
+        with pytest.raises(RuntimeError, match="did not negotiate protocol v2"):
+            await supervisor.dispatch_event("legacy", "event-v1", {})
+
+        delivery = asyncio.create_task(
+            supervisor.dispatch_event("modern", "event-v2", {"message": "hello"})
+        )
+        outbound = await asyncio.wait_for(read_message(modern_reader), timeout=1)
+        assert outbound == EventMessage(
+            correlation_id="event-v2",
+            payload={"message": "hello"},
+        )
+        await write_message(
+            modern_writer,
+            EventAccepted(correlation_id="event-v2", status="accepted"),
+        )
+        assert (await delivery).status == "accepted"
+    finally:
+        legacy_writer.close()
+        modern_writer.close()
+        await legacy_writer.wait_closed()
+        await modern_writer.wait_closed()
+        server.close()
+        await server.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -199,6 +284,111 @@ async def test_action_timeout_removes_pending_request(monkeypatch: pytest.Monkey
         await supervisor.execute_action("action", "request", {}, timeout_seconds=0.01)
 
     assert record.pending_actions == {}
+
+
+@pytest.mark.asyncio
+async def test_event_delivery_timeout_removes_pending_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supervisor = RuntimeSupervisor(logger=FakeLogger())
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="event", kind="custom"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+        protocol_version=2,
+        capabilities=frozenset({"runtime.events.receive"}),
+    )
+    supervisor.records[record.spec.id] = record
+
+    async def ignore_event(_record: RuntimeRecord, _message: Any) -> None:
+        return None
+
+    monkeypatch.setattr(supervisor, "_send", ignore_event)
+    with pytest.raises(TimeoutError):
+        await supervisor.dispatch_event("event", "request", {}, timeout_seconds=0.01)
+
+    assert record.pending_events == {}
+
+
+@pytest.mark.asyncio
+async def test_v2_event_delivery_requires_receive_capability() -> None:
+    supervisor = RuntimeSupervisor(logger=FakeLogger())
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="event", kind="custom"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+        protocol_version=2,
+    )
+    supervisor.records[record.spec.id] = record
+
+    with pytest.raises(RuntimeError, match="does not accept core events"):
+        await supervisor.dispatch_event("event", "request", {})
+
+    assert record.pending_events == {}
+
+
+@pytest.mark.asyncio
+async def test_event_delivery_returns_child_rejection(monkeypatch: pytest.MonkeyPatch) -> None:
+    supervisor = RuntimeSupervisor(logger=FakeLogger())
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="event", kind="custom"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+        protocol_version=2,
+        capabilities=frozenset({"runtime.events.receive"}),
+    )
+    supervisor.records[record.spec.id] = record
+
+    async def reject_event(_record: RuntimeRecord, message: Any) -> None:
+        await supervisor._handle_message(
+            record,
+            EventAccepted(
+                correlation_id=message.correlation_id,
+                status="invalid",
+                detail="unsupported event",
+            ),
+        )
+
+    monkeypatch.setattr(supervisor, "_send", reject_event)
+    result = await supervisor.dispatch_event("event", "request", {})
+
+    assert result.status == "invalid"
+    assert result.detail == "unsupported event"
+    assert record.pending_events == {}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_event_delivery_and_disconnect_are_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent = asyncio.Event()
+    supervisor = RuntimeSupervisor(logger=FakeLogger())
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="event", kind="custom"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+        protocol_version=2,
+        capabilities=frozenset({"runtime.events.receive"}),
+    )
+    supervisor.records[record.spec.id] = record
+
+    async def hold_event(_record: RuntimeRecord, _message: Any) -> None:
+        sent.set()
+
+    monkeypatch.setattr(supervisor, "_send", hold_event)
+    delivery = asyncio.create_task(supervisor.dispatch_event("event", "duplicate", {}))
+    await sent.wait()
+    with pytest.raises(ValueError, match="duplicate event correlation id"):
+        await supervisor.dispatch_event("event", "duplicate", {})
+
+    await supervisor._disconnect(record)
+    with pytest.raises(ConnectionError, match="disconnected"):
+        await delivery
+    assert record.pending_events == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- negotiate runtime protocol v1 or v2 through exact HELLO/WELCOME version confirmation
- add capability-gated core-to-child event delivery with timeout, rejection, duplicate-correlation, and disconnect semantics
- retain concurrent v1 child support and keep NoneBot/v6 reception disabled until their framework contracts exist
- add ADR 0005 and real noop plus raw v1/v2 connection coverage

## Validation

- `uv run ruff check src tests scripts`
- `uv run mypy`
- `uv run pytest` (77 passed)
- `uv lock --check`
- `uv build`
- local Docker build plus `version`, `check`, and non-root user smoke tests