### PR TITLE
✨ restore v6 session compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   in a reusable versioned client shared by all built-in child hosts.
 - added negotiated runtime protocol v2 with capability-gated core-to-child event
   delivery while retaining concurrent v1 child support.
+- restored the process-local v6 session, rule, matcher, and reply-intent API
+  needed by ordinary message plugins without restoring Channel semantics.
 
 ## 7.0.0a1 - 2026-08-04
 

--- a/docs/adr/0006-v6-session-compatibility.md
+++ b/docs/adr/0006-v6-session-compatibility.md
@@ -1,0 +1,68 @@
+# ADR 0006: Define The v6 Session Compatibility Contract
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+LiteyukiBot v6 message plugins commonly import `MessageEvent`, `Rule`, matcher
+decorators, and session identity models. The initial v7 compatibility runtime
+supported plugin loading and lifecycle only, so those imports failed before an
+ordinary message plugin could register.
+
+The final v6 implementation also depended on Channel/shared-memory objects,
+contained inconsistent Session scope typing, and referenced `on_startswith`
+without implementing it. Restoring those defects would violate the v7 process
+boundary and would not provide a deterministic compatibility contract.
+
+## Decision
+
+The `liteyuki.session` compatibility namespace supports these process-local
+surfaces:
+
+- `MessageEvent` with the v6 constructor fields and public attributes;
+- synchronous `MessageEvent.reply()` with string or mapping payloads;
+- `Rule`, including sync or async predicates and short-circuit `&`, `|`, and
+  inversion;
+- `Matcher.handle()` with sync or async handlers;
+- `on_message`, `on_keywords`, `on_startswith`, `on_endswith`, and
+  `on_fullmatch`;
+- `SceneType`, `User`, `Scene`, `Role`, `Member`, and `Session`;
+- `BaseSeg`, `Text`, and `Image` message-segment imports.
+
+Matcher registration is process-local and stable. Larger numeric priorities run
+first, preserving v6 ordering. Registration order is preserved within one
+priority. A matching `block=True` matcher allows remaining matchers at the same
+priority to run, then prevents lower priorities. An unmatched blocking matcher
+does not stop dispatch.
+
+Handler exceptions are logged through Yukilog and isolated from later handlers.
+Dispatch reports matched matcher count, called handler count, block state, and
+failure strings for the compatibility host; plugin handlers may ignore that
+internal result as they did in v6.
+
+`MessageEvent.reply()` records ordered reply intents on the event. It performs no
+I/O. The compatibility host drains those intents only after matcher dispatch and
+will translate them to protocol-neutral Actions in a separately versioned
+runtime contract.
+
+Session scope uses `SceneType`, and `session_id`/`target_id` use stable numeric
+scope identifiers. `on_startswith` is implemented because shipped v6 plugin
+source imports it even though the final v6 registration module omitted it.
+
+## Unsupported
+
+`receive_channel`, Channel, shared memory, cross-process Python objects, dynamic
+matcher removal, hot reload, NoneBot dependency injection, and adapter object
+emulation are outside this contract. Passing a receive channel is an explicit
+`LegacyUnsupportedError`; it never becomes an inert value.
+
+## Consequences
+
+V6 message plugins can import and register without a runtime transport. Pure
+unit dispatch is deterministic and produces ordered reply intents.
+
+This contract alone does not make the v6 runtime advertise
+`runtime.events.receive`. Protocol v2 carries core-originated events but does not
+allow child-originated Actions, so reply delivery requires another negotiated
+protocol version before end-to-end runtime integration.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,3 +9,4 @@ new, explicitly versioned decision.
 3. [Native plugin API](0003-native-plugin-api-v1.md)
 4. [Configuration precedence and error taxonomy](0004-configuration-and-error-contracts.md)
 5. [Runtime IPC v2 and bidirectional events](0005-runtime-ipc-protocol-v2.md)
