### PR TITLE
✨ Bridge NoneBot adapter contracts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,5 +77,7 @@ jobs:
         working-directory: LiteyukiBot
         run: |
           uv python install 3.14
-          uv sync --locked --extra nonebot
-          uv run --extra nonebot pytest tests/test_runtime_v7.py::test_nonebot_runtime_loads_an_existing_plugin
+          uv sync --locked --extra nonebot --extra onebot --extra satori
+          uv run --extra nonebot --extra onebot --extra satori pytest \
+            tests/test_runtime_v7.py::test_nonebot_runtime_loads_an_existing_plugin \
+            tests/test_nonebot_adapters_v7.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   Actions routed through the core's existing protocol-neutral Action service.
 - connected the v6 message matcher runtime to EventBus delivery and translated
   ordered reply intents into correlated protocol-v3 SendMessage Actions.
+- added structured OneBot v11/v12 and Satori event/message translation with
+  exact reply routing, supported proactive sends, and strict JSON Action results.
 
 ## 7.0.0a1 - 2026-08-04
 

--- a/docs/adr/0009-nonebot-adapter-contracts.md
+++ b/docs/adr/0009-nonebot-adapter-contracts.md
@@ -1,0 +1,105 @@
+# ADR 0009: Define The NoneBot Adapter Boundary
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+The NoneBot child host already loads adapters and observes events, but its
+generic bridge flattened messages to plain text and used adapter session IDs as
+conversation keys. That loses media and mention semantics, and OneBot group
+session IDs include the actor, which incorrectly splits EventBus ordering for
+one group across users.
+
+ADR 0008 now sends structured v6 replies back as schema-v1 `SendMessage`
+Actions. The NoneBot boundary must translate those portable Actions into real
+adapter Messages while keeping NoneBot and all adapter packages optional.
+
+## Decision
+
+The NoneBot child owns adapter-specific translation. The core continues to see
+only the frozen schema-v1 `EventEnvelope`, `Message`, `Segment`, and Action
+models. Adapter modules are loaded lazily inside the child and are never
+imported by core modules.
+
+The first explicit contracts are the versions selected by the locked optional
+dependencies: OneBot v11 and v12 from `nonebot-adapter-onebot` 2.4.x, and
+Satori from `nonebot-adapter-satori` 1.3.x. Their stable envelope adapter IDs
+are `onebot-v11`, `onebot-v12`, and `satori`; NoneBot display names are not wire
+identifiers.
+
+Source event names remain in `EventEnvelope.type`. No common notice/request
+taxonomy is claimed in this version. Adapter Pydantic JSON output is retained
+in `raw`, and source timestamps become aware UTC values. The child uses the
+adapter bot registration ID unchanged so Actions can resolve through
+`nonebot.get_bot()`.
+
+Conversation routing is defined independently of adapter composite session
+IDs:
+
+| Source context | Conversation |
+| --- | --- |
+| OneBot private | user ID / `private` |
+| OneBot group | group ID / `group` |
+| OneBot v12 channel | channel ID / `channel`, parent guild ID |
+| Satori direct channel | channel ID / `private` |
+| Satori public channel | channel ID / `channel`, parent channel or guild ID |
+
+Other contextual events use a group, private, or synthetic bot conversation
+only when the source data supports it. Actor display names prefer contextual
+member or group names. Only message-bearing events receive an opaque reply
+token and enter the bounded reply cache.
+
+Message normalization reads `original_message` when available because adapter
+preprocessing may remove a quote, bot mention, or nickname from the matcher
+message. Segment mappings are:
+
+| Portable type | Meaning |
+| --- | --- |
+| `text` | `text`, plus JSON-safe Satori style ranges |
+| `mention` | `user_id`, `role_id`, or `scope = all|here` |
+| `reply` | `message_id`, with optional normalized children |
+| `media` | `media_type`, portable URL when available, and required native fields |
+| `adapter` | stable adapter ID, native type/data, and optional children |
+
+Unknown native segments use `adapter` rather than being stringified or
+discarded. Outbound adapter segments must target the selected adapter. The
+adapter-less `{type, data}` form created by the v6 compatibility bridge remains
+valid as a same-target legacy escape hatch. Malformed segments and media that
+cannot be represented by the target adapter fail deterministically.
+
+A reply-token `SendMessage` resolves the exact cached bot/event and calls
+`Bot.send(event, native_message)`. An invalid token or bot/adapter mismatch
+does not fall back to conversation routing. A visual quote is represented only
+by an explicit `reply` segment.
+
+Proactive routing supports only unambiguous schema-v1 conversations:
+
+- OneBot v11 private/group calls `send_private_msg` or `send_group_msg`;
+- OneBot v12 private/group/channel calls its unified `send_message` API;
+- Satori private/channel treats the conversation ID as a channel ID and calls
+  `Bot.send_message`.
+
+Creating a Satori direct channel from a user ID, unsupported conversation
+types, uploads that require bytes or paths, and other adapter-only operations
+remain explicit `CallApi` workflows or require a future versioned Action.
+`CallApi` names and JSON parameters pass through without a Liteyuki allowlist.
+
+Action results recursively convert Pydantic models, datetimes, enums, mappings,
+and sequences into strict JSON. Non-string object keys, arbitrary objects, NaN,
+and infinity are rejected instead of being hidden by `str()` conversion.
+
+## Consequences
+
+OneBot and Satori message events can traverse the portable EventBus and v6
+compatibility bridge and return structured native replies without sharing
+adapter objects across processes. Group FIFO identity is stable across actors,
+and unknown adapter segments remain available through an explicit escape hatch.
+
+The default kernel dependency set is unchanged. Adapter contract tests run in
+a dedicated CI job that installs all three explicit extras; the normal
+three-platform quality matrix continues to prove the minimal installation.
+
+This record does not promise a portable notice/request taxonomy, arbitrary
+cross-adapter media conversion, automatic file upload, user-ID-based Satori
+direct-message creation, or support for every future adapter version.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ new, explicitly versioned decision.
 6. [v6 session compatibility](0006-v6-session-compatibility.md)
 7. [Runtime IPC v3 and bidirectional Actions](0007-runtime-ipc-protocol-v3.md)
 8. [v6 runtime Event and reply integration](0008-v6-runtime-event-integration.md)
