### PR TITLE
✨ negotiate runtime protocol v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   delivery while retaining concurrent v1 child support.
 - restored the process-local v6 session, rule, matcher, and reply-intent API
   needed by ordinary message plugins without restoring Channel semantics.
+- added negotiated runtime protocol v3 with capability-gated child-originated
+  Actions routed through the core's existing protocol-neutral Action service.
 
 ## 7.0.0a1 - 2026-08-04
 

--- a/docs/adr/0007-runtime-ipc-protocol-v3.md
+++ b/docs/adr/0007-runtime-ipc-protocol-v3.md
@@ -1,0 +1,63 @@
+# ADR 0007: Negotiate Runtime IPC Version 3 And Bidirectional Actions
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+Protocol v2 permits the core to deliver events to a compatibility runtime, but
+retains the protocol-v1 Action direction from core to child. LiteyukiBot v6
+message handlers record reply intents inside the compatibility process, so they
+need a versioned way to submit protocol-neutral Actions back to the core without
+using shared memory or overloading `event_accepted`.
+
+The existing `action` and `action_result` messages already provide correlation,
+JSON validation, and deterministic success or failure. A new message shape is
+not required, but the additional direction must not be enabled accidentally for
+older children.
+
+## Decision
+
+The supervisor accepts runtime protocol versions 1, 2, and 3. Negotiation keeps
+the exact-version rules in ADR 0005. Version 3 retains the framing,
+authentication, limits, schemas, and bidirectional Event behavior of version 2.
+It additionally changes the allowed directions of the existing Action pair:
+
+| Type | v1/v2 direction | v3 direction |
+| --- | --- | --- |
+| `action` | core -> child | either direction |
+| `action_result` | child -> core | either direction |
+
+A v3 child opts into child-to-core Actions with the exact READY capability
+`runtime.actions.send`. The same capability on a v1 or v2 connection has no
+effect. A missing capability, older protocol, unavailable core Action sink, or
+duplicate in-flight correlation identifier receives a correlated failed
+`action_result`; it does not terminate the connection.
+
+The supervisor validates direction and capability, tracks in-flight
+child-originated requests, and owns the wire response. An injected Action sink
+validates and routes the payload. Sink work runs outside the connection receive
+loop so heartbeats and later frames continue to be read. Sink exceptions are
+logged and converted to a deterministic `core action sink failed` response.
+Disconnect cancels unfinished sink tasks.
+
+`LiteyukiApp` validates the payload as the frozen `ActionEnvelope` schema and
+uses the existing `ActionService`. The Action envelope's `runtime_id` names the
+adapter runtime that owns the bot; it need not equal the compatibility runtime
+that submitted the request. Routing an Action back to its source runtime is
+rejected because synchronous self-routing would wait on the same connection and
+form a protocol loop.
+
+The serialized `ActionResult` is returned in `action_result.data`. The wire
+`ok` flag mirrors `ActionResult.success`, and a failed result also exposes its
+message through `action_result.error`.
+
+## Consequences
+
+V1 and v2 children remain valid and retain their previous Action direction.
+Protocol v3 children may receive core events under `runtime.events.receive` and
+submit Actions under `runtime.actions.send`; the capabilities are independent.
+
+This decision does not add the v6 receive loop, matcher dispatch, reply-intent
+translation, or a child-side concurrent response router. Those integrations can
+now be implemented without another core protocol or Action-routing change.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@ new, explicitly versioned decision.
 4. [Configuration precedence and error taxonomy](0004-configuration-and-error-contracts.md)
 5. [Runtime IPC v2 and bidirectional events](0005-runtime-ipc-protocol-v2.md)
 6. [v6 session compatibility](0006-v6-session-compatibility.md)
