### PR TITLE
✨ integrate v6 message runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   needed by ordinary message plugins without restoring Channel semantics.
 - added negotiated runtime protocol v3 with capability-gated child-originated
   Actions routed through the core's existing protocol-neutral Action service.
+- connected the v6 message matcher runtime to EventBus delivery and translated
+  ordered reply intents into correlated protocol-v3 SendMessage Actions.
 
 ## 7.0.0a1 - 2026-08-04
 

--- a/docs/adr/0008-v6-runtime-event-integration.md
+++ b/docs/adr/0008-v6-runtime-event-integration.md
@@ -1,0 +1,82 @@
+# ADR 0008: Integrate v6 Message Plugins Through Protocol v3
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+ADR 0006 restores the process-local v6 message event, rule, matcher, and reply
+intent APIs. ADRs 0005 and 0007 provide capability-gated core-to-child Events
+and child-to-core Actions. The remaining compatibility boundary is the mapping
+between those protocol-neutral envelopes and the supported v6 plugin API.
+
+That mapping must preserve EventBus ordering, continue reading the child socket
+while plugin handlers wait for Action results, and avoid reviving v6 Channel or
+shared-memory transport.
+
+## Decision
+
+`LiteyukiApp` registers one internal EventBus handler when at least one enabled
+`kind = "v6"` runtime is configured. It forwards message-bearing
+`EventEnvelope` schema-v1 payloads to every v6 runtime concurrently through
+`RuntimeSupervisor.dispatch_event()`. Events without a message remain valid but
+are not forwarded by the application bridge. A runtime rejection or delivery
+failure is reported as an isolated EventBus handler failure after every target
+has been attempted.
+
+The v6 child declares both `runtime.events.receive` and
+`runtime.actions.send`. It keeps one receive pump and processes accepted Events
+in bounded concurrent tasks. `max_concurrent_events` is a positive runtime
+option with a default of 32. Exhausted capacity returns `overloaded`; an invalid
+Event envelope returns `invalid`. A validated Event is acknowledged as
+`accepted` only after matcher dispatch and every recorded reply attempt finish.
+
+`RuntimeClient.execute_action()` owns child-side Action correlation and timeout
+cleanup, but never reads the socket. The host remains the only caller of
+`receive()`. That receive pump completes matching Action futures internally and
+continues until it obtains a non-matching message for the host. Unmatched or
+late Action results are exposed to the host. Duplicate in-flight correlation
+identifiers are rejected before sending. EOF, protocol failure, and close fail
+all pending Actions. The v6 reply timeout is the positive runtime option
+`action_timeout_seconds`, defaulting to 10 seconds.
+
+The `EventEnvelope` to `MessageEvent` mapping is:
+
+| `MessageEvent` field | Source |
+| --- | --- |
+| `bot_id` | `EventEnvelope.bot_id` |
+| `message_type` | `EventEnvelope.type` |
+| `message` | JSON copies of normalized message segments |
+| `raw_message` | normalized message plain text |
+| `session_id` | conversation ID |
+| `session_type` | conversation type |
+| `user_id` | actor ID, or an empty string when absent |
+| `data` | a deep JSON copy of `EventEnvelope.raw` |
+
+No synthetic `Session` is attached. The standalone session models remain import
+and construction compatibility because `thread` and `unknown` conversations
+cannot be represented losslessly by the current `SceneType`.
+
+Each reply intent becomes a separate `ActionEnvelope(SendMessage)` targeting
+the source adapter runtime and bot. It preserves the source event ID,
+conversation, and reply token. String replies become a portable text segment.
+Mappings with a supported v7 segment type and object `data` are validated as
+that segment. Unknown legacy types are retained inside an `adapter` segment as
+`{"type": legacy_type, "data": legacy_data}`. Invalid mappings are logged and
+skipped.
+
+Reply Actions execute sequentially in recorded order. A matcher failure,
+invalid reply, timeout, or rejected Action is logged and isolated from later
+replies; it does not reclassify a validated Event as invalid. Shutdown, restart,
+or disconnect cancels unfinished Event tasks and pending Actions.
+
+## Consequences
+
+Ordinary v6 message plugins using the supported matcher and `event.reply()` API
+now run end to end inside the supervised compatibility process. Core and child
+exchange only frozen JSON schemas; no Python framework or adapter object crosses
+the process boundary.
+
+Notices, requests, proactive v6 sends, adapter objects, Channel, shared memory,
+the v6 process manager, hot reload, dependency installation, and arbitrary
+message object emulation remain unsupported.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@ new, explicitly versioned decision.
 5. [Runtime IPC v2 and bidirectional events](0005-runtime-ipc-protocol-v2.md)
 6. [v6 session compatibility](0006-v6-session-compatibility.md)
 7. [Runtime IPC v3 and bidirectional Actions](0007-runtime-ipc-protocol-v3.md)