+6. [v6 session compatibility](0006-v6-session-compatibility.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -60,6 +60,11 @@ NoneBot is hosted through its official initialization, driver, plugin-loading,
 event-preprocessor, `Bot.send`, and `Bot.call_api` surfaces. Event forwarding is
 observational and never suppresses NoneBot matcher dispatch.
 
+The v6 compatibility namespace restores process-local session models, rules,
+matcher registration, deterministic priority dispatch, and ordered reply
+intents. It does not restore Channel or shared-memory object transport; runtime
+event delivery and reply Action transport remain explicit protocol boundaries.
+
 ## Versioned Contracts
 
 The public v1 contracts remain frozen in the accepted

--- a/docs/migration-v6.md
+++ b/docs/migration-v6.md
@@ -10,19 +10,31 @@ namespace is a compatibility package; new plugins should import `liteyukibot`.
 - `get_bot`, `get_config`, and `get_config_with_compat`;
 - explicit `load_plugin` and non-recursive `load_plugins`;
 - before/after startup and shutdown lifecycle decorators;
-- process restart requests for the compatibility runtime.
+- process restart requests for the compatibility runtime;
+- `MessageEvent`, session identity models, composable rules, matcher decorators,
+  stable priority dispatch, and synchronous reply-intent collection.
 
 ## Unsupported
 
 - constructing a nested `LiteyukiBot`;
 - `Channel`, shared memory, and the v6 process-manager APIs;
-- session/matcher APIs and implicit cross-process object sharing;
+- session `receive_channel` and implicit cross-process object sharing;
 - development hot reload and runtime package installation.
 
 Unsupported host construction raises `LegacyUnsupportedError`. Missing legacy
 modules are not recreated as inert stubs: plugin import fails so the migration
 gap remains visible. Compatibility also requires every plugin dependency to
 support CPython 3.14.
+
+Session matchers are process-local. `event.reply()` records an ordered reply
+intent; it does not send through a v6 Channel. Runtime event delivery and reply
+Action translation are introduced separately so plugins cannot observe a
+partially emulated cross-process object.
+
+Supported matcher constructors are `on_message`, `on_keywords`,
+`on_startswith`, `on_endswith`, and `on_fullmatch`. Larger numeric priorities
+run first as in v6; a matching blocking matcher stops lower priorities after all
+matchers at its own priority have run.
 
 Configure modules and directories explicitly:
 

--- a/src/liteyuki/session/__init__.py
+++ b/src/liteyuki/session/__init__.py
@@ -1,7 +1,42 @@
-from typing import NoReturn
+"""Supported LiteyukiBot v6 session compatibility API."""
 
-from liteyuki._unsupported import unsupported
+from .event import MessageEvent, ReplyPayload
+from .matcher import EventHandler, Matcher, MatcherRunResult
+from .models import Member, Role, Scene, SceneType, Session, User
+from .on import (
+    MatcherDispatchResult,
+    add_matcher,
+    get_matchers,
+    on_endswith,
+    on_fullmatch,
+    on_keywords,
+    on_message,
+    on_startswith,
+)
+from .rule import Rule, RuleHandlerFunc, empty_rule, is_su_rule
 
-
-def __getattr__(name: str) -> NoReturn:
-    unsupported(__name__, name)
+__all__ = [
+    "EventHandler",
+    "Matcher",
+    "MatcherDispatchResult",
+    "MatcherRunResult",
+    "Member",
+    "MessageEvent",
+    "ReplyPayload",
+    "Role",
+    "Rule",
+    "RuleHandlerFunc",
+    "Scene",
+    "SceneType",
+    "Session",
+    "User",
+    "add_matcher",
+    "empty_rule",
+    "get_matchers",
+    "is_su_rule",
+    "on_endswith",
+    "on_fullmatch",
+    "on_keywords",
+    "on_message",
+    "on_startswith",
+]

--- a/src/liteyuki/session/event.py
+++ b/src/liteyuki/session/event.py
@@ -1,7 +1,67 @@
-from typing import NoReturn
+"""LiteyukiBot v6-compatible message event model."""
 
-from liteyuki._unsupported import unsupported
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from liteyukibot.exceptions import LegacyUnsupportedError
+
+type ReplyPayload = str | dict[str, Any]
 
 
-def __getattr__(name: str) -> NoReturn:
-    unsupported(__name__, name)
+class MessageEvent:
+    def __init__(
+        self,
+        bot_id: str,
+        message: list[dict[str, Any]] | str,
+        message_type: str,
+        raw_message: str,
+        session_id: str,
+        user_id: str,
+        session_type: str,
+        receive_channel: object | None = None,
+        data: Mapping[str, Any] | None = None,
+    ) -> None:
+        if receive_channel is not None:
+            raise LegacyUnsupportedError(
+                "MessageEvent.receive_channel relies on unsupported v6 Channel semantics; "
+                "hosted v6 plugins must use event.reply()"
+            )
+        self.message_type = message_type
+        self.data = dict(data or {})
+        self.bot_id = bot_id
+        self.message = message
+        self.raw_message = raw_message
+        self.session_id = session_id
+        self.session_type = session_type
+        self.user_id = user_id
+        self.receive_channel = None
+        self._replies: list[ReplyPayload] = []
+
+    def __str__(self) -> str:
+        return (
+            f"Event(message_type={self.message_type}, data={self.data}, bot_id={self.bot_id}, "
+            f"session_id={self.session_id}, session_type={self.session_type})"
+        )
+
+    @property
+    def replies(self) -> tuple[ReplyPayload, ...]:
+        return tuple(self._replies)
+
+    def reply(self, message: str | Mapping[str, Any]) -> None:
+        if isinstance(message, str):
+            payload: ReplyPayload = message
+        elif isinstance(message, Mapping):
+            payload = dict(message)
+        else:
+            raise TypeError("v6 replies must be a string or mapping")
+        self._replies.append(payload)
+
+    def _drain_replies(self) -> tuple[ReplyPayload, ...]:
+        replies = tuple(self._replies)
+        self._replies.clear()
+        return replies
+
+
+__all__ = ["MessageEvent", "ReplyPayload"]

--- a/src/liteyuki/session/matcher.py
+++ b/src/liteyuki/session/matcher.py
@@ -1,7 +1,66 @@
-from typing import NoReturn
+"""LiteyukiBot v6-compatible matcher handlers."""
 
-from liteyuki._unsupported import unsupported
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from liteyuki.log import logger
+
+from .event import MessageEvent
+from .rule import Rule
+
+type EventHandler = Callable[[MessageEvent], Any | Awaitable[Any]]
 
 
-def __getattr__(name: str) -> NoReturn:
-    unsupported(__name__, name)
+@dataclass(frozen=True, slots=True)
+class MatcherRunResult:
+    matched: bool
+    handlers_called: int = 0
+    failures: tuple[str, ...] = ()
+
+
+class Matcher:
+    def __init__(self, rule: Rule, priority: int, block: bool) -> None:
+        if priority < 0:
+            raise ValueError("matcher priority must be non-negative")
+        self.rule = rule
+        self.priority = priority
+        self.block = block
+        self.handlers: list[EventHandler] = []
+
+    def __str__(self) -> str:
+        return f"Matcher(rule={self.rule}, priority={self.priority}, block={self.block})"
+
+    def handle(self) -> Callable[[EventHandler], EventHandler]:
+        def decorator(handler: EventHandler) -> EventHandler:
+            self.handlers.append(handler)
+            return handler
+
+        return decorator
+
+    async def run(self, event: MessageEvent) -> MatcherRunResult:
+        if not await self.rule(event):
+            return MatcherRunResult(matched=False)
+
+        failures: list[str] = []
+        handlers = tuple(self.handlers)
+        for handler in handlers:
+            try:
+                result = handler(event)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as error:
+                name = getattr(handler, "__qualname__", repr(handler))
+                failures.append(f"{name}: {type(error).__name__}: {error}")
+                logger.exception("v6 matcher handler {} failed: {}", name, error)
+        return MatcherRunResult(
+            matched=True,
+            handlers_called=len(handlers),
+            failures=tuple(failures),
+        )
+
+
+__all__ = ["EventHandler", "Matcher", "MatcherRunResult"]

--- a/src/liteyuki/session/message/__init__.py
+++ b/src/liteyuki/session/message/__init__.py
@@ -1,7 +1,5 @@
-from typing import NoReturn
+"""LiteyukiBot v6-compatible message segment exports."""
 
-from liteyuki._unsupported import unsupported
+from .segments import BaseSeg, Image, Text
 
-
-def __getattr__(name: str) -> NoReturn:
-    unsupported(__name__, name)
+__all__ = ["BaseSeg", "Image", "Text"]

--- a/src/liteyuki/session/message/segments.py
+++ b/src/liteyuki/session/message/segments.py
@@ -1,7 +1,23 @@
-from typing import NoReturn
+"""Basic message segment models retained for v6 imports."""
 
-from liteyuki._unsupported import unsupported
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
 
 
-def __getattr__(name: str) -> NoReturn:
-    unsupported(__name__, name)
+class BaseSeg(BaseModel):
+    type: str = "Segment"
+    data: dict[str, Any]
+
+
+class Text(BaseSeg):
+    content: str
+
+
+class Image(BaseSeg):
+    url: str
+
+
+__all__ = ["BaseSeg", "Image", "Text"]

--- a/src/liteyuki/session/models.py
+++ b/src/liteyuki/session/models.py
@@ -1,7 +1,103 @@
-from typing import NoReturn
+"""LiteyukiBot v6-compatible session identity models.
 
-from liteyuki._unsupported import unsupported
+The compatible field layout derives from nonebot-plugin-uninfo models.
+
+MIT License
+
+Copyright (c) 2024 RF-Tar-Railt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import IntEnum
+
+from pydantic import BaseModel, ConfigDict
 
 
-def __getattr__(name: str) -> NoReturn:
-    unsupported(__name__, name)
+class LegacySessionModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class SceneType(IntEnum):
+    PRIVATE = 0
+    GROUP = 1
+    GUILD = 2
+    CHANNEL_TEXT = 3
+    CHANNEL_CATEGORY = 4
+    CHANNEL_VOICE = 5
+
+
+class User(LegacySessionModel):
+    id: str
+    name: str | None = None
+    nick: str | None = None
+    avatar: str | None = None
+    gender: str | None = None
+
+
+class Scene(LegacySessionModel):
+    id: str
+    type: SceneType
+    name: str | None = None
+    avatar: str | None = None
+    parent: Scene | None = None
+
+
+class Role(LegacySessionModel):
+    id: str
+    level: int | None = None
+    name: str | None = None
+
+
+class Member(LegacySessionModel):
+    user: User
+    nickname: str | None = None
+    role: Role | None = None
+    mute: bool | None = None
+    joined_at: datetime | None = None
+
+
+class Session(LegacySessionModel):
+    self_id: str
+    adapter: str
+    scope: SceneType
+    scene: Scene
+    user: User
+    member: Member | None = None
+    operator: Member | None = None
+
+    @property
+    def session_id(self) -> str:
+        if self.scope is SceneType.PRIVATE:
+            target = self.user.id
+        else:
+            target = self.scene.id
+        return f"{self.scope.value}:{target}"
+
+    @property
+    def target_id(self) -> str:
+        if self.scope is SceneType.PRIVATE:
+            return f"{self.scope.value}:{self.user.id}"
+        return f"{self.scope.value}:{self.scene.id}:{self.user.id}"
+
+
+__all__ = ["Member", "Role", "Scene", "SceneType", "Session", "User"]

--- a/src/liteyuki/session/on.py
+++ b/src/liteyuki/session/on.py
@@ -1,7 +1,146 @@
-from typing import NoReturn
+"""Registration helpers for LiteyukiBot v6-compatible matchers."""
 
-from liteyuki._unsupported import unsupported
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .event import MessageEvent
+from .matcher import Matcher
+from .rule import Rule, empty_rule
 
 
-def __getattr__(name: str) -> NoReturn:
-    unsupported(__name__, name)
+@dataclass(frozen=True, slots=True)
+class MatcherDispatchResult:
+    matched: int
+    handlers_called: int
+    blocked: bool
+    failures: tuple[str, ...] = ()
+
+
+_matcher_list: list[Matcher] = []
+
+
+def add_matcher(matcher: Matcher) -> Matcher:
+    for index, registered in enumerate(_matcher_list):
+        if registered.priority < matcher.priority:
+            _matcher_list.insert(index, matcher)
+            break
+    else:
+        _matcher_list.append(matcher)
+    return matcher
+
+
+def get_matchers() -> tuple[Matcher, ...]:
+    return tuple(_matcher_list)
+
+
+def _reset_matchers() -> None:
+    _matcher_list.clear()
+
+
+async def _dispatch_matchers(event: MessageEvent) -> MatcherDispatchResult:
+    matched = 0
+    handlers_called = 0
+    blocked_priority: int | None = None
+    failures: list[str] = []
+    for matcher in tuple(_matcher_list):
+        if blocked_priority is not None and matcher.priority < blocked_priority:
+            break
+        result = await matcher.run(event)
+        if not result.matched:
+            continue
+        matched += 1
+        handlers_called += result.handlers_called
+        failures.extend(result.failures)
+        if matcher.block:
+            blocked_priority = matcher.priority
+    return MatcherDispatchResult(
+        matched=matched,
+        handlers_called=handlers_called,
+        blocked=blocked_priority is not None,
+        failures=tuple(failures),
+    )
+
+
+def on_message(rule: Rule = empty_rule, priority: int = 0, block: bool = False) -> Matcher:
+    return add_matcher(Matcher(rule, priority, block))
+
+
+def on_keywords(
+    keywords: str | Sequence[str],
+    rule: Rule = empty_rule,
+    priority: int = 0,
+    block: bool = False,
+) -> Matcher:
+    normalized = _normalize_keywords(keywords)
+
+    @Rule
+    async def keyword_rule(event: MessageEvent) -> bool:
+        return any(keyword in event.raw_message for keyword in normalized)
+
+    return on_message(keyword_rule & rule, priority, block)
+
+
+def on_startswith(
+    keywords: str | Sequence[str],
+    rule: Rule = empty_rule,
+    priority: int = 0,
+    block: bool = False,
+) -> Matcher:
+    normalized = _normalize_keywords(keywords)
+
+    @Rule
+    async def startswith_rule(event: MessageEvent) -> bool:
+        return event.raw_message.startswith(normalized)
+
+    return on_message(startswith_rule & rule, priority, block)
+
+
+def on_endswith(
+    keywords: str | Sequence[str],
+    rule: Rule = empty_rule,
+    priority: int = 0,
+    block: bool = False,
+) -> Matcher:
+    normalized = _normalize_keywords(keywords)
+
+    @Rule
+    async def endswith_rule(event: MessageEvent) -> bool:
+        return event.raw_message.endswith(normalized)
+
+    return on_message(endswith_rule & rule, priority, block)
+
+
+def on_fullmatch(
+    keywords: str | Sequence[str],
+    rule: Rule = empty_rule,
+    priority: int = 0,
+    block: bool = False,
+) -> Matcher:
+    normalized = _normalize_keywords(keywords)
+
+    @Rule
+    async def fullmatch_rule(event: MessageEvent) -> bool:
+        return event.raw_message in normalized
+
+    return on_message(fullmatch_rule & rule, priority, block)
+
+
+def _normalize_keywords(keywords: str | Sequence[str]) -> tuple[str, ...]:
+    normalized = (keywords,) if isinstance(keywords, str) else tuple(keywords)
+    if not normalized or any(not isinstance(keyword, str) or not keyword for keyword in normalized):
+        raise ValueError("matcher keywords must contain non-empty strings")
+    return normalized
+
+
+__all__ = [
+    "MatcherDispatchResult",
+    "add_matcher",
+    "get_matchers",
+    "on_endswith",
+    "on_fullmatch",
+    "on_keywords",
+    "on_message",
+    "on_startswith",
+]

--- a/src/liteyuki/session/rule.py
+++ b/src/liteyuki/session/rule.py
@@ -1,0 +1,64 @@
+"""Composable LiteyukiBot v6-compatible matcher rules."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+
+from liteyuki.bot import get_config
+
+from .event import MessageEvent
+
+type RuleHandlerFunc = Callable[[MessageEvent], bool | Awaitable[bool]]
+
+
+class Rule:
+    def __init__(self, handler: RuleHandlerFunc) -> None:
+        if not callable(handler):
+            raise TypeError("rule handler must be callable")
+        self.handler = handler
+
+    def __or__(self, other: Rule) -> Rule:
+        async def combined_handler(event: MessageEvent) -> bool:
+            return await self(event) or await other(event)
+
+        return Rule(combined_handler)
+
+    def __and__(self, other: Rule) -> Rule:
+        async def combined_handler(event: MessageEvent) -> bool:
+            return await self(event) and await other(event)
+
+        return Rule(combined_handler)
+
+    def __invert__(self) -> Rule:
+        async def inverted_handler(event: MessageEvent) -> bool:
+            return not await self(event)
+
+        return Rule(inverted_handler)
+
+    async def __call__(self, event: MessageEvent) -> bool:
+        result = self.handler(event)
+        if inspect.isawaitable(result):
+            result = await result
+        return bool(result)
+
+
+@Rule
+async def empty_rule(_event: MessageEvent) -> bool:
+    return True
+
+
+@Rule
+async def is_su_rule(event: MessageEvent) -> bool:
+    configured: object = get_config("liteyuki.superusers", ())
+    superusers: tuple[str, ...]
+    if isinstance(configured, (str, int)):
+        superusers = (str(configured),)
+    elif isinstance(configured, Sequence):
+        superusers = tuple(str(value) for value in configured)
+    else:
+        superusers = ()
+    return str(event.user_id) in superusers
+
+
+__all__ = ["Rule", "RuleHandlerFunc", "empty_rule", "is_su_rule"]

--- a/tests/test_legacy_session_v6.py
+++ b/tests/test_legacy_session_v6.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from liteyuki.bot import _install_runtime, _reset_runtime
+from liteyuki.session import (
+    Matcher,
+    MessageEvent,
+    Rule,
+    Scene,
+    SceneType,
+    Session,
+    User,
+    is_su_rule,
+    on_endswith,
+    on_fullmatch,
+    on_keywords,
+    on_message,
+    on_startswith,
+)
+from liteyuki.session.message import BaseSeg, Image, Text
+from liteyuki.session.on import _dispatch_matchers, _reset_matchers, get_matchers
+from liteyukibot.exceptions import LegacyUnsupportedError
+
+
+@pytest.fixture(autouse=True)
+def reset_matchers() -> Iterator[None]:
+    _reset_matchers()
+    yield
+    _reset_matchers()
+
+
+def _event(raw_message: str = "hello", *, user_id: str = "user") -> MessageEvent:
+    return MessageEvent(
+        bot_id="bot",
+        message=raw_message,
+        message_type="message",
+        raw_message=raw_message,
+        session_id="conversation",
+        user_id=user_id,
+        session_type="group",
+        data={"source": "fixture"},
+    )
+
+
+def test_message_event_preserves_attributes_and_ordered_replies() -> None:
+    event = _event()
+
+    event.reply("first")
+    event.reply({"type": "text", "data": {"text": "second"}})
+
+    assert event.bot_id == "bot"
+    assert event.raw_message == "hello"
+    assert event.data == {"source": "fixture"}
+    assert event.replies == (
+        "first",
+        {"type": "text", "data": {"text": "second"}},
+    )
+    assert event._drain_replies() == (
+        "first",
+        {"type": "text", "data": {"text": "second"}},
+    )
+    assert not event.replies
+
+
+def test_message_event_rejects_receive_channel() -> None:
+    with pytest.raises(LegacyUnsupportedError, match="Channel semantics"):
+        MessageEvent(
+            bot_id="bot",
+            message="hello",
+            message_type="message",
+            raw_message="hello",
+            session_id="conversation",
+            user_id="user",
+            session_type="group",
+            receive_channel=object(),
+        )
+
+
+def test_matcher_registration_validates_inputs_and_can_reset() -> None:
+    on_message()
+    assert len(get_matchers()) == 1
+    _reset_matchers()
+    assert get_matchers() == ()
+
+    with pytest.raises(ValueError, match="non-empty strings"):
+        on_keywords([])
+    with pytest.raises(ValueError, match="non-negative"):
+        on_message(priority=-1)
+
+
+@pytest.mark.asyncio
+async def test_rule_supports_sync_async_and_short_circuit_composition() -> None:
+    calls: list[str] = []
+
+    @Rule
+    def sync_false(_event: MessageEvent) -> bool:
+        calls.append("sync")
+        return False
+
+    @Rule
+    async def async_true(_event: MessageEvent) -> bool:
+        calls.append("async")
+        return True
+
+    event = _event()
+    assert await (sync_false & async_true)(event) is False
+    assert calls == ["sync"]
+    calls.clear()
+    assert await (sync_false | async_true)(event) is True
+    assert calls == ["sync", "async"]
+    assert await (~async_true)(event) is False
+
+
+@pytest.mark.asyncio
+async def test_superuser_rule_reads_runtime_configuration() -> None:
+    _install_runtime({"liteyuki.superusers": ["admin"]}, lambda _name: None)
+    try:
+        assert await is_su_rule(_event(user_id="admin")) is True
+        assert await is_su_rule(_event(user_id="user")) is False
+    finally:
+        _reset_runtime()
+
+
+@pytest.mark.asyncio
+async def test_matcher_priority_and_match_aware_blocking() -> None:
+    calls: list[str] = []
+
+    @on_fullmatch("never", priority=20, block=True).handle()
+    async def unmatched(_event: MessageEvent) -> None:
+        calls.append("unmatched")
+
+    @on_message(priority=10, block=True).handle()
+    async def first(_event: MessageEvent) -> None:
+        calls.append("first")
+
+    @on_message(priority=10).handle()
+    def same_priority(_event: MessageEvent) -> None:
+        calls.append("same")
+
+    @on_message(priority=5).handle()
+    async def lower(_event: MessageEvent) -> None:
+        calls.append("lower")
+
+    result = await _dispatch_matchers(_event())
+
+    assert [matcher.priority for matcher in get_matchers()] == [20, 10, 10, 5]
+    assert calls == ["first", "same"]
+    assert result.matched == 2
+    assert result.handlers_called == 2
+    assert result.blocked is True
+
+
+@pytest.mark.asyncio
+async def test_matcher_isolates_handler_failure_and_continues() -> None:
+    matcher = on_message()
+
+    @matcher.handle()
+    def broken(_event: MessageEvent) -> None:
+        raise RuntimeError("broken handler")
+
+    @matcher.handle()
+    async def working(event: MessageEvent) -> None:
+        event.reply("handled")
+
+    event = _event()
+    result = await _dispatch_matchers(event)
+
+    assert result.handlers_called == 2
+    assert len(result.failures) == 1
+    assert "broken handler" in result.failures[0]
+    assert event.replies == ("handled",)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("register", "raw_message", "matches"),
+    [
+        (lambda: on_keywords(["ell"]), "hello", True),
+        (lambda: on_startswith(["he"]), "hello", True),
+        (lambda: on_endswith(["lo"]), "hello", True),
+        (lambda: on_fullmatch(["hello"]), "hello", True),
+        (lambda: on_fullmatch(["other"]), "hello", False),
+    ],
+)
+async def test_on_predicates(
+    register: Callable[[], Matcher],
+    raw_message: str,
+    matches: bool,
+) -> None:
+    matcher = register()
+
+    assert (await matcher.run(_event(raw_message))).matched is matches
+
+
+@pytest.mark.asyncio
+async def test_representative_v6_plugin_imports_and_registers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "legacy_session_fixture"
+    (tmp_path / f"{module_name}.py").write_text(
+        """
+from liteyuki.session.event import MessageEvent
+from liteyuki.session.on import on_startswith
+
+@on_startswith(["liteecho"]).handle()
+async def echo(event: MessageEvent):
+    event.reply(event.raw_message.removeprefix("liteecho").strip())
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    try:
+        importlib.import_module(module_name)
+        event = _event("liteecho hello")
+        result = await _dispatch_matchers(event)
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert result.matched == 1
+    assert event.replies == ("hello",)
+
+
+def test_session_identity_and_basic_segments() -> None:
+    user = User(id="user")
+    private = Session(
+        self_id="bot",
+        adapter="onebot",
+        scope=SceneType.PRIVATE,
+        scene=Scene(id="user", type=SceneType.PRIVATE),
+        user=user,
+    )
+    group = Session(
+        self_id="bot",
+        adapter="onebot",
+        scope=SceneType.GROUP,
+        scene=Scene(id="group", type=SceneType.GROUP),
+        user=user,
+    )
+
+    assert private.session_id == "0:user"
+    assert private.target_id == "0:user"
+    assert group.session_id == "1:group"
+    assert group.target_id == "1:group:user"
+    assert BaseSeg(data={"value": 1}).type == "Segment"
+    assert Text(data={}, content="hello").content == "hello"
+    assert Image(data={}, url="https://example.invalid/image.png").url.endswith("image.png")

--- a/tests/test_legacy_v6.py
+++ b/tests/test_legacy_v6.py
@@ -34,10 +34,7 @@ def test_legacy_context_and_unsupported_nested_host() -> None:
         _reset_runtime()
 
 
-def test_unsupported_v6_modules_raise_migration_error() -> None:
-    with pytest.raises(LegacyUnsupportedError, match="session.Session"):
-        from liteyuki.session import Session  # noqa: F401
-
+def test_unsupported_v6_channel_raises_migration_error() -> None:
     with pytest.raises(LegacyUnsupportedError, match="comm.channel.get_channel"):
         from liteyuki.comm.channel import get_channel  # noqa: F401
 


### PR DESCRIPTION
## Summary

- restore v6 `MessageEvent`, session models, composable rules, matcher registration, and common `on_*` constructors
- preserve descending v6 priority with stable same-priority order and match-aware blocking
- collect synchronous reply intents without restoring Channel/shared-memory transport
- add ADR 0006, migration guidance, and a representative v6 plugin registration contract

## Compatibility corrections

- implement `on_startswith`, which shipped v6 plugin source imports but v6 omitted
- use typed Session scopes with stable numeric identifiers
- log and isolate handler failures instead of printing tracebacks

## Validation

- `uv run ruff check src tests scripts`
- `uv run mypy`
- `uv run pytest` (91 passed)
- `uv lock --check`
- `uv build`
- local Docker build plus `version`, `check`, and non-root user smoke tests