+7. [Runtime IPC v3 and bidirectional Actions](0007-runtime-ipc-protocol-v3.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -48,8 +48,12 @@ Protocol v1 covers hello/welcome, config, ready, heartbeat, child-originated
 events, actions/results, shutdown, and errors. Protocol v2 is selected by an
 exact hello/welcome version match and permits event/event-accepted pairs in
 either direction. Core-to-child delivery additionally requires the
-`runtime.events.receive` READY capability. V1 and v2 children may run together.
-Abnormal exits use bounded exponential restart; clean exits do not restart.
+`runtime.events.receive` READY capability. Protocol v3 retains bidirectional
+events and permits action/action-result pairs in either direction. A child may
+submit Actions only after declaring `runtime.actions.send`; the core validates
+them as protocol-neutral Action envelopes and routes them to the adapter runtime
+that owns the bot. V1, v2, and v3 children may run together. Abnormal exits use
+bounded exponential restart; clean exits do not restart.
 
 All built-in child hosts use one async `RuntimeClient` for environment identity,
 handshake validation, negotiated heartbeat, serialized writes, receive, and
@@ -73,8 +77,8 @@ runtime IPC, native plugins, configuration precedence, and error taxonomy.
 Changes to these surfaces require an explicit versioned decision rather than an
 unannounced compatible-looking edit.
 
-ADR 0005 adds the negotiated protocol-v2 event direction while ADR 0002 remains
-the frozen v1 contract.
+ADR 0005 adds the negotiated protocol-v2 event direction, and ADR 0007 adds the
+protocol-v3 Action direction, while ADR 0002 remains the frozen v1 contract.
 
 ## Operations
 

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -13,7 +13,7 @@ from .events import ActionEnvelope, ActionResult, EventBus, EventEnvelope
 from .http import HttpServer
 from .logging import Logger, configure_logging, get_logger, shutdown_logging
 from .plugins import PluginManager
-from .runtime import RuntimeSpec, RuntimeSupervisor
+from .runtime import ActionSinkResult, RuntimeSpec, RuntimeSupervisor
 from .services import ServiceRegistry
 
 
@@ -70,7 +70,11 @@ class LiteyukiApp:
         self.logger = logger or get_logger(component="core")
         self.state = AppState.CREATED
         self.services = ServiceRegistry()
-        self.runtimes = RuntimeSupervisor(logger=self.logger, event_sink=self._ingest_runtime_event)
+        self.runtimes = RuntimeSupervisor(
+            logger=self.logger,
+            event_sink=self._ingest_runtime_event,
+            action_sink=self._execute_runtime_action,
+        )
         self.actions = ActionService(self.runtimes)
         core = settings.core
         self.events = EventBus(
@@ -272,6 +276,28 @@ class LiteyukiApp:
             return "invalid"
         result = await self.events.publish(event)
         return "accepted" if result.status == "processed" else result.status
+
+    async def _execute_runtime_action(
+        self, source_runtime_id: str, payload: dict[str, Any]
+    ) -> ActionSinkResult:
+        try:
+            action = ActionEnvelope.model_validate(payload)
+        except ValueError as error:
+            self.logger.bind(runtime=source_runtime_id, component="runtime").warning(
+                "runtime action failed validation: {}", error
+            )
+            return ActionSinkResult(ok=False, error="invalid ActionEnvelope")
+        if action.runtime_id == source_runtime_id:
+            return ActionSinkResult(
+                ok=False,
+                error="child-originated action cannot target its source runtime",
+            )
+        result = await self.actions.execute(action)
+        return ActionSinkResult(
+            ok=result.success,
+            data=result.model_dump(mode="json"),
+            error=result.error_message,
+        )
 
     @staticmethod
     def _plugin_configs(config: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:

--- a/src/liteyukibot/runtime/__init__.py
+++ b/src/liteyukibot/runtime/__init__.py
@@ -19,7 +19,7 @@ from .protocol import (
     read_message,
     write_message,
 )
-from .supervisor import RuntimeSpec, RuntimeState, RuntimeSupervisor
+from .supervisor import ActionSinkResult, RuntimeSpec, RuntimeState, RuntimeSupervisor
 
 __all__ = [
     "MAX_FRAME_SIZE",
@@ -27,6 +27,7 @@ __all__ = [
     "SUPPORTED_PROTOCOL_VERSIONS",
     "ActionRequest",
     "ActionResponse",
+    "ActionSinkResult",
     "ConfigMessage",
     "ErrorMessage",
     "EventMessage",

--- a/src/liteyukibot/runtime/protocol.py
+++ b/src/liteyukibot/runtime/protocol.py
@@ -12,12 +12,12 @@ from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from ..exceptions import RuntimeProtocolError
 
-type ProtocolVersion = Literal[1, 2]
+type ProtocolVersion = Literal[1, 2, 3]
 type JsonScalar = str | int | float | bool | None
 type JsonValue = JsonScalar | list[JsonValue] | dict[str, JsonValue]
 
-PROTOCOL_VERSION: ProtocolVersion = 2
-SUPPORTED_PROTOCOL_VERSIONS: tuple[ProtocolVersion, ...] = (1, 2)
+PROTOCOL_VERSION: ProtocolVersion = 3
+SUPPORTED_PROTOCOL_VERSIONS: tuple[ProtocolVersion, ...] = (1, 2, 3)
 MAX_FRAME_SIZE = 8 * 1024 * 1024
 
 

--- a/src/liteyukibot/runtime/supervisor.py
+++ b/src/liteyukibot/runtime/supervisor.py
@@ -39,6 +39,16 @@ from .protocol import (
 EventSink = Callable[[str, dict[str, JsonValue]], Awaitable[str]]
 
 
+@dataclass(frozen=True, slots=True)
+class ActionSinkResult:
+    ok: bool
+    data: JsonValue = None
+    error: str | None = None
+
+
+ActionSink = Callable[[str, dict[str, JsonValue]], Awaitable[ActionSinkResult]]
+
+
 class RuntimeState(StrEnum):
     STOPPED = "stopped"
     STARTING = "starting"
@@ -91,6 +101,7 @@ class RuntimeRecord:
     output_tasks: tuple[asyncio.Task[None], ...] = ()
     pending_actions: dict[str, asyncio.Future[ActionResponse]] = field(default_factory=dict)
     pending_events: dict[str, asyncio.Future[EventAccepted]] = field(default_factory=dict)
+    inbound_actions: dict[str, asyncio.Task[None]] = field(default_factory=dict)
     protocol_version: ProtocolVersion | None = None
     capabilities: frozenset[str] = frozenset()
     send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -98,9 +109,16 @@ class RuntimeRecord:
 
 
 class RuntimeSupervisor:
-    def __init__(self, *, logger: Any, event_sink: EventSink | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        logger: Any,
+        event_sink: EventSink | None = None,
+        action_sink: ActionSink | None = None,
+    ) -> None:
         self.logger = logger
         self.event_sink = event_sink
+        self.action_sink = action_sink
         self.records: dict[str, RuntimeRecord] = {}
         self._server: asyncio.Server | None = None
         self._host = "127.0.0.1"
@@ -296,6 +314,8 @@ class RuntimeSupervisor:
             event_future = record.pending_events.pop(message.correlation_id, None)
             if event_future is not None and not event_future.done():
                 event_future.set_result(message)
+        elif isinstance(message, ActionRequest):
+            await self._accept_child_action(record, message)
         elif isinstance(message, ActionResponse):
             action_future = record.pending_actions.pop(message.correlation_id, None)
             if action_future is not None and not action_future.done():
@@ -304,6 +324,86 @@ class RuntimeSupervisor:
             self.logger.error("runtime {} error {}: {}", record.spec.id, message.code, message.message)
         else:
             self.logger.debug("ignored runtime {} message {}", record.spec.id, message.type)
+
+    async def _accept_child_action(
+        self, record: RuntimeRecord, request: ActionRequest
+    ) -> None:
+        if record.protocol_version != 3:
+            await self._reject_child_action(
+                record,
+                request,
+                "child-originated actions require runtime protocol v3",
+            )
+            return
+        if "runtime.actions.send" not in record.capabilities:
+            await self._reject_child_action(
+                record,
+                request,
+                "child runtime did not declare runtime.actions.send",
+            )
+            return
+        if self.action_sink is None:
+            await self._reject_child_action(record, request, "core action sink is unavailable")
+            return
+        if request.correlation_id in record.inbound_actions:
+            await self._reject_child_action(
+                record,
+                request,
+                f"duplicate action correlation id: {request.correlation_id}",
+            )
+            return
+
+        task = asyncio.create_task(
+            self._execute_child_action(record, request),
+            name=f"runtime-action:{record.spec.id}:{request.correlation_id}",
+        )
+        record.inbound_actions[request.correlation_id] = task
+
+    async def _execute_child_action(
+        self, record: RuntimeRecord, request: ActionRequest
+    ) -> None:
+        try:
+            assert self.action_sink is not None
+            result = await self.action_sink(record.spec.id, request.payload)
+            response = ActionResponse(
+                correlation_id=request.correlation_id,
+                ok=result.ok,
+                data=result.data,
+                error=result.error,
+            )
+        except Exception as error:
+            self.logger.error(
+                "runtime {} child action {} failed: {}",
+                record.spec.id,
+                request.correlation_id,
+                error,
+            )
+            response = ActionResponse(
+                correlation_id=request.correlation_id,
+                ok=False,
+                error="core action sink failed",
+            )
+        try:
+            await self._send(record, response)
+        except (ConnectionError, RuntimeError):
+            pass
+        finally:
+            record.inbound_actions.pop(request.correlation_id, None)
+
+    async def _reject_child_action(
+        self,
+        record: RuntimeRecord,
+        request: ActionRequest,
+        error: str,
+    ) -> None:
+        await self._send(
+            record,
+            ActionResponse(
+                correlation_id=request.correlation_id,
+                ok=False,
+                error=error,
+            ),
+        )
 
     async def execute_action(
         self,
@@ -337,8 +437,8 @@ class RuntimeSupervisor:
         record = self.records[runtime_id]
         if record.state is not RuntimeState.READY:
             raise RuntimeError(f"runtime {runtime_id} is not ready")
-        if record.protocol_version != 2:
-            raise RuntimeError(f"runtime {runtime_id} did not negotiate protocol v2")
+        if record.protocol_version not in (2, 3):
+            raise RuntimeError(f"runtime {runtime_id} did not negotiate protocol v2 or v3")
         if "runtime.events.receive" not in record.capabilities:
             raise RuntimeError(f"runtime {runtime_id} does not accept core events")
         if correlation_id in record.pending_events:
@@ -446,6 +546,12 @@ class RuntimeSupervisor:
                     ConnectionError(f"runtime {record.spec.id} disconnected")
                 )
         record.pending_events.clear()
+        inbound_actions = tuple(record.inbound_actions.values())
+        record.inbound_actions.clear()
+        for task in inbound_actions:
+            task.cancel()
+        if inbound_actions:
+            await asyncio.gather(*inbound_actions, return_exceptions=True)
         if writer is not None:
             writer.close()
             await writer.wait_closed()

--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -15,6 +15,7 @@ import pytest
 from liteyukibot.app import AppState, LiteyukiApp
 from liteyukibot.config import AppSettings, CoreSettings, HttpSettings, PluginSettings
 from liteyukibot.control import ControlError, ControlServer, request_control
+from liteyukibot.events import ActionEnvelope, ActionResult, Message, Segment, SendMessage
 from liteyukibot.exceptions import PluginError
 from liteyukibot.plugins import PluginDefinition, PluginHandle, PluginManifest
 from liteyukibot.services import ServiceKey, ServiceRequirement
@@ -38,6 +39,78 @@ class FakeLogger:
 
     def exception(self, message: str, *args: Any, **kwargs: Any) -> None:
         pass
+
+
+@pytest.mark.asyncio
+async def test_app_routes_child_action_to_distinct_adapter_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache")
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+    action = ActionEnvelope(
+        action_id="reply-1",
+        event_id="event-1",
+        runtime_id="adapter",
+        bot_id="bot-1",
+        action=SendMessage(
+            message=Message(segments=(Segment(type="text", data={"text": "hello"}),)),
+            reply_token="reply-token",
+        ),
+    )
+    observed: list[ActionEnvelope] = []
+
+    async def execute(envelope: ActionEnvelope) -> ActionResult:
+        observed.append(envelope)
+        return ActionResult(
+            action_id=envelope.action_id,
+            success=True,
+            data={"message_id": "sent-1"},
+        )
+
+    monkeypatch.setattr(app.actions, "execute", execute)
+    result = await app._execute_runtime_action(
+        "compat", action.model_dump(mode="json")
+    )
+
+    assert result.ok is True
+    assert result.data == {
+        "schema_version": 1,
+        "action_id": "reply-1",
+        "success": True,
+        "data": {"message_id": "sent-1"},
+        "error_code": None,
+        "error_message": None,
+    }
+    assert observed == [action]
+
+
+@pytest.mark.asyncio
+async def test_app_rejects_invalid_and_self_targeted_child_actions(tmp_path: Path) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache")
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+
+    invalid = await app._execute_runtime_action("compat", {"invalid": True})
+    self_target = await app._execute_runtime_action(
+        "compat",
+        ActionEnvelope(
+            action_id="reply-1",
+            runtime_id="compat",
+            bot_id="bot-1",
+            action=SendMessage(
+                message=Message(segments=(Segment(type="text", data={"text": "hello"}),)),
+                reply_token="reply-token",
+            ),
+        ).model_dump(mode="json"),
+    )
+
+    assert invalid.ok is False
+    assert invalid.error == "invalid ActionEnvelope"
+    assert self_target.ok is False
+    assert self_target.error == "child-originated action cannot target its source runtime"
 
 
 @pytest.mark.asyncio

--- a/tests/test_protocol_v7.py
+++ b/tests/test_protocol_v7.py
@@ -92,7 +92,7 @@ async def test_protocol_accepts_discriminated_ready_message() -> None:
     assert await read_message(_reader(frame)) == Ready(capabilities=("events",))
 
 
-@pytest.mark.parametrize("protocol", [1, 2])
+@pytest.mark.parametrize("protocol", [1, 2, 3])
 @pytest.mark.asyncio
 async def test_protocol_accepts_negotiated_hello_versions(protocol: int) -> None:
     payload = json.dumps(
@@ -116,7 +116,7 @@ async def test_protocol_rejects_unsupported_hello_version() -> None:
     payload = json.dumps(
         {
             "type": "hello",
-            "protocol": 3,
+            "protocol": 4,
             "runtime_id": "fixture",
             "kind": "custom",
             "token": "secret",

--- a/tests/test_runtime_client_v7.py
+++ b/tests/test_runtime_client_v7.py
@@ -8,6 +8,7 @@ import pytest
 from liteyukibot.exceptions import RuntimeProtocolError
 from liteyukibot.runtime import RuntimeClient
 from liteyukibot.runtime.protocol import (
+    PROTOCOL_VERSION,
     ConfigMessage,
     ErrorMessage,
     Heartbeat,
@@ -40,7 +41,7 @@ async def _server(handler: ServerHandler) -> tuple[asyncio.Server, int, asyncio.
     return server, port, done
 
 
-def _client(port: int, protocol_version: ProtocolVersion = 2) -> RuntimeClient:
+def _client(port: int, protocol_version: ProtocolVersion = PROTOCOL_VERSION) -> RuntimeClient:
     return RuntimeClient(
         host="127.0.0.1",
         port=port,
@@ -59,7 +60,7 @@ def test_runtime_client_rejects_unsupported_protocol_before_connecting() -> None
             runtime_id="fixture",
             kind="test",
             token="secret",
-            protocol_version=3,  # type: ignore[arg-type]
+            protocol_version=4,  # type: ignore[arg-type]
         )
 
 
@@ -95,6 +96,7 @@ async def test_runtime_client_handshake_ready_heartbeat_and_close() -> None:
         await server.wait_closed()
 
     assert isinstance(observed[0], Hello)
+    assert observed[0].protocol == 3
     assert observed[1] == Ready(capabilities=("events",))
     assert isinstance(observed[2], Heartbeat)
     assert client.connected is False
@@ -182,22 +184,25 @@ async def test_runtime_client_reports_eof_after_handshake() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runtime_client_can_negotiate_protocol_v1() -> None:
+@pytest.mark.parametrize("protocol_version", [1, 2])
+async def test_runtime_client_can_negotiate_older_protocol(
+    protocol_version: ProtocolVersion,
+) -> None:
     async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         hello = await read_message(reader)
         assert isinstance(hello, Hello)
-        assert hello.protocol == 1
-        await write_message(writer, Welcome(protocol=1))
+        assert hello.protocol == protocol_version
+        await write_message(writer, Welcome(protocol=protocol_version))
         await write_message(writer, ConfigMessage())
         assert await reader.read() == b""
         writer.close()
         await writer.wait_closed()
 
     server, port, server_done = await _server(handle)
-    client = _client(port, protocol_version=1)
+    client = _client(port, protocol_version=protocol_version)
     try:
         assert await client.connect() == {}
-        assert client.negotiated_protocol == 1
+        assert client.negotiated_protocol == protocol_version
     finally:
         await client.close()
         await server_done
@@ -210,7 +215,7 @@ async def test_runtime_client_rejects_protocol_version_mismatch() -> None:
     async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         hello = await read_message(reader)
         assert isinstance(hello, Hello)
-        assert hello.protocol == 2
+        assert hello.protocol == 3
         await write_message(writer, Welcome(protocol=1))
         assert await reader.read() == b""
         writer.close()

--- a/tests/test_runtime_v7.py
+++ b/tests/test_runtime_v7.py
@@ -11,16 +11,19 @@ import pytest
 
 from liteyukibot.runtime import RuntimeSpec, RuntimeState, RuntimeSupervisor
 from liteyukibot.runtime.protocol import (
+    ActionRequest,
+    ActionResponse,
     ConfigMessage,
     EventAccepted,
     EventMessage,
     Hello,
+    ProtocolVersion,
     Ready,
     Welcome,
     read_message,
     write_message,
 )
-from liteyukibot.runtime.supervisor import RuntimeRecord
+from liteyukibot.runtime.supervisor import ActionSinkResult, RuntimeRecord
 
 
 class FakeLogger:
@@ -137,16 +140,19 @@ async def test_runtime_rejects_bad_and_duplicate_connections() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runtime_negotiates_v1_and_v2_connections_concurrently() -> None:
+async def test_runtime_negotiates_v1_v2_and_v3_connections_concurrently() -> None:
     supervisor = RuntimeSupervisor(logger=FakeLogger())
     supervisor.add(RuntimeSpec(id="legacy", kind="custom"))
     supervisor.add(RuntimeSpec(id="modern", kind="custom"))
+    supervisor.add(RuntimeSpec(id="current", kind="custom"))
     legacy = supervisor.records["legacy"]
     modern = supervisor.records["modern"]
+    current = supervisor.records["current"]
     server = await asyncio.start_server(supervisor._accept, "127.0.0.1", 0)
     port = int(server.sockets[0].getsockname()[1])
     legacy_reader, legacy_writer = await asyncio.open_connection("127.0.0.1", port)
     modern_reader, modern_writer = await asyncio.open_connection("127.0.0.1", port)
+    current_reader, current_writer = await asyncio.open_connection("127.0.0.1", port)
     try:
         await write_message(
             legacy_writer,
@@ -163,14 +169,22 @@ async def test_runtime_negotiates_v1_and_v2_connections_concurrently() -> None:
         assert await read_message(modern_reader) == Welcome(protocol=2)
         assert isinstance(await read_message(modern_reader), ConfigMessage)
         await write_message(modern_writer, Ready(capabilities=("runtime.events.receive",)))
+        await write_message(
+            current_writer,
+            Hello(protocol=3, runtime_id="current", kind="custom", token=current.token),
+        )
+        assert await read_message(current_reader) == Welcome(protocol=3)
+        assert isinstance(await read_message(current_reader), ConfigMessage)
+        await write_message(current_writer, Ready(capabilities=("runtime.events.receive",)))
         await asyncio.wait_for(
-            asyncio.gather(legacy.ready.wait(), modern.ready.wait()),
+            asyncio.gather(legacy.ready.wait(), modern.ready.wait(), current.ready.wait()),
             timeout=1,
         )
 
         assert legacy.protocol_version == 1
         assert modern.protocol_version == 2
-        with pytest.raises(RuntimeError, match="did not negotiate protocol v2"):
+        assert current.protocol_version == 3
+        with pytest.raises(RuntimeError, match="did not negotiate protocol v2 or v3"):
             await supervisor.dispatch_event("legacy", "event-v1", {})
 
         delivery = asyncio.create_task(
@@ -186,13 +200,215 @@ async def test_runtime_negotiates_v1_and_v2_connections_concurrently() -> None:
             EventAccepted(correlation_id="event-v2", status="accepted"),
         )
         assert (await delivery).status == "accepted"
+
+        current_delivery = asyncio.create_task(
+            supervisor.dispatch_event("current", "event-v3", {"message": "hello"})
+        )
+        current_outbound = await asyncio.wait_for(read_message(current_reader), timeout=1)
+        assert current_outbound == EventMessage(
+            correlation_id="event-v3",
+            payload={"message": "hello"},
+        )
+        await write_message(
+            current_writer,
+            EventAccepted(correlation_id="event-v3", status="accepted"),
+        )
+        assert (await current_delivery).status == "accepted"
     finally:
         legacy_writer.close()
         modern_writer.close()
+        current_writer.close()
         await legacy_writer.wait_closed()
         await modern_writer.wait_closed()
+        await current_writer.wait_closed()
         server.close()
         await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_v3_child_action_reaches_core_sink_with_correlation() -> None:
+    observed: list[tuple[str, dict[str, Any]]] = []
+
+    async def execute_child_action(
+        runtime_id: str, payload: dict[str, Any]
+    ) -> ActionSinkResult:
+        observed.append((runtime_id, payload))
+        return ActionSinkResult(ok=True, data={"message_id": "sent-1"})
+
+    supervisor = RuntimeSupervisor(
+        logger=FakeLogger(),
+        action_sink=execute_child_action,
+    )
+    supervisor.add(RuntimeSpec(id="compat", kind="custom"))
+    record = supervisor.records["compat"]
+    server = await asyncio.start_server(supervisor._accept, "127.0.0.1", 0)
+    port = int(server.sockets[0].getsockname()[1])
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    try:
+        await write_message(
+            writer,
+            Hello(protocol=3, runtime_id="compat", kind="custom", token=record.token),
+        )
+        assert await read_message(reader) == Welcome(protocol=3)
+        assert isinstance(await read_message(reader), ConfigMessage)
+        await write_message(writer, Ready(capabilities=("runtime.actions.send",)))
+        await asyncio.wait_for(record.ready.wait(), timeout=1)
+
+        await write_message(
+            writer,
+            ActionRequest(correlation_id="reply-1", payload={"type": "send_message"}),
+        )
+        response = await asyncio.wait_for(read_message(reader), timeout=1)
+
+        assert response == ActionResponse(
+            correlation_id="reply-1",
+            ok=True,
+            data={"message_id": "sent-1"},
+        )
+        assert observed == [("compat", {"type": "send_message"})]
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("protocol_version", "capabilities", "with_sink", "error"),
+    [
+        (1, frozenset({"runtime.actions.send"}), True, "require runtime protocol v3"),
+        (2, frozenset({"runtime.actions.send"}), True, "require runtime protocol v3"),
+        (3, frozenset(), True, "did not declare runtime.actions.send"),
+        (3, frozenset({"runtime.actions.send"}), False, "action sink is unavailable"),
+    ],
+)
+async def test_child_action_requires_v3_capability_and_sink(
+    monkeypatch: pytest.MonkeyPatch,
+    protocol_version: ProtocolVersion,
+    capabilities: frozenset[str],
+    with_sink: bool,
+    error: str,
+) -> None:
+    async def sink(_runtime_id: str, _payload: dict[str, Any]) -> ActionSinkResult:
+        return ActionSinkResult(ok=True)
+
+    supervisor = RuntimeSupervisor(
+        logger=FakeLogger(),
+        action_sink=sink if with_sink else None,
+    )
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="compat", kind="custom"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+        protocol_version=protocol_version,
+        capabilities=capabilities,
+    )
+    responses: list[ActionResponse] = []
+
+    async def capture(_record: RuntimeRecord, message: Any) -> None:
+        assert isinstance(message, ActionResponse)
+        responses.append(message)
+
+    monkeypatch.setattr(supervisor, "_send", capture)
+    await supervisor._handle_message(
+        record,
+        ActionRequest(correlation_id="reply-1", payload={}),
+    )
+
+    assert len(responses) == 1
+    assert responses[0].correlation_id == "reply-1"
+    assert responses[0].ok is False
+    assert responses[0].error is not None and error in responses[0].error
+    assert record.inbound_actions == {}
+
+
+@pytest.mark.asyncio
+async def test_child_action_sink_failure_is_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail(_runtime_id: str, _payload: dict[str, Any]) -> ActionSinkResult:
+        raise RuntimeError("adapter failed")
+
+    supervisor = RuntimeSupervisor(logger=FakeLogger(), action_sink=fail)
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="compat", kind="custom"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+        protocol_version=3,
+        capabilities=frozenset({"runtime.actions.send"}),
+    )
+    response_seen = asyncio.Event()
+    responses: list[ActionResponse] = []
+
+    async def capture(_record: RuntimeRecord, message: Any) -> None:
+        assert isinstance(message, ActionResponse)
+        responses.append(message)
+        response_seen.set()
+
+    monkeypatch.setattr(supervisor, "_send", capture)
+    await supervisor._handle_message(
+        record,
+        ActionRequest(correlation_id="reply-1", payload={}),
+    )
+    await asyncio.wait_for(response_seen.wait(), timeout=1)
+
+    assert responses == [
+        ActionResponse(
+            correlation_id="reply-1",
+            ok=False,
+            error="core action sink failed",
+        )
+    ]
+    assert record.inbound_actions == {}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_child_action_is_rejected_and_disconnect_cancels_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def hold(_runtime_id: str, _payload: dict[str, Any]) -> ActionSinkResult:
+        started.set()
+        try:
+            await asyncio.Future()
+            return ActionSinkResult(ok=True)
+        finally:
+            cancelled.set()
+
+    supervisor = RuntimeSupervisor(logger=FakeLogger(), action_sink=hold)
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="compat", kind="custom"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+        protocol_version=3,
+        capabilities=frozenset({"runtime.actions.send"}),
+    )
+    responses: list[ActionResponse] = []
+
+    async def capture(_record: RuntimeRecord, message: Any) -> None:
+        assert isinstance(message, ActionResponse)
+        responses.append(message)
+
+    monkeypatch.setattr(supervisor, "_send", capture)
+    request = ActionRequest(correlation_id="duplicate", payload={})
+    await supervisor._handle_message(record, request)
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await supervisor._handle_message(record, request)
+
+    assert len(responses) == 1
+    assert responses[0].ok is False
+    assert responses[0].error == "duplicate action correlation id: duplicate"
+
+    await supervisor._disconnect(record)
+
+    assert cancelled.is_set()
+    assert record.inbound_actions == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- negotiate runtime protocol v3 while retaining exact v1/v2 support and v2 event delivery
- allow capability-gated child-originated Actions through an asynchronous supervisor sink
- validate and route child Action envelopes through the existing application Action service
- document the contract in ADR 0007 and expand protocol, supervisor, application, and cleanup coverage

## Contract
- child Actions require protocol v3 and `runtime.actions.send`
- older protocol, missing capability/sink, duplicate correlation, and sink failures receive correlated failures
- self-targeted child Actions are rejected to prevent same-connection routing loops
- disconnect cancels unfinished inbound Action tasks

## Validation
- `uv run ruff check src tests scripts`
- `uv run mypy`
- `uv run pytest -q` (102 passed)
- `uv build`
- `docker build -t liteyukibot:v7-protocol-v3-local .`
- Docker `version`, config `check`, and non-root identity smoke tests