+8. [v6 runtime Event and reply integration](0008-v6-runtime-event-integration.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -57,8 +57,10 @@ bounded exponential restart; clean exits do not restart.
 
 All built-in child hosts use one async `RuntimeClient` for environment identity,
 handshake validation, negotiated heartbeat, serialized writes, receive, and
-idempotent connection cleanup. Framework hosts retain ownership of event and
-action dispatch; the supervisor remains the sole restart-policy owner.
+idempotent connection cleanup. Its child-side Action correlation retains one
+host-owned receive pump and fails pending requests on timeout, protocol failure,
+or close. Framework hosts retain ownership of event and action dispatch; the
+supervisor remains the sole restart-policy owner.
 
 NoneBot is hosted through its official initialization, driver, plugin-loading,
 event-preprocessor, `Bot.send`, and `Bot.call_api` surfaces. Event forwarding is
@@ -66,8 +68,10 @@ observational and never suppresses NoneBot matcher dispatch.
 
 The v6 compatibility namespace restores process-local session models, rules,
 matcher registration, deterministic priority dispatch, and ordered reply
-intents. It does not restore Channel or shared-memory object transport; runtime
-event delivery and reply Action transport remain explicit protocol boundaries.
+intents. The core EventBus forwards normalized messages to configured v6 child
+runtimes; they map Events into the shared matcher registry and translate ordered
+reply intents into protocol-neutral SendMessage Actions. It does not restore
+Channel, shared-memory object transport, notices, requests, or adapter objects.
 
 ## Versioned Contracts
 
@@ -78,7 +82,8 @@ Changes to these surfaces require an explicit versioned decision rather than an
 unannounced compatible-looking edit.
 
 ADR 0005 adds the negotiated protocol-v2 event direction, and ADR 0007 adds the
-protocol-v3 Action direction, while ADR 0002 remains the frozen v1 contract.
+protocol-v3 Action direction. ADR 0008 defines their v6 message-plugin mapping,
+while ADR 0002 remains the frozen v1 contract.
 
 ## Operations
 

--- a/docs/migration-v6.md
+++ b/docs/migration-v6.md
@@ -12,7 +12,9 @@ namespace is a compatibility package; new plugins should import `liteyukibot`.
 - before/after startup and shutdown lifecycle decorators;
 - process restart requests for the compatibility runtime;
 - `MessageEvent`, session identity models, composable rules, matcher decorators,
-  stable priority dispatch, and synchronous reply-intent collection.
+  stable priority dispatch, and synchronous reply-intent collection;
+- supervised delivery of normalized message events and ordered string or
+  mapping replies through protocol-neutral Actions.
 
 ## Unsupported
 
@@ -27,9 +29,14 @@ gap remains visible. Compatibility also requires every plugin dependency to
 support CPython 3.14.
 
 Session matchers are process-local. `event.reply()` records an ordered reply
-intent; it does not send through a v6 Channel. Runtime event delivery and reply
-Action translation are introduced separately so plugins cannot observe a
-partially emulated cross-process object.
+intent; it does not send through a v6 Channel. The v6 runtime translates each
+intent after matcher dispatch and waits for its Action result before submitting
+the next reply. Handler, reply validation, and Action failures are isolated from
+later replies.
+
+Only events with normalized message content are forwarded by the application
+bridge. `MessageEvent.data` is a deep JSON copy of the adapter event's raw
+payload; no adapter object or synthetic `Session` crosses into the plugin.
 
 Supported matcher constructors are `on_message`, `on_keywords`,
 `on_startswith`, `on_endswith`, and `on_fullmatch`. Larger numeric priorities
@@ -45,6 +52,8 @@ kind = "v6"
 [runtimes.legacy.options]
 plugins = ["my_legacy_plugin"]
 plugin_dirs = ["plugins"]
+max_concurrent_events = 32
+action_timeout_seconds = 10.0
 
 [runtimes.legacy.options.config]
 nickname = ["Liteyuki"]

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -110,6 +110,7 @@ class LiteyukiApp:
         self._runtimes_started = False
         self._control_started = False
         self._http_started = False
+        v6_runtime_ids: list[str] = []
 
         for runtime_id, runtime in settings.runtimes.items():
             if not runtime.enabled:
@@ -129,6 +130,14 @@ class LiteyukiApp:
                     heartbeat_interval=runtime.heartbeat_interval_seconds,
                     stale_after=runtime.stale_after_seconds,
                 )
+            )
+            if runtime.kind == "v6":
+                v6_runtime_ids.append(runtime_id)
+        self._v6_runtime_ids = tuple(v6_runtime_ids)
+        if self._v6_runtime_ids:
+            self.events.subscribe(
+                self._forward_v6_event,
+                name="runtime.v6",
             )
 
     async def start(self) -> None:
@@ -298,6 +307,48 @@ class LiteyukiApp:
             data=result.model_dump(mode="json"),
             error=result.error_message,
         )