+9. [NoneBot OneBot and Satori adapter contracts](0009-nonebot-adapter-contracts.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -64,7 +64,11 @@ supervisor remains the sole restart-policy owner.
 
 NoneBot is hosted through its official initialization, driver, plugin-loading,
 event-preprocessor, `Bot.send`, and `Bot.call_api` surfaces. Event forwarding is
-observational and never suppresses NoneBot matcher dispatch.
+observational and never suppresses NoneBot matcher dispatch. The child lazily
+loads OneBot v11/v12 and Satori codecs, maps their conversation identity and
+structured messages into frozen core envelopes, and reconstructs native
+messages for replies and supported proactive routes. Adapter packages remain
+optional and adapter objects never cross the runtime boundary.
 
 The v6 compatibility namespace restores process-local session models, rules,
 matcher registration, deterministic priority dispatch, and ordered reply
@@ -83,7 +87,8 @@ unannounced compatible-looking edit.
 
 ADR 0005 adds the negotiated protocol-v2 event direction, and ADR 0007 adds the
 protocol-v3 Action direction. ADR 0008 defines their v6 message-plugin mapping,
-while ADR 0002 remains the frozen v1 contract.
+and ADR 0009 defines the NoneBot OneBot/Satori adapter boundary, while ADR 0002
+remains the frozen v1 contract.
 
 ## Operations
 

--- a/src/liteyukibot/runtime/nonebot.py
+++ b/src/liteyukibot/runtime/nonebot.py
@@ -4,35 +4,31 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import json
 import os
 import threading
 from collections import OrderedDict
 from collections.abc import Callable, Coroutine, Mapping, Sequence
 from concurrent.futures import Future
 from typing import Any
-from uuid import uuid4
 
 from yukilog import configure_child_runtime, get_logger
 
-from ..events import (
-    ActionEnvelope,
-    ActorRef,
-    CallApi,
-    ConversationRef,
-    EventEnvelope,
-    Message,
-    Segment,
-    SendMessage,
-)
+from ..events import ActionEnvelope, CallApi, EventEnvelope, SendMessage
 from .client import RuntimeClient
+from .nonebot_contracts import (
+    AdapterContractError,
+    adapter_id,
+    json_value,
+    normalize_event,
+    send_proactive,
+    to_native_message,
+)
 from .protocol import (
     ActionRequest,
     ActionResponse,
     EventMessage,
     Shutdown,
     WireMessage,
-    json_mapping,
 )
 
 logger = get_logger(component="nonebot", runtime=os.environ.get("LITEYUKI_RUNTIME_ID"))
@@ -134,7 +130,7 @@ class SupervisorBridge:
                 response = ActionResponse(
                     correlation_id=request.correlation_id,
                     ok=ok,
-                    data=_json_value(data),
+                    data=json_value(data),
                     error=error,
                 )
             except Exception as error:
@@ -173,10 +169,11 @@ class NoneBotHost:
 
         async def forward(bot: Any, event: Any) -> None:
             envelope = self._normalize_event(bot, event)
-            self.events[envelope.reply_token or envelope.id] = (bot, event)
-            self.events.move_to_end(envelope.reply_token or envelope.id)
-            while len(self.events) > 2048:
-                self.events.popitem(last=False)
+            if envelope.reply_token is not None:
+                self.events[envelope.reply_token] = (bot, event)
+                self.events.move_to_end(envelope.reply_token)
+                while len(self.events) > 2048:
+                    self.events.popitem(last=False)
             self.bridge.emit_event(envelope)
 
         adapters = importlib.import_module("nonebot.adapters")
@@ -208,51 +205,36 @@ class NoneBotHost:
         bot = self.nonebot.get_bot(envelope.bot_id)
         action = envelope.action
         if isinstance(action, CallApi):
-            result = await bot.call_api(action.api, **action.params)
-            return True, result, None
+            params = json_value(action.params)
+            if not isinstance(params, dict):
+                return False, None, "CallApi params must serialize to an object"
+            result = await bot.call_api(action.api, **params)
+            return True, json_value(result), None
         if isinstance(action, SendMessage):
-            if not action.reply_token:
-                return False, None, "generic proactive NoneBot sends require CallApi"
-            target = self.events.get(action.reply_token)
-            if target is None:
-                return False, None, "reply token is unknown or expired"
-            target_bot, event = target
-            result = await target_bot.send(event, action.message.plain_text)
-            return True, result, None
+            selected_adapter = adapter_id(str(bot.adapter.get_name()))
+            try:
+                message = to_native_message(selected_adapter, action.message)
+                if action.reply_token:
+                    target = self.events.get(action.reply_token)
+                    if target is None:
+                        return False, None, "reply token is unknown or expired"
+                    target_bot, event = target
+                    if str(target_bot.self_id) != envelope.bot_id:
+                        return False, None, "reply token belongs to a different bot"
+                    target_adapter = adapter_id(str(target_bot.adapter.get_name()))
+                    if target_adapter != selected_adapter:
+                        return False, None, "reply token belongs to a different adapter"
+                    result = await target_bot.send(event, message)
+                else:
+                    result = await send_proactive(bot, selected_adapter, action, message)
+            except AdapterContractError as error:
+                return False, None, str(error)
+            return True, json_value(result), None
         return False, None, f"unsupported NoneBot action: {type(action).__name__}"
 
     @staticmethod
     def _normalize_event(bot: Any, event: Any) -> EventEnvelope:
-        reply_token = str(uuid4())
-        try:
-            plain_text = event.get_plaintext()
-        except (AttributeError, NotImplementedError):
-            plain_text = ""
-        try:
-            actor_id = str(event.get_user_id())
-        except (AttributeError, NotImplementedError, ValueError):
-            actor_id = None
-        try:
-            conversation_id = str(event.get_session_id())
-        except (AttributeError, NotImplementedError):
-            conversation_id = reply_token
-        try:
-            event_name = str(event.get_event_name())
-        except (AttributeError, NotImplementedError):
-            event_name = type(event).__name__
-        adapter_name = str(bot.adapter.get_name())
-        raw = _event_raw(event)
-        return EventEnvelope(
-            runtime_id=os.environ.get("LITEYUKI_RUNTIME_ID", "nonebot"),
-            adapter=adapter_name,
-            bot_id=str(bot.self_id),
-            type=event_name,
-            conversation=ConversationRef(id=conversation_id),
-            actor=ActorRef(id=actor_id) if actor_id else None,
-            message=Message(segments=(Segment(type="text", data={"text": plain_text}),)) if plain_text else None,
-            reply_token=reply_token,
-            raw=raw,
-        )
+        return normalize_event(bot, event)
 
 
 def run() -> None:
@@ -294,19 +276,6 @@ def _load_symbol(spec: str) -> Any:
     if not separator or not module_name or not attribute:
         raise ValueError(f"adapter must use module:attribute syntax: {spec}")
     return getattr(importlib.import_module(module_name), attribute)
-
-
-def _event_raw(event: Any) -> dict[str, Any]:
-    try:
-        value = event.model_dump(mode="json")
-        return json_mapping(value) if isinstance(value, Mapping) else {}
-    except (AttributeError, TypeError, ValueError):
-        return {}
-
-
-def _json_value(value: Any) -> Any:
-    encoded = json.dumps(value, ensure_ascii=False, default=str, allow_nan=False)
-    return json.loads(encoded)
 
 
 __all__ = ["NoneBotHost", "SupervisorBridge", "run"]

--- a/src/liteyukibot/runtime/nonebot_contracts.py
+++ b/src/liteyukibot/runtime/nonebot_contracts.py
@@ -1,0 +1,632 @@
+"""Protocol-neutral contracts for NoneBot adapter events and actions."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import math
+import os
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from ..events import ActorRef, ConversationRef, EventEnvelope, Message, Segment, SendMessage
+
+_MESSAGE_MODULES = {
+    "onebot-v11": "nonebot.adapters.onebot.v11",
+    "onebot-v12": "nonebot.adapters.onebot.v12",
+    "satori": "nonebot.adapters.satori",
+}
+_MEDIA_TYPES = frozenset({"image", "audio", "voice", "video", "file"})
+
+
+class AdapterContractError(ValueError):
+    """An Action cannot be represented by the selected adapter contract."""
+
+
+def adapter_id(display_name: str) -> str:
+    normalized = "-".join(display_name.strip().lower().replace("_", "-").split())
+    aliases = {
+        "onebot-v11": "onebot-v11",
+        "onebot-v12": "onebot-v12",
+        "satori": "satori",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def normalize_event(bot: Any, event: Any) -> EventEnvelope:
+    adapter = adapter_id(str(bot.adapter.get_name()))
+    bot_id = str(bot.self_id)
+    native_message = _original_message(event)
+    timestamp = _event_timestamp(event)
+    values: dict[str, Any] = {
+        "runtime_id": os.environ.get("LITEYUKI_RUNTIME_ID", "nonebot"),
+        "adapter": adapter,
+        "bot_id": bot_id,
+        "type": _event_name(event),
+        "conversation": _conversation(adapter, bot_id, event),
+        "actor": _actor(adapter, bot_id, event),
+        "message": _to_portable_message(adapter, native_message) if native_message is not None else None,
+        "reply_token": str(uuid4()) if native_message is not None else None,
+        "raw": _event_raw(event),
+    }
+    if timestamp is not None:
+        values["timestamp"] = timestamp
+    return EventEnvelope.model_validate(values)
+
+
+def to_native_message(adapter: str, message: Message) -> Any:
+    module_name = _MESSAGE_MODULES.get(adapter)
+    if module_name is None:
+        raise AdapterContractError(f"structured messages are unsupported for adapter {adapter!r}")
+    module = importlib.import_module(module_name)
+    message_class = module.Message
+    segment_class = module.MessageSegment
+    segments = [_to_native_segment(adapter, segment_class, segment) for segment in message.segments]
+    return message_class(segments)
+
+
+async def send_proactive(bot: Any, adapter: str, action: SendMessage, message: Any) -> Any:
+    conversation = action.conversation
+    if conversation is None:
+        raise AdapterContractError("proactive sends require a conversation")
+
+    if adapter == "onebot-v11":
+        target_id = _positive_integer_id(conversation.id)
+        if conversation.type == "private":
+            return await bot.call_api("send_private_msg", user_id=target_id, message=message)
+        if conversation.type == "group":
+            return await bot.call_api("send_group_msg", group_id=target_id, message=message)
+        raise AdapterContractError(f"OneBot v11 proactive sends do not support {conversation.type!r} conversations")
+
+    if adapter == "onebot-v12":
+        params: dict[str, Any] = {"detail_type": conversation.type, "message": message}
+        if conversation.type == "private":
+            params["user_id"] = conversation.id
+        elif conversation.type == "group":
+            params["group_id"] = conversation.id
+        elif conversation.type == "channel":
+            if not conversation.parent_id:
+                raise AdapterContractError("OneBot v12 channel sends require conversation.parent_id")
+            params["guild_id"] = conversation.parent_id
+            params["channel_id"] = conversation.id
+        else:
+            raise AdapterContractError(f"OneBot v12 proactive sends do not support {conversation.type!r} conversations")
+        return await bot.call_api("send_message", **params)
+
+    if adapter == "satori":
+        if conversation.type not in {"private", "channel"}:
+            raise AdapterContractError(
+                f"Satori proactive sends require a private or channel conversation, got {conversation.type!r}"
+            )
+        return await bot.send_message(conversation.id, message)
+
+    raise AdapterContractError(f"proactive sends are unsupported for adapter {adapter!r}")
+
+
+def json_value(value: Any) -> Any:
+    normalized = _normalize_json(value)
+    encoded = json.dumps(normalized, ensure_ascii=False, allow_nan=False)
+    return json.loads(encoded)
+
+
+def _normalize_json(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return _normalize_json(value.model_dump(mode="python"))
+    if isinstance(value, datetime):
+        return _aware_utc(value).isoformat()
+    if isinstance(value, Enum):
+        return _normalize_json(value.value)
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("JSON results must not contain NaN or infinity")
+        return value
+    if isinstance(value, Mapping):
+        if any(not isinstance(key, str) for key in value):
+            raise TypeError("JSON results must use string object keys")
+        return {key: _normalize_json(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_normalize_json(item) for item in value]
+    raise TypeError(f"Action result contains non-JSON value {type(value).__name__}")
+
+
+def _event_timestamp(event: Any) -> datetime | None:
+    value = getattr(event, "time", None)
+    if value is None:
+        value = getattr(event, "timestamp", None)
+    if isinstance(value, datetime):
+        return _aware_utc(value)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return datetime.fromtimestamp(value, UTC)
+    return None
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is not None and value.utcoffset() is not None:
+        return value.astimezone(UTC)
+    return datetime.fromtimestamp(value.timestamp(), UTC)
+
+
+def _event_name(event: Any) -> str:
+    try:
+        return str(event.get_event_name())
+    except AttributeError, NotImplementedError, TypeError, ValueError:
+        return type(event).__name__
+
+
+def _conversation(adapter: str, bot_id: str, event: Any) -> ConversationRef:
+    if adapter in {"onebot-v11", "onebot-v12"}:
+        channel_id = _string_attribute(event, "channel_id")
+        if channel_id:
+            return ConversationRef(
+                id=channel_id,
+                type="channel",
+                parent_id=_string_attribute(event, "guild_id"),
+            )
+        group_id = _string_attribute(event, "group_id")
+        if group_id:
+            return ConversationRef(id=group_id, type="group")
+        user_id = _string_attribute(event, "user_id")
+        if user_id:
+            return ConversationRef(id=user_id, type="private")
+
+    if adapter == "satori":
+        channel = getattr(event, "channel", None)
+        channel_id = _string_attribute(channel, "id")
+        if channel_id:
+            channel_type = getattr(channel, "type", None)
+            kind: Literal["private", "channel"] = "private" if _integer_value(channel_type) == 1 else "channel"
+            guild = getattr(event, "guild", None)
+            parent_id = _string_attribute(channel, "parent_id") or _string_attribute(guild, "id")
+            return ConversationRef(id=channel_id, type=kind, parent_id=parent_id)
+        guild_id = _string_attribute(getattr(event, "guild", None), "id")
+        if guild_id:
+            return ConversationRef(id=guild_id, type="group")
+        actor_id = _context_actor_id(event)
+        if actor_id:
+            return ConversationRef(id=actor_id, type="private")
+
+    try:
+        session_id = str(event.get_session_id())
+    except AttributeError, NotImplementedError, TypeError, ValueError:
+        session_id = ""
+    return ConversationRef(id=session_id or f"bot:{bot_id}")
+
+
+def _actor(adapter: str, bot_id: str, event: Any) -> ActorRef | None:
+    actor_id = _context_actor_id(event)
+    if not actor_id:
+        return None
+
+    display_name: str | None = None
+    is_bot = actor_id == bot_id
+    if adapter == "onebot-v11":
+        sender = getattr(event, "sender", None)
+        display_name = _string_attribute(sender, "card") or _string_attribute(sender, "nickname")
+    elif adapter == "satori":
+        member = getattr(event, "member", None)
+        user = getattr(event, "user", None) or getattr(event, "operator", None)
+        display_name = (
+            _string_attribute(member, "nick") or _string_attribute(user, "nick") or _string_attribute(user, "name")
+        )
+        explicit_is_bot = getattr(user, "is_bot", None)
+        if explicit_is_bot is not None:
+            is_bot = bool(explicit_is_bot)
+        else:
+            login_user = getattr(getattr(event, "login", None), "user", None)
+            is_bot = actor_id == _string_attribute(login_user, "id")
+    return ActorRef(id=actor_id, display_name=display_name, is_bot=is_bot)
+
+
+def _context_actor_id(event: Any) -> str | None:
+    actor_id = _string_attribute(event, "user_id")
+    if actor_id:
+        return actor_id
+    user = getattr(event, "user", None) or getattr(event, "operator", None)
+    actor_id = _string_attribute(user, "id")
+    if actor_id:
+        return actor_id
+    try:
+        return str(event.get_user_id()) or None
+    except AttributeError, NotImplementedError, TypeError, ValueError:
+        return None
+
+
+def _original_message(event: Any) -> Any | None:
+    original = getattr(event, "original_message", None)
+    if original is not None:
+        return original
+    try:
+        return event.get_message()
+    except AttributeError, NotImplementedError, TypeError, ValueError:
+        return None
+
+
+def _to_portable_message(adapter: str, native_message: Any) -> Message:
+    return Message(segments=tuple(_to_portable_segment(adapter, segment) for segment in native_message))
+
+
+def _to_portable_segment(adapter: str, native_segment: Any) -> Segment:
+    native_type = str(native_segment.type)
+    data = _native_data(adapter, native_type, getattr(native_segment, "data", {}))
+    children = getattr(native_segment, "children", None)
+    portable_children = (
+        [segment.model_dump(mode="json") for segment in _to_portable_message(adapter, children).segments]
+        if children
+        else []
+    )
+
+    if native_type == "text":
+        return Segment(type="text", data=data)
+
+    if (
+        (adapter == "onebot-v11" and native_type == "at")
+        or (adapter == "onebot-v12" and native_type in {"mention", "mention_all"})
+        or (adapter == "satori" and native_type == "at")
+    ):
+        return Segment(type="mention", data=_portable_mention(adapter, native_type, data))
+
+    if (adapter in {"onebot-v11", "onebot-v12"} and native_type == "reply") or (
+        adapter == "satori" and native_type == "quote"
+    ):
+        reply = _portable_reply(adapter, data)
+        if portable_children:
+            reply["children"] = portable_children
+        return Segment(type="reply", data=reply)
+
+    media_type = _portable_media_type(adapter, native_type)
+    if media_type is not None:
+        media = dict(data)
+        media["media_type"] = media_type
+        if native_type != media_type:
+            media["adapter_type"] = native_type
+        source = data.get("src") or data.get("url") or data.get("file")
+        if isinstance(source, str) and source:
+            media["url"] = source
+        if portable_children:
+            media["children"] = portable_children
+        return Segment(type="media", data=media)
+
+    adapter_data: dict[str, Any] = {
+        "adapter": adapter,
+        "type": native_type,
+        "data": data,
+    }
+    if portable_children:
+        adapter_data["children"] = portable_children
+    return Segment(type="adapter", data=adapter_data)
+
+
+def _native_data(adapter: str, native_type: str, value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"native {native_type!r} segment data must be an object")
+    if adapter == "satori" and native_type == "text":
+        mutable = dict(value)
+        styles = mutable.pop("styles", None)
+        data = json_value(mutable)
+        if not isinstance(data, dict):
+            raise TypeError("native segment data must serialize to an object")
+        data["styles"] = _portable_styles(styles)
+        return data
+    data = json_value(value)
+    if not isinstance(data, dict):
+        raise TypeError("native segment data must serialize to an object")
+    return data
+
+
+def _portable_styles(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Mapping):
+        return []
+    styles: list[dict[str, Any]] = []
+    for bounds, names in value.items():
+        if not isinstance(bounds, tuple) or len(bounds) != 2:
+            continue
+        if not isinstance(names, Sequence) or isinstance(names, (str, bytes, bytearray)):
+            continue
+        styles.append(
+            {
+                "start": int(bounds[0]),
+                "end": int(bounds[1]),
+                "types": [str(name) for name in names],
+            }
+        )
+    return styles
+
+
+def _portable_mention(adapter: str, native_type: str, data: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(data)
+    if adapter == "onebot-v11":
+        target = str(result.pop("qq", ""))
+        if target == "all":
+            result["scope"] = "all"
+        elif target:
+            result["user_id"] = target
+    elif adapter == "onebot-v12":
+        target = result.pop("user_id", None)
+        if native_type == "mention_all":
+            result["scope"] = "all"
+        elif target is not None:
+            result["user_id"] = str(target)
+    else:
+        target = result.pop("id", None)
+        role = result.pop("role", None)
+        scope = result.pop("type", None)
+        if target is not None:
+            result["user_id"] = str(target)
+        elif role is not None:
+            result["role_id"] = str(role)
+        elif scope in {"all", "here"}:
+            result["scope"] = scope
+    return result
+
+
+def _portable_reply(adapter: str, data: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(data)
+    native_key = "id" if adapter in {"onebot-v11", "satori"} else "message_id"
+    message_id = result.pop(native_key, None)
+    if message_id is not None:
+        result["message_id"] = str(message_id)
+    return result
+
+
+def _portable_media_type(adapter: str, native_type: str) -> str | None:
+    if adapter == "onebot-v11":
+        return {"image": "image", "record": "voice", "video": "video"}.get(native_type)
+    if adapter == "onebot-v12":
+        return native_type if native_type in _MEDIA_TYPES else None
+    if adapter == "satori":
+        return {"img": "image", "audio": "audio", "video": "video", "file": "file"}.get(native_type)
+    return None
+
+
+def _to_native_segment(adapter: str, segment_class: Any, segment: Segment) -> Any:
+    dumped = segment.model_dump(mode="json")
+    dumped_data = dumped.get("data")
+    if not isinstance(dumped_data, dict):
+        raise AdapterContractError("segment data must serialize to an object")
+    data = dumped_data
+    children = _portable_children(data.pop("children", None))
+    native_data: dict[Any, Any]
+    if segment.type == "text":
+        native_type = "text"
+        native_data = dict(data)
+        if adapter == "satori":
+            native_data["styles"] = _native_styles(native_data.get("styles"))
+    elif segment.type == "mention":
+        native_type, native_data = _native_mention(adapter, data)
+    elif segment.type == "reply":
+        native_type, native_data = _native_reply(adapter, data)
+    elif segment.type == "media":
+        native_type, native_data = _native_media(adapter, data)
+    else:
+        native_type, native_data = _native_adapter_segment(adapter, data)
+
+    native_segment_class = _satori_segment_class(native_type) if adapter == "satori" else segment_class
+    native_segment = native_segment_class(native_type, native_data)
+    if children:
+        if adapter != "satori":
+            raise AdapterContractError(f"adapter {adapter!r} segments cannot contain children")
+        child_message = to_native_message(adapter, Message(segments=children))
+        native_segment(*child_message)
+    return native_segment
+
+
+def _portable_children(value: Any) -> tuple[Segment, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise AdapterContractError("segment children must be an array")
+    try:
+        return tuple(Segment.model_validate(item) for item in value)
+    except ValueError as error:
+        raise AdapterContractError(f"invalid child segment: {error}") from error
+
+
+def _native_styles(value: Any) -> dict[tuple[int, int], list[str]]:
+    if value in (None, ()):  # frozen empty JSON arrays become tuples
+        return {}
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise AdapterContractError("Satori text styles must be an array")
+    styles: dict[tuple[int, int], list[str]] = {}
+    for entry in value:
+        if not isinstance(entry, Mapping):
+            raise AdapterContractError("Satori text style entries must be objects")
+        start = entry.get("start")
+        end = entry.get("end")
+        names = entry.get("types")
+        if not isinstance(start, int) or not isinstance(end, int) or start < 0 or end < start:
+            raise AdapterContractError("Satori text style ranges are invalid")
+        if not isinstance(names, Sequence) or isinstance(names, (str, bytes, bytearray)):
+            raise AdapterContractError("Satori text style types must be an array")
+        styles[(start, end)] = [str(name) for name in names]
+    return styles
+
+
+def _native_mention(adapter: str, data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    scope = data.pop("scope", None)
+    user_id = data.pop("user_id", None)
+    role_id = data.pop("role_id", None)
+    if adapter == "onebot-v11":
+        if role_id is not None or scope == "here":
+            raise AdapterContractError("OneBot v11 does not support this mention target")
+        target = "all" if scope == "all" else user_id
+        if target is None:
+            raise AdapterContractError("mention segments require user_id or scope")
+        data["qq"] = str(target)
+        return "at", data
+    if adapter == "onebot-v12":
+        if role_id is not None or scope == "here":
+            raise AdapterContractError("OneBot v12 does not support this mention target")
+        if scope == "all":
+            return "mention_all", data
+        if user_id is None:
+            raise AdapterContractError("mention segments require user_id or scope")
+        data["user_id"] = str(user_id)
+        return "mention", data
+    if adapter == "satori":
+        if user_id is not None:
+            data["id"] = str(user_id)
+        elif role_id is not None:
+            data["role"] = str(role_id)
+        elif scope in {"all", "here"}:
+            data["type"] = scope
+        else:
+            raise AdapterContractError("mention segments require user_id, role_id, or scope")
+        return "at", data
+    raise AdapterContractError(f"mentions are unsupported for adapter {adapter!r}")
+
+
+def _native_reply(adapter: str, data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    message_id = data.pop("message_id", None)
+    if not isinstance(message_id, str) or not message_id:
+        raise AdapterContractError("reply segments require a non-empty message_id")
+    if adapter == "onebot-v11":
+        data["id"] = message_id
+        return "reply", data
+    if adapter == "onebot-v12":
+        data["message_id"] = message_id
+        return "reply", data
+    if adapter == "satori":
+        data["id"] = message_id
+        return "quote", data
+    raise AdapterContractError(f"replies are unsupported for adapter {adapter!r}")
+
+
+def _native_media(adapter: str, data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    media_type = data.pop("media_type", None)
+    adapter_type = data.pop("adapter_type", None)
+    if media_type not in _MEDIA_TYPES:
+        raise AdapterContractError(f"unsupported media_type: {media_type!r}")
+    url = data.pop("url", None)
+    data.pop("children", None)
+
+    if adapter == "onebot-v11":
+        native_type = (
+            str(adapter_type)
+            if adapter_type in {"image", "record", "video"}
+            else str({"audio": "record", "voice": "record"}.get(media_type, media_type))
+        )
+        if native_type not in {"image", "record", "video"}:
+            raise AdapterContractError(f"OneBot v11 does not support {media_type!r} media")
+        if "file" not in data:
+            if not isinstance(url, str) or not url:
+                raise AdapterContractError("OneBot v11 media requires data.file or data.url")
+            data["file"] = url
+        return native_type, data
+
+    if adapter == "onebot-v12":
+        native_type = str(adapter_type) if adapter_type in _MEDIA_TYPES else str(media_type)
+        if native_type not in _MEDIA_TYPES:
+            raise AdapterContractError(f"OneBot v12 does not support {media_type!r} media")
+        if not isinstance(data.get("file_id"), str) or not data["file_id"]:
+            raise AdapterContractError("OneBot v12 media requires data.file_id")
+        return native_type, data
+
+    if adapter == "satori":
+        native_type = (
+            str(adapter_type)
+            if adapter_type in {"img", "audio", "video", "file"}
+            else str({"image": "img", "voice": "audio"}.get(media_type, media_type))
+        )
+        if native_type not in {"img", "audio", "video", "file"}:
+            raise AdapterContractError(f"Satori does not support {media_type!r} media")
+        if "src" not in data:
+            if not isinstance(url, str) or not url:
+                raise AdapterContractError("Satori media requires data.src or data.url")
+            data["src"] = url
+        return native_type, data
+
+    raise AdapterContractError(f"media is unsupported for adapter {adapter!r}")
+
+
+def _native_adapter_segment(adapter: str, data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    target = data.get("adapter")
+    if target is not None and target != adapter:
+        raise AdapterContractError(f"adapter segment targets {target!r}, but the selected adapter is {adapter!r}")
+    native_type = data.get("type")
+    native_data = data.get("data")
+    if not isinstance(native_type, str) or not native_type:
+        raise AdapterContractError("adapter segments require a non-empty type")
+    if not isinstance(native_data, Mapping):
+        raise AdapterContractError("adapter segments require an object data field")
+    result = dict(native_data)
+    if adapter == "onebot-v11" and native_type in {"image", "record", "video"}:
+        if "file" not in result and isinstance(result.get("url"), str):
+            result["file"] = result.pop("url")
+        if not isinstance(result.get("file"), str) or not result["file"]:
+            raise AdapterContractError(f"OneBot v11 {native_type} segments require data.file or data.url")
+    elif adapter == "onebot-v12" and native_type in _MEDIA_TYPES:
+        if not isinstance(result.get("file_id"), str) or not result["file_id"]:
+            raise AdapterContractError(f"OneBot v12 {native_type} segments require data.file_id")
+    elif adapter == "satori" and native_type == "image":
+        native_type = "img"
+        if "src" not in result and isinstance(result.get("url"), str):
+            result["src"] = result.pop("url")
+    return native_type, result
+
+
+def _satori_segment_class(native_type: str) -> Any:
+    message_module = importlib.import_module("nonebot.adapters.satori.message")
+    classes = {
+        "text": message_module.Text,
+        "at": message_module.At,
+        "sharp": message_module.Sharp,
+        "emoji": message_module.Emoji,
+        "link": message_module.Link,
+        "img": message_module.Image,
+        "audio": message_module.Audio,
+        "video": message_module.Video,
+        "file": message_module.File,
+        "message": message_module.RenderMessage,
+        "quote": message_module.RenderMessage,
+        "author": message_module.Author,
+        "button": message_module.Button,
+        "br": message_module.Br,
+    }
+    return classes.get(native_type, message_module.Custom)
+
+
+def _event_raw(event: Any) -> dict[str, Any]:
+    try:
+        value = event.model_dump(mode="json")
+        normalized = json_value(value)
+        return normalized if isinstance(normalized, dict) else {}
+    except AttributeError, TypeError, ValueError:
+        return {}
+
+
+def _positive_integer_id(value: str) -> int:
+    if not value.isdecimal() or (parsed := int(value)) <= 0:
+        raise AdapterContractError("OneBot v11 conversation IDs must be positive integers")
+    return parsed
+
+
+def _string_attribute(value: Any, name: str) -> str | None:
+    attribute = getattr(value, name, None)
+    if attribute is None:
+        return None
+    result = str(attribute)
+    return result or None
+
+
+def _integer_value(value: Any) -> int | None:
+    try:
+        return int(value)
+    except TypeError, ValueError:
+        return None
+
+
+__all__ = [
+    "AdapterContractError",
+    "adapter_id",
+    "json_value",
+    "normalize_event",
+    "send_proactive",
+    "to_native_message",
+]

--- a/tests/test_nonebot_adapters_v7.py
+++ b/tests/test_nonebot_adapters_v7.py
@@ -31,8 +31,11 @@ _ADAPTER_MODULES = (
     "nonebot.adapters.onebot.v12",
     "nonebot.adapters.satori",
 )
+_ADAPTERS_INSTALLED = importlib.util.find_spec("nonebot") is not None and all(
+    importlib.util.find_spec(module) is not None for module in _ADAPTER_MODULES
+)
 pytestmark = pytest.mark.skipif(
-    any(importlib.util.find_spec(module) is None for module in _ADAPTER_MODULES),
+    not _ADAPTERS_INSTALLED,
     reason="NoneBot OneBot and Satori extras are not installed",
 )
 

--- a/tests/test_nonebot_adapters_v7.py
+++ b/tests/test_nonebot_adapters_v7.py
@@ -1,0 +1,571 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import math
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from liteyukibot.events import (
+    ActionEnvelope,
+    CallApi,
+    ConversationRef,
+    Message,
+    Segment,
+    SendMessage,
+)
+from liteyukibot.runtime.nonebot import NoneBotHost
+from liteyukibot.runtime.nonebot_contracts import (
+    AdapterContractError,
+    adapter_id,
+    json_value,
+    normalize_event,
+    to_native_message,
+)
+
+_ADAPTER_MODULES = (
+    "nonebot.adapters.onebot.v11",
+    "nonebot.adapters.onebot.v12",
+    "nonebot.adapters.satori",
+)
+pytestmark = pytest.mark.skipif(
+    any(importlib.util.find_spec(module) is None for module in _ADAPTER_MODULES),
+    reason="NoneBot OneBot and Satori extras are not installed",
+)
+
+
+class FakeAdapter:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def get_name(self) -> str:
+        return self.name
+
+
+class FakeBot:
+    def __init__(self, self_id: str, adapter_name: str) -> None:
+        self.self_id = self_id
+        self.adapter = FakeAdapter(adapter_name)
+        self.api_calls: list[tuple[str, dict[str, Any]]] = []
+        self.replies: list[tuple[Any, Any]] = []
+        self.channel_sends: list[tuple[str, Any]] = []
+        self.api_result: Any = {"message_id": "sent"}
+
+    async def call_api(self, api: str, **params: Any) -> Any:
+        self.api_calls.append((api, params))
+        return self.api_result
+
+    async def send(self, event: Any, message: Any) -> Any:
+        self.replies.append((event, message))
+        return self.api_result
+
+    async def send_message(self, channel_id: str, message: Any) -> Any:
+        self.channel_sends.append((channel_id, message))
+        return self.api_result
+
+
+class FakeNoneBot:
+    def __init__(self, *bots: FakeBot) -> None:
+        self.bots = {bot.self_id: bot for bot in bots}
+
+    def get_bot(self, bot_id: str) -> FakeBot:
+        return self.bots[bot_id]
+
+
+def _onebot_v11_group_event() -> Any:
+    onebot = importlib.import_module("nonebot.adapters.onebot.v11")
+    return onebot.GroupMessageEvent.model_validate(
+        {
+            "time": 1_720_000_000,
+            "self_id": 42,
+            "post_type": "message",
+            "sub_type": "normal",
+            "user_id": 1001,
+            "message_type": "group",
+            "message_id": 7,
+            "message": [
+                {"type": "text", "data": {"text": "hello"}},
+                {"type": "at", "data": {"qq": "42"}},
+                {
+                    "type": "image",
+                    "data": {"file": "image-id", "url": "https://example.test/image.png"},
+                },
+                {"type": "record", "data": {"file": "audio-id"}},
+                {"type": "video", "data": {"file": "video-id"}},
+                {"type": "reply", "data": {"id": "6"}},
+                {"type": "face", "data": {"id": "123"}},
+            ],
+            "raw_message": "hello",
+            "font": 0,
+            "sender": {"user_id": 1001, "nickname": "nickname", "card": "group card"},
+            "group_id": 2002,
+        }
+    )
+
+
+def _onebot_v11_private_event() -> Any:
+    onebot = importlib.import_module("nonebot.adapters.onebot.v11")
+    return onebot.PrivateMessageEvent.model_validate(
+        {
+            "time": 1_720_000_000,
+            "self_id": 42,
+            "post_type": "message",
+            "sub_type": "friend",
+            "user_id": 1001,
+            "message_type": "private",
+            "message_id": 8,
+            "message": [{"type": "text", "data": {"text": "private"}}],
+            "raw_message": "private",
+            "font": 0,
+            "sender": {"user_id": 1001, "nickname": "nickname"},
+        }
+    )
+
+
+def _onebot_v12_event(detail_type: str) -> Any:
+    onebot = importlib.import_module("nonebot.adapters.onebot.v12")
+    event_class = {
+        "private": onebot.PrivateMessageEvent,
+        "group": onebot.GroupMessageEvent,
+        "channel": onebot.ChannelMessageEvent,
+    }[detail_type]
+    value: dict[str, Any] = {
+        "id": f"event-{detail_type}",
+        "time": datetime(2026, 8, 9, 1, 2, tzinfo=UTC),
+        "type": "message",
+        "detail_type": detail_type,
+        "sub_type": "",
+        "self": {"platform": "test", "user_id": "bot"},
+        "message_id": f"message-{detail_type}",
+        "message": [
+            {"type": "text", "data": {"text": detail_type}},
+            {"type": "mention", "data": {"user_id": "bot"}},
+            {"type": "image", "data": {"file_id": "file-1"}},
+            {"type": "reply", "data": {"message_id": "previous"}},
+        ],
+        "alt_message": detail_type,
+        "user_id": "user",
+    }
+    if detail_type == "group":
+        value["group_id"] = "group"
+    elif detail_type == "channel":
+        value["guild_id"] = "guild"
+        value["channel_id"] = "channel"
+    return event_class.model_validate(value)
+
+
+def _satori_event(*, direct: bool) -> Any:
+    satori_event = importlib.import_module("nonebot.adapters.satori.event")
+    event_class = satori_event.PrivateMessageCreatedEvent if direct else satori_event.PublicMessageCreatedEvent
+    value: dict[str, Any] = {
+        "type": "message-created",
+        "timestamp": 1_720_000_000_000,
+        "login": {
+            "sn": 1,
+            "adapter": "test",
+            "platform": "discord",
+            "user": {"id": "bot"},
+        },
+        "channel": {"id": "direct" if direct else "channel", "type": 1 if direct else 0},
+        "message": {
+            "id": "message",
+            "content": (
+                '<quote id="previous">quoted</quote><at id="bot"/> '
+                '<b>hello</b><img src="https://example.test/image.png"/>'
+                '<custom foo="bar">nested</custom>'
+                '<a href="https://example.test">link</a>'
+                '<button type="action" id="go">Go</button><br/>'
+            ),
+        },
+        "user": {"id": "user", "name": "account", "nick": "nickname", "is_bot": False},
+        "sn": 9,
+    }
+    if not direct:
+        value["guild"] = {"id": "guild"}
+        value["member"] = {"nick": "member nickname"}
+    return event_class.model_validate(value)
+
+
+def _action(bot_id: str, action: SendMessage | CallApi) -> dict[str, Any]:
+    return ActionEnvelope(
+        runtime_id="nonebot",
+        bot_id=bot_id,
+        action=action,
+    ).model_dump(mode="json")
+
+
+def test_adapter_ids_and_strict_json_results() -> None:
+    satori_models = importlib.import_module("nonebot.adapters.satori.models")
+    source_timestamp = 1_720_000_000
+    result = json_value(
+        [
+            satori_models.MessageObject(
+                id="message",
+                content="hello",
+                created_at=datetime.fromtimestamp(source_timestamp),
+            )
+        ]
+    )
+
+    assert adapter_id("OneBot V11") == "onebot-v11"
+    assert adapter_id("OneBot V12") == "onebot-v12"
+    assert adapter_id("Satori") == "satori"
+    assert result == [
+        {
+            "id": "message",
+            "content": "hello",
+            "channel": None,
+            "guild": None,
+            "member": None,
+            "user": None,
+            "created_at": datetime.fromtimestamp(source_timestamp, UTC).isoformat(),
+            "updated_at": None,
+            "referrer": None,
+        }
+    ]
+    with pytest.raises(ValueError, match="NaN"):
+        json_value(math.nan)
+    with pytest.raises(TypeError, match="non-JSON"):
+        json_value(object())
+
+
+def test_onebot_v11_event_uses_group_fifo_key_and_original_segments() -> None:
+    event = _onebot_v11_group_event()
+    event.message.clear()
+    envelope = normalize_event(FakeBot("42", "OneBot V11"), event)
+
+    assert envelope.adapter == "onebot-v11"
+    assert envelope.type == "message.group.normal"
+    assert envelope.timestamp == datetime.fromtimestamp(1_720_000_000, UTC)
+    assert envelope.conversation == ConversationRef(id="2002", type="group")
+    assert envelope.actor is not None
+    assert envelope.actor.id == "1001"
+    assert envelope.actor.display_name == "group card"
+    assert envelope.reply_token
+    assert envelope.raw["group_id"] == 2002
+    assert envelope.message is not None
+    assert [segment.type for segment in envelope.message.segments] == [
+        "text",
+        "mention",
+        "media",
+        "media",
+        "media",
+        "reply",
+        "adapter",
+    ]
+    assert envelope.message.segments[1].data["user_id"] == "42"
+    assert envelope.message.segments[2].data["media_type"] == "image"
+    assert envelope.message.segments[3].data["media_type"] == "voice"
+    assert envelope.message.segments[3].data["adapter_type"] == "record"
+    assert envelope.message.segments[5].data["message_id"] == "6"
+    assert envelope.message.segments[6].data == {
+        "adapter": "onebot-v11",
+        "type": "face",
+        "data": {"id": "123"},
+    }
+
+
+def test_onebot_v11_private_conversation_is_actor_not_composite_session() -> None:
+    envelope = normalize_event(FakeBot("42", "OneBot V11"), _onebot_v11_private_event())
+
+    assert envelope.conversation == ConversationRef(id="1001", type="private")
+    assert envelope.type == "message.private.friend"
+
+
+@pytest.mark.parametrize(
+    ("detail_type", "expected"),
+    [
+        ("private", ConversationRef(id="user", type="private")),
+        ("group", ConversationRef(id="group", type="group")),
+        ("channel", ConversationRef(id="channel", type="channel", parent_id="guild")),
+    ],
+)
+def test_onebot_v12_conversation_and_segments(
+    detail_type: str,
+    expected: ConversationRef,
+) -> None:
+    envelope = normalize_event(FakeBot("bot", "OneBot V12"), _onebot_v12_event(detail_type))
+
+    assert envelope.adapter == "onebot-v12"
+    assert envelope.type == f"message.{detail_type}"
+    assert envelope.conversation == expected
+    assert envelope.message is not None
+    assert [segment.type for segment in envelope.message.segments] == [
+        "text",
+        "mention",
+        "media",
+        "reply",
+    ]
+    assert envelope.message.segments[1].data["user_id"] == "bot"
+    assert envelope.message.segments[2].data["file_id"] == "file-1"
+
+
+@pytest.mark.parametrize(
+    ("direct", "expected"),
+    [
+        (True, ConversationRef(id="direct", type="private")),
+        (False, ConversationRef(id="channel", type="channel", parent_id="guild")),
+    ],
+)
+def test_satori_event_preserves_original_recursive_elements(
+    direct: bool,
+    expected: ConversationRef,
+) -> None:
+    event = _satori_event(direct=direct)
+    event.get_message().clear()
+    envelope = normalize_event(FakeBot("discord:bot", "Satori"), event)
+
+    assert envelope.adapter == "satori"
+    assert envelope.type == "message-created"
+    assert envelope.timestamp.tzinfo is not None
+    assert envelope.conversation == expected
+    assert envelope.actor is not None
+    assert envelope.actor.display_name == ("nickname" if direct else "member nickname")
+    assert envelope.message is not None
+    types = [segment.type for segment in envelope.message.segments]
+    assert types == [
+        "reply",
+        "mention",
+        "text",
+        "media",
+        "adapter",
+        "adapter",
+        "adapter",
+        "adapter",
+    ]
+    assert envelope.message.segments[0].data["message_id"] == "previous"
+    assert envelope.message.segments[2].data["styles"]
+    assert envelope.message.segments[3].data["url"] == "https://example.test/image.png"
+    custom = envelope.message.segments[4]
+    assert custom.data["adapter"] == "satori"
+    assert custom.data["type"] == "custom"
+    assert custom.data["children"]
+
+    restored = to_native_message("satori", envelope.message)
+    assert '<quote id="previous">' in str(restored)
+    assert '<custom foo="bar">nested</custom>' in str(restored)
+    assert "<b>hello</b>" in str(restored)
+    assert '<a href="https://example.test">link</a>' in str(restored)
+    assert '<button type="action" id="go">Go</button>' in str(restored)
+    assert "<br/>" in str(restored)
+
+
+def test_native_message_conversion_rejects_cross_adapter_and_bad_media() -> None:
+    with pytest.raises(AdapterContractError, match="targets"):
+        to_native_message(
+            "onebot-v11",
+            Message(
+                segments=(
+                    Segment(
+                        type="adapter",
+                        data={"adapter": "satori", "type": "custom", "data": {}},
+                    ),
+                )
+            ),
+        )
+    with pytest.raises(AdapterContractError, match="file_id"):
+        to_native_message(
+            "onebot-v12",
+            Message(segments=(Segment(type="media", data={"media_type": "image", "url": "https://example.test"}),)),
+        )
+    with pytest.raises(AdapterContractError, match="data.file"):
+        to_native_message(
+            "onebot-v11",
+            Message(segments=(Segment(type="adapter", data={"type": "image", "data": {}}),)),
+        )
+    with pytest.raises(AdapterContractError, match="file_id"):
+        to_native_message(
+            "onebot-v12",
+            Message(segments=(Segment(type="adapter", data={"type": "image", "data": {}}),)),
+        )
+
+
+def test_onebot_native_message_deeply_thaws_segment_data_for_real_encoder() -> None:
+    encoder = importlib.import_module("nonebot.utils").DataclassEncoder
+    native = to_native_message(
+        "onebot-v11",
+        Message(
+            segments=(
+                Segment(
+                    type="adapter",
+                    data={
+                        "type": "custom",
+                        "data": {"nested": {"values": (1, 2)}},
+                    },
+                ),
+            )
+        ),
+    )
+
+    assert type(native[0].data["nested"]) is dict
+    assert type(native[0].data["nested"]["values"]) is list
+    assert json.loads(json.dumps(native, cls=encoder))[0]["data"]["nested"] == {"values": [1, 2]}
+
+
+def test_portable_voice_maps_to_onebot_v11_record() -> None:
+    native = to_native_message(
+        "onebot-v11",
+        Message(
+            segments=(
+                Segment(
+                    type="media",
+                    data={"media_type": "voice", "url": "https://example.test/voice.ogg"},
+                ),
+            )
+        ),
+    )
+
+    assert native[0].type == "record"
+    assert native[0].data["file"] == "https://example.test/voice.ogg"
+
+
+def test_satori_actor_falls_back_to_login_identity_when_is_bot_is_unknown() -> None:
+    event = _satori_event(direct=True)
+    event.user.id = "bot"
+    event.user.is_bot = None
+
+    envelope = normalize_event(FakeBot("discord:bot", "Satori"), event)
+
+    assert envelope.actor is not None
+    assert envelope.actor.is_bot is True
+
+
+@pytest.mark.asyncio
+async def test_nonebot_host_executes_structured_reply_and_legacy_adapter_segment() -> None:
+    bot = FakeBot("42", "OneBot V11")
+    event = _onebot_v11_group_event()
+    envelope = normalize_event(bot, event)
+    assert envelope.reply_token is not None
+    host = NoneBotHost(FakeNoneBot(bot), bridge=None)  # type: ignore[arg-type]
+    host.events[envelope.reply_token] = (bot, event)
+    action = SendMessage(
+        reply_token=envelope.reply_token,
+        message=Message(
+            segments=(
+                Segment(type="text", data={"text": "reply"}),
+                Segment(type="mention", data={"user_id": "1001"}),
+                Segment(type="media", data={"media_type": "image", "url": "https://example.test/a.png"}),
+                Segment(type="reply", data={"message_id": "7"}),
+                Segment(type="adapter", data={"type": "image", "data": {"url": "https://example.test/b.png"}}),
+            )
+        ),
+    )
+
+    assert await host.execute_action(_action("42", action)) == (
+        True,
+        {"message_id": "sent"},
+        None,
+    )
+    assert len(bot.replies) == 1
+    target_event, native_message = bot.replies[0]
+    assert target_event is event
+    assert [segment.type for segment in native_message] == ["text", "at", "image", "reply", "image"]
+    assert native_message[2].data["file"] == "https://example.test/a.png"
+    assert native_message[4].data["file"] == "https://example.test/b.png"
+
+
+@pytest.mark.asyncio
+async def test_nonebot_host_rejects_expired_and_cross_bot_reply_tokens() -> None:
+    source = FakeBot("42", "OneBot V11")
+    selected = FakeBot("84", "OneBot V11")
+    event = _onebot_v11_group_event()
+    host = NoneBotHost(FakeNoneBot(source, selected), bridge=None)  # type: ignore[arg-type]
+    host.events["source-token"] = (source, event)
+    message = Message(segments=(Segment(type="text", data={"text": "reply"}),))
+
+    assert await host.execute_action(_action("42", SendMessage(reply_token="expired", message=message))) == (
+        False,
+        None,
+        "reply token is unknown or expired",
+    )
+    assert await host.execute_action(_action("84", SendMessage(reply_token="source-token", message=message))) == (
+        False,
+        None,
+        "reply token belongs to a different bot",
+    )
+    assert source.replies == []
+    assert selected.replies == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("adapter_name", "conversation", "expected_api", "expected_target"),
+    [
+        ("OneBot V11", ConversationRef(id="1001", type="private"), "send_private_msg", ("user_id", 1001)),
+        ("OneBot V11", ConversationRef(id="2002", type="group"), "send_group_msg", ("group_id", 2002)),
+        (
+            "OneBot V12",
+            ConversationRef(id="channel", type="channel", parent_id="guild"),
+            "send_message",
+            ("channel_id", "channel"),
+        ),
+    ],
+)
+async def test_nonebot_host_executes_onebot_proactive_routes(
+    adapter_name: str,
+    conversation: ConversationRef,
+    expected_api: str,
+    expected_target: tuple[str, Any],
+) -> None:
+    bot = FakeBot("bot", adapter_name)
+    host = NoneBotHost(FakeNoneBot(bot), bridge=None)  # type: ignore[arg-type]
+    action = SendMessage(
+        conversation=conversation,
+        message=Message(segments=(Segment(type="text", data={"text": "proactive"}),)),
+    )
+
+    assert (await host.execute_action(_action("bot", action)))[0] is True
+    api, params = bot.api_calls[0]
+    assert api == expected_api
+    assert params[expected_target[0]] == expected_target[1]
+    assert params["message"].extract_plain_text() == "proactive"
+
+
+@pytest.mark.asyncio
+async def test_nonebot_host_executes_satori_channel_send_and_call_api() -> None:
+    bot = FakeBot("discord:bot", "Satori")
+    host = NoneBotHost(FakeNoneBot(bot), bridge=None)  # type: ignore[arg-type]
+    message = Message(segments=(Segment(type="text", data={"text": "hello"}),))
+
+    sent = await host.execute_action(
+        _action(
+            "discord:bot",
+            SendMessage(
+                conversation=ConversationRef(id="direct-channel", type="private"),
+                message=message,
+            ),
+        )
+    )
+    called = await host.execute_action(
+        _action(
+            "discord:bot",
+            CallApi(
+                api="message_get",
+                params={
+                    "channel_id": "direct-channel",
+                    "message_id": "1",
+                    "nested": {"values": (1, 2)},
+                },
+            ),
+        )
+    )
+
+    assert sent == (True, {"message_id": "sent"}, None)
+    assert bot.channel_sends[0][0] == "direct-channel"
+    assert str(bot.channel_sends[0][1]) == "hello"
+    assert called == (True, {"message_id": "sent"}, None)
+    assert bot.api_calls == [
+        (
+            "message_get",
+            {
+                "channel_id": "direct-channel",
+                "message_id": "1",
+                "nested": {"values": [1, 2]},
+            },
+        )
+    ]
+    assert type(bot.api_calls[0][1]["nested"]) is dict
+    assert type(bot.api_calls[0][1]["nested"]["values"]) is list


### PR DESCRIPTION
## Summary

- normalize OneBot v11/v12 and Satori events into stable conversation, actor, timestamp, and structured segment contracts
- reconstruct native adapter messages for exact replies and supported proactive routes while keeping adapters optional
- add strict Action result JSON conversion, ADR 0009, and a dedicated real-adapter CI contract

## Contract boundaries

- adapter-private types remain inside the NoneBot child runtime
- unknown native segments use the portable `adapter` escape segment
- unsupported media uploads, ambiguous Satori user-ID direct sends, and unsupported conversation types fail explicitly or use `CallApi`

## Validation

- `uv run ruff check src tests scripts`
- `uv run mypy`
- `uv run --extra nonebot --extra onebot --extra satori pytest -q` (137 passed)
- `uv run python scripts/check_release.py`
- `uv build`
- isolated wheel install verification
- local Docker build plus `version`, `check`, and UID 10001 smoke tests