+
+    async def _forward_v6_event(self, event: EventEnvelope) -> None:
+        if event.message is None:
+            return
+        runtime_ids = tuple(
+            runtime_id
+            for runtime_id in self._v6_runtime_ids
+            if runtime_id != event.runtime_id
+        )
+        if not runtime_ids:
+            return
+        outcomes = await asyncio.gather(
+            *(self._deliver_v6_event(runtime_id, event) for runtime_id in runtime_ids),
+            return_exceptions=True,
+        )
+        fatal = next(
+            (
+                outcome
+                for outcome in outcomes
+                if isinstance(outcome, BaseException) and not isinstance(outcome, Exception)
+            ),
+            None,
+        )
+        if fatal is not None:
+            raise fatal
+        errors = [outcome for outcome in outcomes if isinstance(outcome, Exception)]
+        if len(errors) == 1:
+            raise errors[0]
+        if len(errors) > 1:
+            raise ExceptionGroup("v6 runtime event delivery failed", errors)
+
+    async def _deliver_v6_event(self, runtime_id: str, event: EventEnvelope) -> None:
+        result = await self.runtimes.dispatch_event(
+            runtime_id,
+            event.id,
+            event.model_dump(mode="json"),
+        )
+        if result.status != "accepted":
+            detail = f": {result.detail}" if result.detail else ""
+            raise RuntimeError(
+                f"v6 runtime {runtime_id} rejected event {event.id} as {result.status}{detail}"
+            )
 
     @staticmethod
     def _plugin_configs(config: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:

--- a/src/liteyukibot/runtime/client.py
+++ b/src/liteyukibot/runtime/client.py
@@ -6,11 +6,14 @@ import asyncio
 import os
 import time
 from collections.abc import Mapping, Sequence
+from typing import Any
 
 from ..exceptions import RuntimeProtocolError
 from .protocol import (
     PROTOCOL_VERSION,
     SUPPORTED_PROTOCOL_VERSIONS,
+    ActionRequest,
+    ActionResponse,
     ConfigMessage,
     Heartbeat,
     Hello,
@@ -19,6 +22,7 @@ from .protocol import (
     Ready,
     Welcome,
     WireMessage,
+    json_mapping,
     read_message,
     write_message,
 )
@@ -51,8 +55,11 @@ class RuntimeClient:
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._send_lock = asyncio.Lock()
+        self._receive_lock = asyncio.Lock()
         self._heartbeat_interval: float | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
+        self._capabilities: frozenset[str] = frozenset()
+        self._pending_actions: dict[str, asyncio.Future[ActionResponse]] = {}
         self._closed = False
 
     @classmethod
@@ -112,7 +119,9 @@ class RuntimeClient:
     async def ready(self, capabilities: Sequence[str] = ()) -> None:
         if self._heartbeat_task is not None:
             raise RuntimeError("runtime client is already ready")
-        await self.send(Ready(capabilities=tuple(capabilities)))
+        normalized = tuple(capabilities)
+        await self.send(Ready(capabilities=normalized))
+        self._capabilities = frozenset(normalized)
         assert self._heartbeat_interval is not None
         self._heartbeat_task = asyncio.create_task(
             self._heartbeat(self._heartbeat_interval),
@@ -122,7 +131,51 @@ class RuntimeClient:
     async def receive(self) -> WireMessage:
         if self._reader is None or self._closed:
             raise ConnectionError("runtime client is not connected")
-        return await read_message(self._reader)
+        if self._receive_lock.locked():
+            raise RuntimeError("runtime client already has an active receiver")
+        async with self._receive_lock:
+            while True:
+                try:
+                    message = await read_message(self._reader)
+                except (EOFError, ConnectionError, RuntimeProtocolError) as error:
+                    self._fail_pending_actions(error)
+                    raise
+                if isinstance(message, ActionResponse):
+                    future = self._pending_actions.pop(message.correlation_id, None)
+                    if future is not None and not future.done():
+                        future.set_result(message)
+                        continue
+                return message
+
+    async def execute_action(
+        self,
+        correlation_id: str,
+        payload: Mapping[str, Any],
+        timeout_seconds: float = 30.0,
+    ) -> ActionResponse:
+        if timeout_seconds <= 0:
+            raise ValueError("runtime action timeout must be positive")
+        if self.negotiated_protocol != 3:
+            raise RuntimeError("child-originated actions require runtime protocol v3")
+        if self._heartbeat_task is None:
+            raise RuntimeError("runtime client is not ready")
+        if "runtime.actions.send" not in self._capabilities:
+            raise RuntimeError("runtime client did not declare runtime.actions.send")
+        if correlation_id in self._pending_actions:
+            raise ValueError(f"duplicate action correlation id: {correlation_id}")
+
+        request = ActionRequest(
+            correlation_id=correlation_id,
+            payload=json_mapping(payload),
+        )
+        future: asyncio.Future[ActionResponse] = asyncio.get_running_loop().create_future()
+        self._pending_actions[correlation_id] = future
+        try:
+            await self.send(request)
+            async with asyncio.timeout(timeout_seconds):
+                return await future
+        finally:
+            self._pending_actions.pop(correlation_id, None)
 
     async def send(self, message: WireMessage) -> None:
         writer = self._writer
@@ -137,7 +190,9 @@ class RuntimeClient:
         if self._closed:
             return
         self._closed = True
+        self._fail_pending_actions(ConnectionError("runtime client closed"))
         heartbeat, self._heartbeat_task = self._heartbeat_task, None
+        self._capabilities = frozenset()
         if heartbeat is not None:
             heartbeat.cancel()
             await asyncio.gather(heartbeat, return_exceptions=True)
@@ -148,6 +203,12 @@ class RuntimeClient:
             if writer is not None:
                 writer.close()
                 await writer.wait_closed()
+
+    def _fail_pending_actions(self, error: BaseException) -> None:
+        for future in self._pending_actions.values():
+            if not future.done():
+                future.set_exception(error)
+        self._pending_actions.clear()
 
     async def _heartbeat(self, interval: float) -> None:
         while True:

--- a/src/liteyukibot/runtime/v6.py
+++ b/src/liteyukibot/runtime/v6.py
@@ -11,9 +11,153 @@ from yukilog import configure_child_runtime, get_logger
 
 from liteyuki.bot import _emit_lifecycle, _install_runtime, _reset_runtime
 from liteyuki.plugin import load_plugin, load_plugins
+from liteyuki.session.on import _dispatch_matchers
 
+from ..events import EventEnvelope
 from .client import RuntimeClient
-from .protocol import ActionRequest, ActionResponse, Shutdown
+from .protocol import (
+    ActionRequest,
+    ActionResponse,
+    EventAccepted,
+    EventMessage,
+    Shutdown,
+)
+from .v6_events import reply_to_action, to_legacy_message_event
+
+
+class _V6RuntimeHost:
+    def __init__(
+        self,
+        client: RuntimeClient,
+        logger: Any,
+        *,
+        max_concurrent_events: int,
+        action_timeout_seconds: float,
+    ) -> None:
+        self.client = client
+        self.logger = logger
+        self.max_concurrent_events = max_concurrent_events
+        self.action_timeout_seconds = action_timeout_seconds
+        self._event_tasks: set[asyncio.Task[None]] = set()
+
+    async def serve(self, restart_requested: asyncio.Event) -> str:
+        while True:
+            incoming = asyncio.create_task(self.client.receive(), name="v6-runtime-receive")
+            restart = asyncio.create_task(
+                restart_requested.wait(),
+                name="v6-runtime-restart",
+            )
+            done, pending = await asyncio.wait(
+                (incoming, restart),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            if restart in done and restart.result():
+                return "restart"
+
+            message = incoming.result()
+            if isinstance(message, Shutdown):
+                return "shutdown"
+            if isinstance(message, ActionRequest):
+                await self.client.send(
+                    ActionResponse(
+                        correlation_id=message.correlation_id,
+                        ok=False,
+                        error="v6 compatibility plugins do not expose a protocol adapter",
+                    )
+                )
+            elif isinstance(message, EventMessage):
+                await self._accept_event(message)
+            elif isinstance(message, ActionResponse):
+                self.logger.warning(
+                    "ignored unmatched v6 Action response {}",
+                    message.correlation_id,
+                )
+
+    async def close(self) -> None:
+        tasks = tuple(self._event_tasks)
+        self._event_tasks.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _accept_event(self, message: EventMessage) -> None:
+        if len(self._event_tasks) >= self.max_concurrent_events:
+            await self.client.send(
+                EventAccepted(
+                    correlation_id=message.correlation_id,
+                    status="overloaded",
+                    detail="v6 runtime event capacity is exhausted",
+                )
+            )
+            return
+        task = asyncio.create_task(
+            self._process_event(message),
+            name=f"v6-event:{message.correlation_id}",
+        )
+        self._event_tasks.add(task)
+        task.add_done_callback(self._event_finished)
+
+    def _event_finished(self, task: asyncio.Task[None]) -> None:
+        self._event_tasks.discard(task)
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            self.logger.error("v6 event task failed: {}", error)
+
+    async def _process_event(self, message: EventMessage) -> None:
+        try:
+            envelope = EventEnvelope.model_validate(message.payload)
+        except ValueError as error:
+            self.logger.warning("v6 runtime rejected invalid EventEnvelope: {}", error)
+            await self.client.send(
+                EventAccepted(
+                    correlation_id=message.correlation_id,
+                    status="invalid",
+                    detail="invalid EventEnvelope",
+                )
+            )
+            return
+
+        event = to_legacy_message_event(envelope)
+        if event is not None:
+            try:
+                result = await _dispatch_matchers(event)
+                if result.failures:
+                    self.logger.warning(
+                        "v6 event {} completed with {} matcher failure(s)",
+                        envelope.id,
+                        len(result.failures),
+                    )
+            except Exception as error:
+                self.logger.exception("v6 matcher dispatch failed for {}: {}", envelope.id, error)
+            for reply in event._drain_replies():
+                try:
+                    action = reply_to_action(reply, envelope)
+                    response = await self.client.execute_action(
+                        action.action_id,
+                        action.model_dump(mode="json"),
+                        timeout_seconds=self.action_timeout_seconds,
+                    )
+                    if not response.ok:
+                        self.logger.warning(
+                            "v6 reply Action {} failed: {}",
+                            action.action_id,
+                            response.error or "runtime rejected the Action",
+                        )
+                except Exception as error:
+                    self.logger.exception("v6 reply failed for event {}: {}", envelope.id, error)
+
+        await self.client.send(
+            EventAccepted(
+                correlation_id=message.correlation_id,
+                status="accepted",
+            )
+        )
 
 
 async def run() -> None:
@@ -23,6 +167,7 @@ async def run() -> None:
     client = RuntimeClient.from_environment("v6")
     runtime_installed = False
     restarting = False
+    host: _V6RuntimeHost | None = None
     try:
         options = await client.connect()
         legacy_config = _mapping_option(options, "config")
@@ -39,36 +184,35 @@ async def run() -> None:
         await _emit_lifecycle("after_start")
         if int(os.environ.get("LITEYUKI_RUNTIME_RESTART_COUNT", "0")) > 0:
             await _emit_lifecycle("after_restart")
-        await client.ready(("v6.plugins", "v6.lifecycle"))
-
-        while True:
-            incoming = asyncio.create_task(client.receive(), name="v6-runtime-receive")
-            restart = asyncio.create_task(restart_requested.wait(), name="v6-runtime-restart")
-            done, pending = await asyncio.wait(
-                (incoming, restart),
-                return_when=asyncio.FIRST_COMPLETED,
+        host = _V6RuntimeHost(
+            client,
+            logger,
+            max_concurrent_events=_positive_int_option(options, "max_concurrent_events", 32),
+            action_timeout_seconds=_positive_float_option(
+                options,
+                "action_timeout_seconds",
+                10.0,
+            ),
+        )
+        await client.ready(
+            (
+                "v6.plugins",
+                "v6.lifecycle",
+                "runtime.events.receive",
+                "runtime.actions.send",
             )
-            for task in pending:
-                task.cancel()
-            await asyncio.gather(*pending, return_exceptions=True)
-            if restart in done and restart.result():
-                restarting = True
-                await _emit_lifecycle("before_process_restart", runtime_id)
-                break
-            message = incoming.result()
-            if isinstance(message, Shutdown):
-                await _emit_lifecycle("before_process_shutdown", runtime_id)
-                break
-            if isinstance(message, ActionRequest):
-                await client.send(
-                    ActionResponse(
-                        correlation_id=message.correlation_id,
-                        ok=False,
-                        error="v6 compatibility plugins do not expose a protocol adapter",
-                    )
-                )
+        )
+        outcome = await host.serve(restart_requested)
+        await host.close()
+        if outcome == "restart":
+            restarting = True
+            await _emit_lifecycle("before_process_restart", runtime_id)
+        else:
+            await _emit_lifecycle("before_process_shutdown", runtime_id)
         await _emit_lifecycle("after_shutdown")
     finally:
+        if host is not None:
+            await host.close()
         if runtime_installed:
             _reset_runtime()
         await client.close()
@@ -100,6 +244,20 @@ def _load_configured_plugins(options: Mapping[str, Any]) -> None:
         raise RuntimeError(f"failed to load v6 plugins: {', '.join(failed)}")
     if directories and not loaded_from_directories:
         raise RuntimeError("configured v6 plugin directories did not load any plugins")
+
+
+def _positive_int_option(options: Mapping[str, Any], key: str, default: int) -> int:
+    value = options.get(key, default)
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"v6 runtime option {key!r} must be a positive integer")
+    return value
+
+
+def _positive_float_option(options: Mapping[str, Any], key: str, default: float) -> float:
+    value = options.get(key, default)
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"v6 runtime option {key!r} must be a positive number")
+    return float(value)
 
 
 __all__ = ["run"]

--- a/src/liteyukibot/runtime/v6_events.py
+++ b/src/liteyukibot/runtime/v6_events.py
@@ -1,0 +1,84 @@
+"""Pure event and reply translation for the v6 compatibility runtime."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from liteyuki.session import MessageEvent, ReplyPayload
+
+from ..events import ActionEnvelope, EventEnvelope, Message, Segment, SendMessage
+
+_PORTABLE_SEGMENT_TYPES = frozenset({"text", "media", "mention", "reply", "adapter"})
+
+
+def to_legacy_message_event(envelope: EventEnvelope) -> MessageEvent | None:
+    if envelope.message is None:
+        return None
+    dumped = envelope.model_dump(mode="json")
+    message = dumped["message"]
+    assert isinstance(message, dict)
+    segments = message["segments"]
+    assert isinstance(segments, list)
+    raw = dumped["raw"]
+    assert isinstance(raw, dict)
+    return MessageEvent(
+        bot_id=envelope.bot_id,
+        message=segments,
+        message_type=envelope.type,
+        raw_message=envelope.message.plain_text,
+        session_id=envelope.conversation.id,
+        user_id=envelope.actor.id if envelope.actor is not None else "",
+        session_type=envelope.conversation.type,
+        data=raw,
+    )
+
+
+def reply_to_action(reply: ReplyPayload, envelope: EventEnvelope) -> ActionEnvelope:
+    message = _reply_message(reply)
+    return ActionEnvelope(
+        event_id=envelope.id,
+        runtime_id=envelope.runtime_id,
+        bot_id=envelope.bot_id,
+        action=SendMessage(
+            message=message,
+            conversation=envelope.conversation,
+            reply_token=envelope.reply_token,
+        ),
+    )
+
+
+def _reply_message(reply: ReplyPayload) -> Message:
+    if isinstance(reply, str):
+        return Message(segments=(Segment(type="text", data={"text": reply}),))
+
+    segment_type = reply.get("type")
+    data = reply.get("data")
+    if not isinstance(segment_type, str) or not segment_type:
+        raise ValueError("v6 mapping replies require a non-empty string type")
+    if not isinstance(data, Mapping):
+        raise ValueError("v6 mapping replies require an object data field")
+    normalized_data = _json_mapping(data)
+    if segment_type in _PORTABLE_SEGMENT_TYPES:
+        segment = Segment.model_validate({"type": segment_type, "data": normalized_data})
+    else:
+        segment = Segment(
+            type="adapter",
+            data={"type": segment_type, "data": normalized_data},
+        )
+    return Message(segments=(segment,))
+
+
+def _json_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): _json_value(item) for key, item in value.items()}
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _json_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    return value
+
+
+__all__ = ["reply_to_action", "to_legacy_message_event"]

--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -13,11 +13,26 @@ from urllib.request import urlopen
 import pytest
 
 from liteyukibot.app import AppState, LiteyukiApp
-from liteyukibot.config import AppSettings, CoreSettings, HttpSettings, PluginSettings
+from liteyukibot.config import (
+    AppSettings,
+    CoreSettings,
+    HttpSettings,
+    PluginSettings,
+    RuntimeSettings,
+)
 from liteyukibot.control import ControlError, ControlServer, request_control
-from liteyukibot.events import ActionEnvelope, ActionResult, Message, Segment, SendMessage
+from liteyukibot.events import (
+    ActionEnvelope,
+    ActionResult,
+    ConversationRef,
+    EventEnvelope,
+    Message,
+    Segment,
+    SendMessage,
+)
 from liteyukibot.exceptions import PluginError
 from liteyukibot.plugins import PluginDefinition, PluginHandle, PluginManifest
+from liteyukibot.runtime.protocol import EventAccepted
 from liteyukibot.services import ServiceKey, ServiceRequirement
 
 
@@ -111,6 +126,126 @@ async def test_app_rejects_invalid_and_self_targeted_child_actions(tmp_path: Pat
     assert invalid.error == "invalid ActionEnvelope"
     assert self_target.ok is False
     assert self_target.error == "child-originated action cannot target its source runtime"
+
+
+def _message_event() -> EventEnvelope:
+    return EventEnvelope(
+        id="event-1",
+        runtime_id="adapter",
+        adapter="onebot-v11",
+        bot_id="bot-1",
+        type="message.group.normal",
+        conversation=ConversationRef(id="group-1", type="group"),
+        message=Message(segments=(Segment(type="text", data={"text": "hello"}),)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_app_event_bus_fans_out_messages_to_v6_runtimes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
+        runtimes={
+            "legacy-a": RuntimeSettings(kind="v6"),
+            "legacy-b": RuntimeSettings(kind="v6"),
+            "nonebot": RuntimeSettings(kind="nonebot"),
+        },
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+    started: set[str] = set()
+    both_started = asyncio.Event()
+
+    async def dispatch(
+        runtime_id: str,
+        correlation_id: str,
+        payload: dict[str, Any],
+        timeout_seconds: float = 30.0,
+    ) -> EventAccepted:
+        assert correlation_id == "event-1"
+        event = EventEnvelope.model_validate(payload)
+        assert event.id == "event-1"
+        assert event.message is not None and event.message.plain_text == "hello"
+        assert timeout_seconds == 30.0
+        started.add(runtime_id)
+        if len(started) == 2:
+            both_started.set()
+        await asyncio.wait_for(both_started.wait(), timeout=1)
+        return EventAccepted(correlation_id=correlation_id, status="accepted")
+
+    monkeypatch.setattr(app.runtimes, "dispatch_event", dispatch)
+    try:
+        result = await app.events.publish(_message_event())
+    finally:
+        await app.events.aclose()
+
+    assert started == {"legacy-a", "legacy-b"}
+    assert result.handlers_called == 1
+    assert result.failures == ()
+
+
+@pytest.mark.asyncio
+async def test_app_v6_bridge_filters_non_messages_and_isolates_rejection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
+        runtimes={
+            "legacy-a": RuntimeSettings(kind="v6"),
+            "legacy-b": RuntimeSettings(kind="v6"),
+        },
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+    delivered: list[str] = []
+
+    async def dispatch(
+        runtime_id: str,
+        correlation_id: str,
+        _payload: dict[str, Any],
+        timeout_seconds: float = 30.0,
+    ) -> EventAccepted:
+        assert timeout_seconds == 30.0
+        delivered.append(runtime_id)
+        if runtime_id == "legacy-a":
+            return EventAccepted(
+                correlation_id=correlation_id,
+                status="invalid",
+                detail="fixture rejection",
+            )
+        return EventAccepted(correlation_id=correlation_id, status="accepted")
+
+    monkeypatch.setattr(app.runtimes, "dispatch_event", dispatch)
+    no_message_payload = _message_event().model_dump(mode="json")
+    no_message_payload["message"] = None
+    try:
+        ignored = await app.events.publish(EventEnvelope.model_validate(no_message_payload))
+        rejected = await app.events.publish(_message_event())
+    finally:
+        await app.events.aclose()
+
+    assert ignored.failures == ()
+    assert delivered == ["legacy-a", "legacy-b"]
+    assert len(rejected.failures) == 1
+    assert rejected.failures[0].handler == "runtime.v6"
+    assert "fixture rejection" in rejected.failures[0].message
+
+
+@pytest.mark.asyncio
+async def test_app_without_v6_runtime_does_not_register_bridge(tmp_path: Path) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
+        runtimes={
+            "nonebot": RuntimeSettings(kind="nonebot"),
+            "disabled-legacy": RuntimeSettings(kind="v6", enabled=False),
+        },
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+    try:
+        result = await app.events.publish(_message_event())
+    finally:
+        await app.events.aclose()
+
+    assert result.handlers_called == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_legacy_v6.py
+++ b/tests/test_legacy_v6.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from liteyuki import LiteyukiBot, get_bot, get_config
 from liteyuki.bot import _emit_lifecycle, _install_runtime, _reset_runtime
+from liteyukibot.events import (
+    ActionEnvelope,
+    ActorRef,
+    ConversationRef,
+    EventEnvelope,
+    Message,
+    Segment,
+    SendMessage,
+)
 from liteyukibot.exceptions import LegacyUnsupportedError
-from liteyukibot.runtime import RuntimeSpec, RuntimeSupervisor
+from liteyukibot.runtime import ActionSinkResult, RuntimeSpec, RuntimeSupervisor
 
 from .test_runtime_v7 import FakeLogger
 
@@ -77,3 +87,97 @@ async def after_shutdown():
     assert (tmp_path / "started.txt").read_text(encoding="utf-8") == "started"
     await supervisor.stop()
     assert (tmp_path / "stopped.txt").read_text(encoding="utf-8") == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_v6_runtime_dispatches_matchers_and_returns_ordered_reply_actions(
+    tmp_path: Path,
+) -> None:
+    plugin = tmp_path / "legacy_echo_fixture.py"
+    plugin.write_text(
+        """
+from liteyuki.session.event import MessageEvent
+from liteyuki.session.on import on_startswith
+
+@on_startswith("liteecho").handle()
+async def echo(event: MessageEvent):
+    event.reply(event.raw_message.removeprefix("liteecho").strip())
+    event.reply({"type": "image", "data": {"url": "https://example.invalid/reply.png"}})
+""".lstrip(),
+        encoding="utf-8",
+    )
+    actions: list[ActionEnvelope] = []
+
+    async def execute_action(
+        source_runtime_id: str,
+        payload: dict[str, Any],
+    ) -> ActionSinkResult:
+        assert source_runtime_id == "legacy"
+        action = ActionEnvelope.model_validate(payload)
+        actions.append(action)
+        if len(actions) == 1:
+            return ActionSinkResult(ok=False, error="fixture failure")
+        return ActionSinkResult(ok=True, data={"message_id": "sent-2"})
+
+    supervisor = RuntimeSupervisor(
+        logger=FakeLogger(),
+        action_sink=execute_action,
+    )
+    supervisor.add(
+        RuntimeSpec(
+            id="legacy",
+            kind="v6",
+            options={"plugins": ["legacy_echo_fixture"]},
+            working_directory=tmp_path,
+            ready_timeout=5,
+            heartbeat_interval=0.05,
+            stale_after=1,
+        )
+    )
+    envelope = EventEnvelope(
+        id="event-1",
+        runtime_id="adapter",
+        adapter="onebot-v11",
+        bot_id="bot-1",
+        type="message.group.normal",
+        conversation=ConversationRef(id="group-1", type="group"),
+        actor=ActorRef(id="user-1"),
+        message=Message(
+            segments=(Segment(type="text", data={"text": "liteecho hello"}),)
+        ),
+        reply_token="reply-token",
+        raw={"message_id": 42},
+    )
+
+    await supervisor.start()
+    try:
+        record = supervisor.records["legacy"]
+        assert "runtime.events.receive" in record.capabilities
+        assert "runtime.actions.send" in record.capabilities
+
+        accepted = await supervisor.dispatch_event(
+            "legacy",
+            "delivery-1",
+            envelope.model_dump(mode="json"),
+            timeout_seconds=5,
+        )
+    finally:
+        await supervisor.stop()
+
+    assert accepted.status == "accepted"
+    assert len(actions) == 2
+    first, second = actions
+    assert first.event_id == second.event_id == "event-1"
+    assert first.runtime_id == second.runtime_id == "adapter"
+    assert first.bot_id == second.bot_id == "bot-1"
+    assert isinstance(first.action, SendMessage)
+    assert isinstance(second.action, SendMessage)
+    assert first.action.message.plain_text == "hello"
+    assert first.action.reply_token == second.action.reply_token == "reply-token"
+    assert second.action.message.segments[0] == Segment(
+        type="adapter",
+        data={
+            "type": "image",
+            "data": {"url": "https://example.invalid/reply.png"},
+        },
+    )

--- a/tests/test_runtime_client_v7.py
+++ b/tests/test_runtime_client_v7.py
@@ -9,12 +9,16 @@ from liteyukibot.exceptions import RuntimeProtocolError
 from liteyukibot.runtime import RuntimeClient
 from liteyukibot.runtime.protocol import (
     PROTOCOL_VERSION,
+    ActionRequest,
+    ActionResponse,
     ConfigMessage,
     ErrorMessage,
+    EventMessage,
     Heartbeat,
     Hello,
     ProtocolVersion,
     Ready,
+    Shutdown,
     Welcome,
     read_message,
     write_message,
@@ -229,5 +233,257 @@ async def test_runtime_client_rejects_protocol_version_mismatch() -> None:
         await server_done
     finally:
         await client.close()
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_routes_action_response_without_stealing_messages() -> None:
+    expected_response = ActionResponse(
+        correlation_id="action-1",
+        ok=True,
+        data={"message_id": "sent-1"},
+    )
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, Welcome())
+        await write_message(writer, ConfigMessage())
+        assert isinstance(await read_message(reader), Ready)
+        request = await read_message(reader)
+        assert request == ActionRequest(correlation_id="action-1", payload={"value": 1})
+        await write_message(
+            writer,
+            EventMessage(correlation_id="event-1", payload={"value": 2}),
+        )
+        await write_message(writer, expected_response)
+        await write_message(writer, Shutdown())
+        assert await reader.read() == b""
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        await client.connect()
+        await client.ready(("runtime.actions.send",))
+        action = asyncio.create_task(client.execute_action("action-1", {"value": 1}))
+
+        assert await client.receive() == EventMessage(
+            correlation_id="event-1",
+            payload={"value": 2},
+        )
+        assert await client.receive() == Shutdown()
+        assert await action == expected_response
+    finally:
+        await client.close()
+        await server_done
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_correlates_concurrent_actions_returned_in_reverse() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, Welcome())
+        await write_message(writer, ConfigMessage())
+        assert isinstance(await read_message(reader), Ready)
+        requests = [await read_message(reader), await read_message(reader)]
+        assert all(isinstance(request, ActionRequest) for request in requests)
+        for request in reversed(requests):
+            assert isinstance(request, ActionRequest)
+            await write_message(
+                writer,
+                ActionResponse(
+                    correlation_id=request.correlation_id,
+                    ok=True,
+                    data=request.payload,
+                ),
+            )
+        await write_message(writer, Shutdown())
+        assert await reader.read() == b""
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        await client.connect()
+        await client.ready(("runtime.actions.send",))
+        first = asyncio.create_task(client.execute_action("first", {"order": 1}))
+        second = asyncio.create_task(client.execute_action("second", {"order": 2}))
+
+        assert await client.receive() == Shutdown()
+        assert (await first).data == {"order": 1}
+        assert (await second).data == {"order": 2}
+    finally:
+        await client.close()
+        await server_done
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_action_duplicate_timeout_and_late_response() -> None:
+    request_seen = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, Welcome())
+        await write_message(writer, ConfigMessage())
+        assert isinstance(await read_message(reader), Ready)
+        request = await read_message(reader)
+        assert isinstance(request, ActionRequest)
+        request_seen.set()
+        await release_response.wait()
+        await write_message(
+            writer,
+            ActionResponse(correlation_id=request.correlation_id, ok=True),
+        )
+        await write_message(writer, Shutdown())
+        assert await reader.read() == b""
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        await client.connect()
+        await client.ready(("runtime.actions.send",))
+        action = asyncio.create_task(
+            client.execute_action("late", {}, timeout_seconds=0.01)
+        )
+        await request_seen.wait()
+        with pytest.raises(ValueError, match="duplicate action correlation id"):
+            await client.execute_action("late", {})
+        with pytest.raises(TimeoutError):
+            await action
+
+        release_response.set()
+        assert await client.receive() == ActionResponse(correlation_id="late", ok=True)
+        assert await client.receive() == Shutdown()
+    finally:
+        await client.close()
+        await server_done
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_close_fails_pending_action() -> None:
+    request_seen = asyncio.Event()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, Welcome())
+        await write_message(writer, ConfigMessage())
+        assert isinstance(await read_message(reader), Ready)
+        assert isinstance(await read_message(reader), ActionRequest)
+        request_seen.set()
+        assert await reader.read() == b""
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    await client.connect()
+    await client.ready(("runtime.actions.send",))
+    action = asyncio.create_task(client.execute_action("pending", {}))
+    await request_seen.wait()
+
+    await client.close()
+
+    with pytest.raises(ConnectionError, match="runtime client closed"):
+        await action
+    await server_done
+    server.close()
+    await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_rejects_child_action_on_protocol_v2() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, Welcome(protocol=2))
+        await write_message(writer, ConfigMessage())
+        assert isinstance(await read_message(reader), Ready)
+        assert await reader.read() == b""
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port, protocol_version=2)
+    try:
+        await client.connect()
+        await client.ready(("runtime.actions.send",))
+        with pytest.raises(RuntimeError, match="require runtime protocol v3"):
+            await client.execute_action("unsupported", {})
+    finally:
+        await client.close()
+        await server_done
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_eof_fails_receive_and_pending_action() -> None:
+    request_seen = asyncio.Event()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, Welcome())
+        await write_message(writer, ConfigMessage())
+        assert isinstance(await read_message(reader), Ready)
+        assert isinstance(await read_message(reader), ActionRequest)
+        request_seen.set()
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        await client.connect()
+        await client.ready(("runtime.actions.send",))
+        action = asyncio.create_task(client.execute_action("pending", {}))
+        await request_seen.wait()
+
+        with pytest.raises(EOFError, match="connection closed"):
+            await client.receive()
+        with pytest.raises(EOFError, match="connection closed"):
+            await action
+    finally:
+        await client.close()
+        await server_done
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_action_requires_ready_capability_and_positive_timeout() -> None:
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        assert isinstance(await read_message(reader), Hello)
+        await write_message(writer, Welcome())
+        await write_message(writer, ConfigMessage())
+        assert isinstance(await read_message(reader), Ready)
+        assert await reader.read() == b""
+        writer.close()
+        await writer.wait_closed()
+
+    server, port, server_done = await _server(handle)
+    client = _client(port)
+    try:
+        await client.connect()
+        with pytest.raises(RuntimeError, match="not ready"):
+            await client.execute_action("not-ready", {})
+        await client.ready(())
+        with pytest.raises(RuntimeError, match="did not declare runtime.actions.send"):
+            await client.execute_action("missing-capability", {})
+        with pytest.raises(ValueError, match="timeout must be positive"):
+            await client.execute_action("invalid-timeout", {}, timeout_seconds=0)
+    finally:
+        await client.close()
+        await server_done
         server.close()
         await server.wait_closed()

--- a/tests/test_v6_runtime_bridge.py
+++ b/tests/test_v6_runtime_bridge.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from typing import Any, cast
+
+import pytest
+
+from liteyuki.session import MessageEvent, on_message
+from liteyuki.session.on import _reset_matchers
+from liteyukibot.events import (
+    ActorRef,
+    ConversationRef,
+    EventEnvelope,
+    Message,
+    Segment,
+    SendMessage,
+)
+from liteyukibot.runtime import RuntimeClient
+from liteyukibot.runtime.protocol import ActionResponse, EventAccepted, EventMessage
+from liteyukibot.runtime.v6 import _V6RuntimeHost
+from liteyukibot.runtime.v6_events import reply_to_action, to_legacy_message_event
+
+from .test_runtime_v7 import FakeLogger
+
+
+@pytest.fixture(autouse=True)
+def reset_matchers() -> Iterator[None]:
+    _reset_matchers()
+    yield
+    _reset_matchers()
+
+
+def _envelope(*, message: Message | None = None, actor: ActorRef | None = None) -> EventEnvelope:
+    return EventEnvelope(
+        id="event-1",
+        runtime_id="adapter",
+        adapter="onebot-v11",
+        bot_id="bot-1",
+        type="message.group.normal",
+        conversation=ConversationRef(id="group-1", type="group"),
+        actor=actor if actor is not None else ActorRef(id="user-1"),
+        message=message
+        if message is not None
+        else Message(
+            segments=(
+                Segment(type="text", data={"text": "hello"}),
+                Segment(type="mention", data={"user_id": "bot-1"}),
+            )
+        ),
+        reply_token="reply-token",
+        raw={"nested": {"value": 1}},
+    )
+
+
+def test_event_envelope_maps_to_legacy_message_event_with_deep_json_copy() -> None:
+    envelope = _envelope()
+
+    event = to_legacy_message_event(envelope)
+
+    assert event is not None
+    assert event.bot_id == "bot-1"
+    assert event.message_type == "message.group.normal"
+    assert event.message == [
+        {"type": "text", "data": {"text": "hello"}},
+        {"type": "mention", "data": {"user_id": "bot-1"}},
+    ]
+    assert event.raw_message == "hello"
+    assert event.session_id == "group-1"
+    assert event.session_type == "group"
+    assert event.user_id == "user-1"
+    assert event.data == {"nested": {"value": 1}}
+
+    nested = cast(dict[str, Any], event.data["nested"])
+    nested["value"] = 2
+    assert envelope.model_dump(mode="json")["raw"] == {"nested": {"value": 1}}
+
+
+def test_event_mapping_handles_missing_actor_and_message() -> None:
+    without_actor = _envelope(actor=ActorRef(id="temporary"))
+    payload = without_actor.model_dump(mode="json")
+    payload["actor"] = None
+    event = to_legacy_message_event(EventEnvelope.model_validate(payload))
+    no_message_payload = without_actor.model_dump(mode="json")
+    no_message_payload["message"] = None
+
+    assert event is not None
+    assert event.user_id == ""
+    assert to_legacy_message_event(EventEnvelope.model_validate(no_message_payload)) is None
+
+
+def test_reply_intents_translate_to_ordered_protocol_neutral_actions() -> None:
+    envelope = _envelope()
+
+    text = reply_to_action("hello", envelope)
+    mention = reply_to_action(
+        {"type": "mention", "data": {"user_id": "user-2"}},
+        envelope,
+    )
+    image = reply_to_action(
+        {"type": "image", "data": {"url": "https://example.invalid/image.png"}},
+        envelope,
+    )
+
+    assert len({text.action_id, mention.action_id, image.action_id}) == 3
+    for action in (text, mention, image):
+        assert action.event_id == "event-1"
+        assert action.runtime_id == "adapter"
+        assert action.bot_id == "bot-1"
+        assert isinstance(action.action, SendMessage)
+        assert action.action.conversation == envelope.conversation
+        assert action.action.reply_token == "reply-token"
+    assert isinstance(text.action, SendMessage)
+    assert isinstance(mention.action, SendMessage)
+    assert isinstance(image.action, SendMessage)
+    assert text.action.message.plain_text == "hello"
+    assert mention.action.message.segments[0] == Segment(
+        type="mention",
+        data={"user_id": "user-2"},
+    )
+    assert image.action.message.segments[0] == Segment(
+        type="adapter",
+        data={
+            "type": "image",
+            "data": {"url": "https://example.invalid/image.png"},
+        },
+    )
+
+    with pytest.raises(ValueError, match="non-empty string type"):
+        reply_to_action({"data": {}}, envelope)
+    with pytest.raises(ValueError, match="object data field"):
+        reply_to_action({"type": "text", "data": "invalid"}, envelope)
+
+
+class _FakeClient:
+    def __init__(self, responses: list[ActionResponse] | None = None) -> None:
+        self.sent: list[object] = []
+        self.actions: list[tuple[str, dict[str, Any]]] = []
+        self.responses = list(responses or [])
+
+    async def send(self, message: object) -> None:
+        self.sent.append(message)
+
+    async def execute_action(
+        self,
+        correlation_id: str,
+        payload: dict[str, Any],
+        timeout_seconds: float = 30.0,
+    ) -> ActionResponse:
+        self.actions.append((correlation_id, payload))
+        return self.responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_v6_host_preserves_reply_order_and_isolates_action_failure() -> None:
+    matcher = on_message()
+
+    @matcher.handle()
+    async def reply(event: MessageEvent) -> None:
+        event.reply("first")
+        event.reply({"type": "text", "data": {"text": "second"}})
+
+    client = _FakeClient(
+        [
+            ActionResponse(correlation_id="ignored", ok=False, error="failed"),
+            ActionResponse(correlation_id="ignored", ok=True),
+        ]
+    )
+    host = _V6RuntimeHost(
+        cast(RuntimeClient, client),
+        FakeLogger(),
+        max_concurrent_events=2,
+        action_timeout_seconds=1,
+    )
+
+    await host._process_event(
+        EventMessage(
+            correlation_id="delivery-1",
+            payload=_envelope().model_dump(mode="json"),
+        )
+    )
+
+    assert len(client.actions) == 2
+    actions = [payload for _correlation_id, payload in client.actions]
+    assert actions[0]["action"]["message"]["segments"][0]["data"]["text"] == "first"
+    assert actions[1]["action"]["message"]["segments"][0]["data"]["text"] == "second"
+    assert client.sent == [EventAccepted(correlation_id="delivery-1", status="accepted")]
+
+
+@pytest.mark.asyncio
+async def test_v6_host_accepts_non_message_and_rejects_malformed_event() -> None:
+    calls = 0
+
+    @on_message().handle()
+    async def observe(_event: MessageEvent) -> None:
+        nonlocal calls
+        calls += 1
+
+    client = _FakeClient()
+    host = _V6RuntimeHost(
+        cast(RuntimeClient, client),
+        FakeLogger(),
+        max_concurrent_events=1,
+        action_timeout_seconds=1,
+    )
+    payload = _envelope().model_dump(mode="json")
+    payload["message"] = None
+
+    await host._process_event(EventMessage(correlation_id="notice", payload=payload))
+    await host._process_event(EventMessage(correlation_id="invalid", payload={"invalid": True}))
+
+    assert calls == 0
+    assert client.sent == [
+        EventAccepted(correlation_id="notice", status="accepted"),
+        EventAccepted(
+            correlation_id="invalid",
+            status="invalid",
+            detail="invalid EventEnvelope",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v6_host_rejects_event_when_capacity_is_exhausted() -> None:
+    client = _FakeClient()
+    host = _V6RuntimeHost(
+        cast(RuntimeClient, client),
+        FakeLogger(),
+        max_concurrent_events=1,
+        action_timeout_seconds=1,
+    )
+    release = asyncio.Event()
+    pending = asyncio.create_task(release.wait())
+    host._event_tasks.add(cast(asyncio.Task[None], pending))
+
+    await host._accept_event(
+        EventMessage(
+            correlation_id="overloaded",
+            payload=_envelope().model_dump(mode="json"),
+        )
+    )
+    await host.close()
+
+    assert client.sent == [
+        EventAccepted(
+            correlation_id="overloaded",
+            status="overloaded",
+            detail="v6 runtime event capacity is exhausted",
+        )
+    ]


### PR DESCRIPTION
## Summary
- forward normalized message events from the core EventBus to enabled v6 runtimes
- dispatch the shared v6 matcher registry and translate ordered reply intents into protocol-v3 SendMessage Actions
- add child-side Action correlation to RuntimeClient without introducing a second socket reader
- bound v6 event concurrency and isolate malformed events, matcher failures, invalid replies, Action failures, timeouts, restart, and shutdown cleanup
- document the contract in ADR 0008 and update the v6 migration boundary

## Compatibility contract
- v6 advertises `runtime.events.receive` and `runtime.actions.send`
- EventEnvelope fields map to the existing MessageEvent without synthetic Session or adapter objects
- string replies become text segments; unknown legacy segment types are preserved inside adapter segments
- replies execute sequentially and EventAccepted follows the final reply attempt
- Channel, shared memory, notices/requests, proactive sends, hot reload, and runtime dependency installation remain unsupported

## Validation
- `uv run ruff check src tests scripts`
- `uv run mypy`
- `uv run pytest -q` (119 passed)
- `uv build`
- real supervised v6 subprocess with `on_startswith` and ordered reply Actions
- Docker build plus `version`, config `check`, and non-root identity smoke tests