### PR TITLE
Publish v7 plugin and runtime developer kit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,10 +33,13 @@ jobs:
         working-directory: LiteyukiBot
         run: |
           uv run python scripts/check_release.py
-          uv run ruff check src tests scripts
+          uv run ruff check src tests scripts examples
           uv run mypy
           uv run pytest
           uv build
+          uv build --project examples/native-plugin --out-dir dist/examples
+          uv build --project examples/custom-runtime --out-dir dist/examples
+          uv run python scripts/run_developer_kit_install.py
       - name: Capture baseline
         working-directory: LiteyukiBot
         run: uv run python scripts/benchmark_v7.py --output benchmark.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   ordered reply intents into correlated protocol-v3 SendMessage Actions.
 - added structured OneBot v11/v12 and Satori event/message translation with
   exact reply routing, supported proactive sends, and strict JSON Action results.
+- added dependency-free native-plugin and custom-runtime conformance harnesses,
+  installable examples, and explicit lifecycle/single-reader authoring guidance.
+- bounded pre-stable protocol numbering at v5 and made v3 the direct iteration
+  target without an alpha backwards-compatibility guarantee.
 
 ## 7.0.0a1 - 2026-08-04
 

--- a/README.md
+++ b/README.md
@@ -76,3 +76,9 @@ uv build
 The architecture overview is documented in `docs/architecture/v7.md`; accepted
 v1 contracts are indexed in `docs/adr/README.md`; the v6 compatibility boundary
 is documented in `docs/migration-v6.md`.
+
+Plugin and runtime authors should start with the installable examples and their
+focused guides:
+
+- `examples/native-plugin` and `docs/development/native-plugins.md`;
+- `examples/custom-runtime` and `docs/development/custom-runtimes.md`.

--- a/docs/adr/0010-developer-kit-contracts.md
+++ b/docs/adr/0010-developer-kit-contracts.md
@@ -1,0 +1,68 @@
+# ADR 0010: Publish Developer Conformance Harnesses
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+The native plugin API and runtime protocols are documented, but third-party authors
+currently have to reconstruct internal application wiring to test them. Example
+code that only demonstrates model construction does not prove plugin discovery,
+lifecycle cleanup, authenticated runtime negotiation, or correlation behavior.
+
+The developer surface must remain smaller than the kernel. Adding a test
+framework, a second plugin host, or an in-memory protocol imitation would create
+new behavior instead of verifying the accepted contracts.
+
+## Decision
+
+`liteyukibot.testing` provides two dependency-free, single-use async context
+managers. It never imports pytest and is included in the normal distribution.
+
+`PluginTestHarness` runs one `PluginDefinition` through the real
+`PluginManager`, `EventBus`, `ServiceRegistry`, Action path, and managed-task
+lifecycle. It accepts a test root, plugin config, declared dependency values,
+and an optional Action executor. It exposes the loaded context, immutable
+recorded Actions, event publication, and service lookup. The default Action
+result is a correlated success. Multi-plugin dependency topology remains a
+kernel integration test and does not receive a second abstraction.
+
+The harness does not infer EventBus ownership. Plugins must retain and remove
+their subscriptions in their stop callback. The manager continues to own
+managed-task cancellation and removal of services provided by the plugin.
+
+`RuntimeTestHarness` runs one explicit `RuntimeSpec.command` through a real
+`RuntimeSupervisor` and loopback subprocess connection. It records
+child-originated Events and Actions, supplies correlated default success
+results, and exposes core-to-child Event and Action calls. Runtime state,
+negotiated protocol version, and capabilities are observable without exposing
+the mutable supervisor record.
+
+Every child runtime has exactly one physical receive pump. Work that may await
+`RuntimeClient.execute_action()` runs in separately tracked tasks so the receive
+pump can route its `ActionResponse`. Children acknowledge every Event, respond
+to every Action request, cancel and collect their work on Shutdown, and never
+implement their own reconnect loop. Restart policy belongs to the supervisor.
+
+Supervisor Event and Action dispatch reject non-positive timeouts before
+runtime lookup or transmission. Duplicate in-flight correlation IDs are
+rejected before pending state is changed. `RuntimeSpec` rejects empty command
+sequences and empty command arguments.
+
+The installable examples under `examples/native-plugin` and
+`examples/custom-runtime` use only public imports. Native entry-point metadata
+must resolve to a `PluginDefinition` whose manifest ID equals the entry-point
+name.
+
+## Consequences
+
+Authors can verify real lifecycle and wire behavior without depending on
+LiteyukiBot's internal test suite or adding a test dependency to production.
+The helpers intentionally favor conformance over isolated mocking, so custom
+runtime tests launch a real subprocess and native plugin tests exercise the real
+bounded EventBus.
+
+This decision does not add pytest fixtures, scaffolding commands, automatic
+dependency installation, multi-plugin simulation, a runtime handler framework,
+background protocol readers, automatic reconnect, hot reload, sandboxing,
+remote transport, or PyO3.

--- a/docs/adr/0011-pre-stable-protocol-policy.md
+++ b/docs/adr/0011-pre-stable-protocol-policy.md
@@ -1,0 +1,56 @@
+# ADR 0011: Bound Pre-stable Protocol Versioning
+
+- Status: Accepted
+- Date: 2026-08-09
+
+## Context
+
+v7 is in rapid alpha development. Treating every wire or schema correction as
+a permanent compatibility event would create artificial protocol versions such
+as v20 or v99 before the design has reached a stable release. It would also
+force the project to maintain experiments that have not been released as stable
+contracts.
+
+The current local runtime IPC version is v3. The repository still tests v1 and
+v2 peers because that code exists and remains inexpensive to exercise, but this
+must not be confused with a pre-stable compatibility promise.
+
+## Decision
+
+All v7 protocol contracts are explicitly unstable until the first stable v7
+release. During this period, wire messages, Event/Action schemas, capabilities,
+and their semantics may change without backwards-compatibility shims. Each
+change still requires updated models, tests, documentation, and migration notes
+where existing alpha users would otherwise be surprised.
+
+Protocol numbering is intentionally bounded:
+
+- v3 remains the default development protocol;
+- small or medium corrections, additions, removals, and breaking changes modify
+  v3 directly instead of incrementing the number;
+- v4 or v5 is reserved for a large cross-cutting redesign where retaining the
+  v3 identity would make wire direction, ownership, or negotiation materially
+  misleading;
+- no pre-stable protocol version may exceed v5;
+- version gaps, date-based protocol numbers, and cosmetic increments are not
+  used.
+
+Retaining compatibility with v1, v2, or an earlier v3 shape is optional during
+alpha. It is kept only when its implementation and testing cost remain low and
+it does not distort the intended architecture. Removing such compatibility is
+an ordinary reviewed change, not a major-version event.
+
+Before the first stable release, the project will select the stable wire and
+schema baselines, document their migration policy, and replace this alpha rule
+with an explicit long-term compatibility policy.
+
+## Consequences
+
+The version number communicates architectural generations rather than commit
+count. Fast iteration can correct contracts directly, while v4/v5 remain
+available if a genuinely large protocol redesign occurs.
+
+Accepted ADRs continue to record design intent and testable behavior, but their
+compatibility language does not override this pre-stable policy. Review still
+requires evidence and explicit documentation; instability is not permission for
+undocumented wire drift.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,8 +1,8 @@
 # LiteyukiBot v7 ADRs
 
-These accepted records freeze public versioned contracts. New behavior must
-either fit one of these records without changing its semantics or introduce a
-new, explicitly versioned decision.
+These accepted records define the current public contracts. During alpha,
+compatibility and version increments are governed by ADR 0011 rather than a
+stable-release guarantee.
 
 1. [Event and action contracts](0001-event-and-action-contracts.md)
 2. [Local runtime IPC protocol](0002-runtime-ipc-protocol-v1.md)
@@ -13,3 +13,5 @@ new, explicitly versioned decision.
 7. [Runtime IPC v3 and bidirectional Actions](0007-runtime-ipc-protocol-v3.md)
 8. [v6 runtime Event and reply integration](0008-v6-runtime-event-integration.md)
 9. [NoneBot OneBot and Satori adapter contracts](0009-nonebot-adapter-contracts.md)
+10. [Developer conformance harnesses](0010-developer-kit-contracts.md)
+11. [Pre-stable protocol versioning](0011-pre-stable-protocol-policy.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -29,6 +29,13 @@ entry point returns `PluginDefinition(manifest, setup)`. `setup(context)` is
 async and may return start/stop callbacks. Service contracts use `name@major`
 keys, one provider per key, and a startup dependency graph.
 
+The public `PluginTestHarness` composes the same manager, event bus, service
+registry, Action path, and managed tasks for single-plugin conformance tests.
+The public `RuntimeTestHarness` launches one real supervised subprocess for
+protocol conformance. Neither helper is a second production host or depends on
+a test framework. Installable examples and author guidance live under
+`examples/` and `docs/development/`.
+
 ## Events And Actions
 
 Runtime events become frozen Pydantic envelopes. The bounded bus preserves FIFO
@@ -79,16 +86,20 @@ Channel, shared-memory object transport, notices, requests, or adapter objects.
 
 ## Versioned Contracts
 
-The public v1 contracts remain frozen in the accepted
+The current public contracts are recorded in the accepted
 [architecture decision records](../adr/README.md): event/action schemas, local
 runtime IPC, native plugins, configuration precedence, and error taxonomy.
-Changes to these surfaces require an explicit versioned decision rather than an
-unannounced compatible-looking edit.
+Changes to these surfaces require explicit models, tests, and documentation
+rather than unannounced wire drift.
 
 ADR 0005 adds the negotiated protocol-v2 event direction, and ADR 0007 adds the
 protocol-v3 Action direction. ADR 0008 defines their v6 message-plugin mapping,
-and ADR 0009 defines the NoneBot OneBot/Satori adapter boundary, while ADR 0002
-remains the frozen v1 contract.
+ADR 0009 defines the NoneBot OneBot/Satori adapter boundary, and ADR 0010
+defines the developer conformance helpers. ADR 0011 governs rapid pre-stable
+iteration: v3 remains the default, small and medium breaking changes revise it
+directly, and only a cross-cutting redesign may consume v4 or v5. No alpha
+protocol version may exceed v5. Existing v1/v2 support is tested but is not a
+compatibility promise before the first stable v7 release.
 
 ## Operations
 

--- a/docs/development/custom-runtimes.md
+++ b/docs/development/custom-runtimes.md
@@ -1,0 +1,76 @@
+# Custom runtime development
+
+Custom runtimes are supervised local subprocesses. Configure an explicit
+command; the supervisor injects authenticated loopback connection values through
+`LITEYUKI_RUNTIME_HOST`, `LITEYUKI_RUNTIME_PORT`, `LITEYUKI_RUNTIME_TOKEN`,
+`LITEYUKI_RUNTIME_ID`, `LITEYUKI_RUNTIME_KIND`, and
+`LITEYUKI_RUNTIME_RESTART_COUNT`.
+
+```toml
+[runtimes.example]
+kind = "custom"
+command = ["liteyuki-example-runtime"]
+
+[runtimes.example.options]
+mode = "example"
+```
+
+The complete protocol-v3 child is in
+[`examples/custom-runtime`](../../examples/custom-runtime). It uses
+`RuntimeClient.from_environment("custom")`, calls `connect()`, then declares
+capabilities with `ready()`.
+
+## Single reader rule
+
+Exactly one coroutine calls `RuntimeClient.receive()`. `execute_action()` sends
+an Action request and waits on a Future; it does not read the socket. Therefore
+an Event handler that calls `execute_action()` must run in a separate tracked
+task while the receive pump continues routing Action responses. Calling and
+awaiting it inline in the receive loop deadlocks until timeout.
+
+The host must also:
+
+- bound the number of handler tasks and return `overloaded` when full;
+- send exactly one `EventAccepted` for each Event message;
+- send exactly one `ActionResponse` for each Action request;
+- validate payloads before acting on them;
+- cancel and await all owned tasks on Shutdown;
+- close the client in `finally`;
+- never reconnect itself, because restart limits and backoff belong to the
+  supervisor.
+
+Protocol v2/v3 Event receipt requires `runtime.events.receive`. Child-originated
+Actions require protocol v3 and `runtime.actions.send`. Capability names and
+protocol versions are negotiated exactly rather than inferred.
+
+The protocol is pre-stable. v3 remains the normal development target and may
+change without backwards-compatibility shims during alpha. v4/v5 are reserved
+for large protocol redesigns, and no pre-stable version will exceed v5. Pin the
+LiteyukiBot alpha version used to build and test an external runtime.
+
+## Testing
+
+`RuntimeTestHarness` launches the real command and protocol connection:
+
+```python
+from liteyukibot.runtime import RuntimeSpec
+from liteyukibot.testing import RuntimeTestHarness
+
+
+async def verify(event_payload) -> None:
+    spec = RuntimeSpec(
+        id="example",
+        kind="custom",
+        command=("liteyuki-example-runtime",),
+    )
+    async with RuntimeTestHarness(spec) as harness:
+        accepted = await harness.dispatch_event(event_payload)
+        assert accepted.status == "accepted"
+        assert len(harness.child_actions) == 1
+```
+
+The harness records child-originated Event and Action payloads before invoking
+optional sinks. Without custom sinks it accepts Events and returns a successful
+Action result. `dispatch_event()` and `execute_action()` generate correlation
+IDs when none are supplied and reject non-positive timeouts through the real
+supervisor contract.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -1,0 +1,68 @@
+# Native plugin development
+
+Native v7 plugins are trusted packages loaded into the core process. Publish a
+`PluginDefinition` through the `liteyukibot.plugins` entry-point group; the
+entry-point name and `PluginManifest.id` must be identical.
+
+```toml
+[project.entry-points."liteyukibot.plugins"]
+"example.echo" = "liteyukibot_example_plugin:plugin"
+```
+
+The complete minimal package is in [`examples/native-plugin`](../../examples/native-plugin).
+Its setup function subscribes an async handler and returns a stop callback that
+removes that subscription. Event handlers return protocol-neutral
+`HandlerResult` values containing Actions; adapter objects do not belong in a
+native plugin.
+
+Enable an installed plugin explicitly:
+
+```toml
+[plugins]
+enabled = ["example.echo"]
+
+[plugins.config."example.echo"]
+prefix = "answer: "
+```
+
+Use only the ownership surfaces supplied by `PluginContext`:
+
+- configuration is read-only;
+- services must be declared in the manifest before they are provided or
+  required;
+- background coroutines are started through `context.tasks.start()`;
+- private data/cache paths exist only when `storage = "private"`;
+- EventBus subscriptions are removed by the plugin's stop callback;
+- replies and API calls use frozen models from `liteyukibot.events`.
+
+## Testing
+
+`PluginTestHarness` uses the production lifecycle and EventBus without importing
+pytest:
+
+```python
+from pathlib import Path
+
+from liteyukibot.testing import PluginTestHarness
+from liteyukibot_example_plugin import plugin
+
+
+async def verify(event) -> None:
+    async with PluginTestHarness(
+        plugin,
+        root=Path(".test-data"),
+        config={"prefix": "answer: "},
+    ) as harness:
+        result = await harness.publish(event)
+        assert result.status == "processed"
+        assert len(harness.recorded_actions) == 1
+```
+
+Dependency values are supplied with `dependencies={ServiceKey(...): value}`.
+Use `require_service()` to inspect a plugin's declared output. An optional
+`action_executor` can return real success/failure results; otherwise the harness
+records the Action and returns a correlated success.
+
+The harness is single-use and intentionally tests one plugin. Use
+`LiteyukiApp` or the kernel components directly for multi-plugin topology and
+full configuration tests.

--- a/examples/custom-runtime/README.md
+++ b/examples/custom-runtime/README.md
@@ -1,0 +1,10 @@
+# Custom runtime example
+
+This package is a protocol-v3 child runtime. `RuntimeSupervisor` supplies its
+connection environment and owns restart policy. The child keeps one receive
+pump and runs Event/Action work in bounded tasks so correlated Action responses
+continue to be routed while handlers are awaiting them.
+
+```bash
+uv build
+```

--- a/examples/custom-runtime/pyproject.toml
+++ b/examples/custom-runtime/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "liteyukibot-example-runtime"
+version = "0.1.0"
+description = "Minimal supervised LiteyukiBot v7 custom runtime."
+readme = "README.md"
+requires-python = ">=3.14"
+dependencies = [
+    "liteyukibot-v7>=7.0.0a1,<8",
+]
+
+[project.scripts]
+liteyuki-example-runtime = "liteyukibot_example_runtime:main"
+
+[build-system]
+requires = ["uv_build>=0.11.32,<0.12"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "liteyukibot_example_runtime"

--- a/examples/custom-runtime/src/liteyukibot_example_runtime/__init__.py
+++ b/examples/custom-runtime/src/liteyukibot_example_runtime/__init__.py
@@ -1,0 +1,141 @@
+"""Minimal supervised LiteyukiBot v7 custom runtime."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any, Literal
+
+from pydantic import ValidationError
+
+from liteyukibot.events import ActionEnvelope, EventEnvelope, Message, Segment, SendMessage
+from liteyukibot.runtime import (
+    ActionRequest,
+    ActionResponse,
+    EventAccepted,
+    EventMessage,
+    RuntimeClient,
+    Shutdown,
+)
+
+MAX_IN_FLIGHT = 32
+
+
+async def _handle_event(client: RuntimeClient, message: EventMessage) -> None:
+    status: Literal["accepted", "overloaded", "invalid"] = "accepted"
+    detail: str | None = None
+    try:
+        event = EventEnvelope.model_validate(message.payload)
+    except ValidationError as error:
+        status = "invalid"
+        detail = str(error)
+    else:
+        try:
+            if event.message is not None:
+                reply = ActionEnvelope(
+                    event_id=event.id,
+                    runtime_id=event.runtime_id,
+                    bot_id=event.bot_id,
+                    action=SendMessage(
+                        message=Message(
+                            segments=(
+                                Segment(
+                                    type="text",
+                                    data={"text": "runtime: " + event.message.plain_text},
+                                ),
+                            )
+                        ),
+                        conversation=event.conversation,
+                        reply_token=event.reply_token,
+                    ),
+                )
+                result = await client.execute_action(
+                    reply.action_id,
+                    reply.model_dump(mode="json"),
+                )
+                if not result.ok:
+                    status = "invalid"
+                    detail = result.error or "core rejected the reply Action"
+        except Exception as error:
+            status = "invalid"
+            detail = f"{type(error).__name__}: {error}"
+
+    await client.send(
+        EventAccepted(
+            correlation_id=message.correlation_id,
+            status=status,
+            detail=detail,
+        )
+    )
+
+
+async def _handle_action(client: RuntimeClient, message: ActionRequest) -> None:
+    await client.send(
+        ActionResponse(
+            correlation_id=message.correlation_id,
+            ok=True,
+            data={"echo": message.payload},
+        )
+    )
+
+
+async def run() -> None:
+    client = RuntimeClient.from_environment("custom")
+    tasks: set[asyncio.Task[None]] = set()
+
+    def task_done(task: asyncio.Task[None]) -> None:
+        tasks.discard(task)
+        if not task.cancelled():
+            task.exception()
+
+    def spawn(awaitable: Coroutine[Any, Any, None], *, name: str) -> None:
+        task = asyncio.create_task(awaitable, name=name)
+        tasks.add(task)
+        task.add_done_callback(task_done)
+
+    try:
+        await client.connect()
+        await client.ready(("runtime.events.receive", "runtime.actions.send"))
+        while True:
+            message = await client.receive()
+            if isinstance(message, Shutdown):
+                break
+            if isinstance(message, EventMessage):
+                if len(tasks) >= MAX_IN_FLIGHT:
+                    await client.send(
+                        EventAccepted(
+                            correlation_id=message.correlation_id,
+                            status="overloaded",
+                        )
+                    )
+                else:
+                    spawn(
+                        _handle_event(client, message),
+                        name=f"event:{message.correlation_id}",
+                    )
+            elif isinstance(message, ActionRequest):
+                if len(tasks) >= MAX_IN_FLIGHT:
+                    await client.send(
+                        ActionResponse(
+                            correlation_id=message.correlation_id,
+                            ok=False,
+                            error="runtime is overloaded",
+                        )
+                    )
+                else:
+                    spawn(
+                        _handle_action(client, message),
+                        name=f"action:{message.correlation_id}",
+                    )
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await client.close()
+
+
+def main() -> None:
+    asyncio.run(run())
+
+
+__all__ = ["main", "run"]

--- a/examples/custom-runtime/src/liteyukibot_example_runtime/__main__.py
+++ b/examples/custom-runtime/src/liteyukibot_example_runtime/__main__.py
@@ -1,0 +1,3 @@
+from . import main
+
+main()

--- a/examples/native-plugin/README.md
+++ b/examples/native-plugin/README.md
@@ -1,0 +1,10 @@
+# Native plugin example
+
+This package exposes `example.echo` through the `liteyukibot.plugins` entry
+point. Its handler replies to message events through protocol-neutral v7 Event
+and Action models. The plugin explicitly removes its EventBus subscription in
+the stop callback.
+
+```bash
+uv build
+```

--- a/examples/native-plugin/pyproject.toml
+++ b/examples/native-plugin/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "liteyukibot-example-plugin"
+version = "0.1.0"
+description = "Minimal installable LiteyukiBot v7 native plugin."
+readme = "README.md"
+requires-python = ">=3.14"
+dependencies = [
+    "liteyukibot-v7>=7.0.0a1,<8",
+]
+
+[project.entry-points."liteyukibot.plugins"]
+"example.echo" = "liteyukibot_example_plugin:plugin"
+
+[build-system]
+requires = ["uv_build>=0.11.32,<0.12"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "liteyukibot_example_plugin"

--- a/examples/native-plugin/src/liteyukibot_example_plugin/__init__.py
+++ b/examples/native-plugin/src/liteyukibot_example_plugin/__init__.py
@@ -1,0 +1,55 @@
+"""Minimal installable LiteyukiBot v7 native plugin."""
+
+from __future__ import annotations
+
+from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
+from liteyukibot.events import (
+    ActionEnvelope,
+    EventEnvelope,
+    HandlerResult,
+    Message,
+    Segment,
+    SendMessage,
+)
+
+
+async def setup(context: PluginContext) -> PluginHandle:
+    prefix = context.config.get("prefix", "echo: ")
+    if not isinstance(prefix, str):
+        raise TypeError("example.echo config prefix must be a string")
+
+    async def echo(event: EventEnvelope) -> HandlerResult | None:
+        if event.message is None:
+            return None
+        reply = Message(segments=(Segment(type="text", data={"text": prefix + event.message.plain_text}),))
+        action = ActionEnvelope(
+            event_id=event.id,
+            runtime_id=event.runtime_id,
+            bot_id=event.bot_id,
+            action=SendMessage(
+                message=reply,
+                conversation=event.conversation,
+                reply_token=event.reply_token,
+            ),
+        )
+        return HandlerResult(actions=(action,))
+
+    subscription = context.events.subscribe(echo, name="example.echo")
+
+    async def stop() -> None:
+        context.events.unsubscribe(subscription)
+
+    return PluginHandle(stop=stop)
+
+
+plugin = PluginDefinition(
+    manifest=PluginManifest(
+        id="example.echo",
+        name="Echo example",
+        version="0.1.0",
+        storage="private",
+    ),
+    setup=setup,
+)
+
+__all__ = ["plugin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ asyncio_mode = "auto"
 [tool.ruff]
 line-length = 120
 target-version = "py314"
-src = ["src", "tests", "scripts"]
+src = ["src", "tests", "scripts", "examples"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "ASYNC"]
@@ -67,4 +67,4 @@ select = ["E", "F", "I", "UP", "B", "ASYNC"]
 [tool.mypy]
 python_version = "3.14"
 strict = true
-files = ["src", "tests", "scripts"]
+files = ["src", "tests", "scripts", "examples"]

--- a/scripts/run_developer_kit_install.py
+++ b/scripts/run_developer_kit_install.py
@@ -1,0 +1,39 @@
+"""Run the developer-kit verifier with the wheels built in this checkout."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _one_wheel(directory: Path, distribution: str) -> Path:
+    matches = tuple(directory.glob(f"{distribution}-*-py3-none-any.whl"))
+    if len(matches) != 1:
+        raise RuntimeError(
+            f"expected one {distribution} wheel in {directory}, found {len(matches)}"
+        )
+    return matches[0].resolve()
+
+
+def main() -> int:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv executable was not found")
+    wheels = (
+        _one_wheel(ROOT / "dist", "liteyukibot_v7"),
+        _one_wheel(ROOT / "dist" / "examples", "liteyukibot_example_plugin"),
+        _one_wheel(ROOT / "dist" / "examples", "liteyukibot_example_runtime"),
+    )
+    command = [uv, "run", "--no-project", "--python", "3.14"]
+    for wheel in wheels:
+        command.extend(("--with", str(wheel)))
+    command.extend(("python", str(ROOT / "scripts" / "verify_developer_kit_install.py")))
+    subprocess.run(command, cwd=ROOT, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_developer_kit_install.py
+++ b/scripts/verify_developer_kit_install.py
@@ -1,0 +1,113 @@
+"""Verify developer-kit wheels without importing the source checkout."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.metadata
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import liteyukibot
+from liteyukibot import PluginDefinition
+from liteyukibot.events import (
+    ActorRef,
+    ConversationRef,
+    EventEnvelope,
+    Message,
+    Segment,
+)
+from liteyukibot.runtime import RuntimeSpec
+from liteyukibot.testing import PluginTestHarness, RuntimeTestHarness
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src"
+IMPORTED_LITEYUKIBOT = Path(liteyukibot.__file__).resolve()
+PY_TYPED_MARKER = IMPORTED_LITEYUKIBOT.with_name("py.typed")
+HAS_PY_TYPED = PY_TYPED_MARKER.is_file()
+
+
+def _event() -> EventEnvelope:
+    return EventEnvelope(
+        runtime_id="adapter-runtime",
+        adapter="example",
+        bot_id="bot-1",
+        type="message",
+        conversation=ConversationRef(id="conversation-1", type="group"),
+        actor=ActorRef(id="user-1"),
+        message=Message(segments=(Segment(type="text", data={"text": "installed"}),)),
+        reply_token="reply-1",
+    )
+
+
+def _installed_plugin() -> PluginDefinition:
+    matches = tuple(
+        item
+        for item in importlib.metadata.entry_points(group="liteyukibot.plugins")
+        if item.name == "example.echo"
+    )
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one example.echo entry point, found {len(matches)}")
+    candidate: Any = matches[0].load()
+    if not isinstance(candidate, PluginDefinition):
+        raise TypeError("example.echo did not resolve to PluginDefinition")
+    if candidate.manifest.id != matches[0].name:
+        raise RuntimeError("example.echo entry-point name and manifest id differ")
+    return candidate
+
+
+async def verify() -> dict[str, Any]:
+    if IMPORTED_LITEYUKIBOT.is_relative_to(SOURCE_ROOT):
+        raise RuntimeError(
+            f"liteyukibot imported from source checkout: {IMPORTED_LITEYUKIBOT}"
+        )
+    if not HAS_PY_TYPED:
+        raise RuntimeError(f"installed package is missing py.typed: {PY_TYPED_MARKER}")
+
+    with tempfile.TemporaryDirectory() as directory:
+        async with PluginTestHarness(
+            _installed_plugin(),
+            root=Path(directory),
+            config={"prefix": "wheel: "},
+        ) as plugin_harness:
+            dispatch = await plugin_harness.publish(_event())
+            if dispatch.status != "processed" or len(plugin_harness.recorded_actions) != 1:
+                raise RuntimeError("installed plugin did not process the test Event")
+
+        command = shutil.which("liteyuki-example-runtime")
+        if command is None:
+            raise RuntimeError("installed custom runtime console script was not found")
+        spec = RuntimeSpec(
+            id="installed-runtime",
+            kind="custom",
+            command=(command,),
+            ready_timeout=5,
+            heartbeat_interval=0.05,
+            stale_after=1,
+            shutdown_timeout=2,
+            restart_limit=1,
+        )
+        async with RuntimeTestHarness(spec) as runtime_harness:
+            accepted = await runtime_harness.dispatch_event(
+                _event().model_dump(mode="json"),
+                timeout_seconds=2,
+            )
+            if accepted.status != "accepted" or len(runtime_harness.child_actions) != 1:
+                raise RuntimeError("installed runtime did not complete the Event/Action round trip")
+
+    return {
+        "liteyukibot": str(IMPORTED_LITEYUKIBOT),
+        "plugin": "example.echo",
+        "py_typed": str(PY_TYPED_MARKER),
+        "runtime": "installed-runtime",
+    }
+
+
+def main() -> int:
+    print(json.dumps(asyncio.run(verify()), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/liteyukibot/__init__.py
+++ b/src/liteyukibot/__init__.py
@@ -2,7 +2,14 @@
 
 from ._version import __version__
 from .app import LiteyukiApp
-from .plugins import PluginContext, PluginDefinition, PluginHandle, PluginManifest
+from .plugins import (
+    PluginContext,
+    PluginDefinition,
+    PluginHandle,
+    PluginManifest,
+    PluginPaths,
+    PluginServices,
+)
 from .services import ServiceKey, ServiceRegistry, ServiceRequirement
 
 __all__ = [
@@ -11,6 +18,8 @@ __all__ = [
     "PluginDefinition",
     "PluginHandle",
     "PluginManifest",
+    "PluginPaths",
+    "PluginServices",
     "ServiceKey",
     "ServiceRegistry",
     "ServiceRequirement",

--- a/src/liteyukibot/runtime/__init__.py
+++ b/src/liteyukibot/runtime/__init__.py
@@ -9,17 +9,27 @@ from .protocol import (
     ActionResponse,
     ConfigMessage,
     ErrorMessage,
+    EventAccepted,
     EventMessage,
     Heartbeat,
     Hello,
+    JsonValue,
     ProtocolVersion,
     Ready,
     Shutdown,
     Welcome,
+    WireMessage,
     read_message,
     write_message,
 )
-from .supervisor import ActionSinkResult, RuntimeSpec, RuntimeState, RuntimeSupervisor
+from .supervisor import (
+    ActionSink,
+    ActionSinkResult,
+    EventSink,
+    RuntimeSpec,
+    RuntimeState,
+    RuntimeSupervisor,
+)
 
 __all__ = [
     "MAX_FRAME_SIZE",
@@ -27,12 +37,16 @@ __all__ = [
     "SUPPORTED_PROTOCOL_VERSIONS",
     "ActionRequest",
     "ActionResponse",
+    "ActionSink",
     "ActionSinkResult",
     "ConfigMessage",
     "ErrorMessage",
+    "EventAccepted",
     "EventMessage",
+    "EventSink",
     "Heartbeat",
     "Hello",
+    "JsonValue",
     "ProtocolVersion",
     "Ready",
     "RuntimeClient",
@@ -41,6 +55,7 @@ __all__ = [
     "RuntimeSupervisor",
     "Shutdown",
     "Welcome",
+    "WireMessage",
     "read_message",
     "write_message",
 ]

--- a/src/liteyukibot/runtime/supervisor.py
+++ b/src/liteyukibot/runtime/supervisor.py
@@ -82,6 +82,10 @@ class RuntimeSpec:
             raise ValueError("runtime lifecycle timeouts must be positive")
         if self.heartbeat_interval <= 0 or self.stale_after <= self.heartbeat_interval:
             raise ValueError("runtime stale_after must exceed its positive heartbeat interval")
+        if self.command is not None and (
+            not self.command or any(not part for part in self.command)
+        ):
+            raise ValueError("runtime command arguments must not be empty")
 
 
 @dataclass(slots=True)
@@ -412,9 +416,13 @@ class RuntimeSupervisor:
         payload: Mapping[str, Any],
         timeout_seconds: float = 30.0,
     ) -> ActionResponse:
+        if timeout_seconds <= 0:
+            raise ValueError("runtime action timeout must be positive")
         record = self.records[runtime_id]
         if record.state is not RuntimeState.READY:
             raise RuntimeError(f"runtime {runtime_id} is not ready")
+        if correlation_id in record.pending_actions:
+            raise ValueError(f"duplicate action correlation id: {correlation_id}")
         future: asyncio.Future[ActionResponse] = asyncio.get_running_loop().create_future()
         record.pending_actions[correlation_id] = future
         try:
@@ -434,6 +442,8 @@ class RuntimeSupervisor:
         payload: Mapping[str, Any],
         timeout_seconds: float = 30.0,
     ) -> EventAccepted:
+        if timeout_seconds <= 0:
+            raise ValueError("runtime event timeout must be positive")
         record = self.records[runtime_id]
         if record.state is not RuntimeState.READY:
             raise RuntimeError(f"runtime {runtime_id} is not ready")

--- a/src/liteyukibot/testing.py
+++ b/src/liteyukibot/testing.py
@@ -1,0 +1,282 @@
+"""Public conformance harnesses for plugins and child runtimes."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from .events import (
+    ActionEnvelope,
+    ActionExecutor,
+    ActionResult,
+    DispatchResult,
+    EventBus,
+    EventEnvelope,
+)
+from .logging import get_logger
+from .plugins import PluginContext, PluginDefinition, PluginManager
+from .runtime import (
+    ActionResponse,
+    EventAccepted,
+    ProtocolVersion,
+    RuntimeSpec,
+    RuntimeState,
+    RuntimeSupervisor,
+)
+from .runtime.protocol import JsonValue, json_mapping
+from .runtime.supervisor import ActionSink, ActionSinkResult, EventSink
+from .services import ServiceKey, ServiceRegistry
+
+
+class _RecordingActionService:
+    def __init__(self, executor: ActionExecutor | None) -> None:
+        self._executor = executor
+        self.recorded: list[ActionEnvelope] = []
+
+    async def execute(self, action: ActionEnvelope) -> ActionResult:
+        self.recorded.append(action)
+        if self._executor is None:
+            return ActionResult(action_id=action.action_id, success=True)
+        result = self._executor(action)
+        if inspect.isawaitable(result):
+            result = await result
+        if not isinstance(result, ActionResult):
+            raise TypeError(f"expected ActionResult, got {type(result).__name__}")
+        if result.action_id != action.action_id:
+            raise ValueError("action result correlation id does not match the action")
+        return result
+
+
+class PluginTestHarness:
+    """Run one native plugin against the real v7 lifecycle and event bus."""
+
+    def __init__(
+        self,
+        definition: PluginDefinition,
+        *,
+        root: Path,
+        config: Mapping[str, Any] | None = None,
+        dependencies: Mapping[ServiceKey, Any] | None = None,
+        action_executor: ActionExecutor | None = None,
+    ) -> None:
+        self.definition = definition
+        self.root = Path(root)
+        self._services = ServiceRegistry()
+        for key, value in (dependencies or {}).items():
+            self._services.provide(key, value, provider="liteyukibot.testing")
+        self._actions = _RecordingActionService(action_executor)
+        self._events = EventBus(
+            action_executor=self._actions.execute,
+            logger=get_logger(component="plugin-test"),
+        )
+        self._manager = PluginManager(
+            services=self._services,
+            events=self._events,
+            actions=self._actions,
+            logger=get_logger(component="plugin-test"),
+            data_dir=self.root / "data",
+            cache_dir=self.root / "cache",
+        )
+        self._config = dict(config or {})
+        self._started = False
+        self._closed = False
+
+    @property
+    def context(self) -> PluginContext:
+        loaded = self._manager.loaded.get(self.definition.manifest.id)
+        if loaded is None or not self._started:
+            raise RuntimeError("plugin test harness is not started")
+        return loaded.context
+
+    @property
+    def recorded_actions(self) -> tuple[ActionEnvelope, ...]:
+        return tuple(self._actions.recorded)
+
+    def require_service(self, key: ServiceKey) -> Any:
+        return self._services.require(key)
+
+    async def publish(self, event: EventEnvelope) -> DispatchResult:
+        if not self._started:
+            raise RuntimeError("plugin test harness is not started")
+        return await self._events.publish(event)
+
+    async def start(self) -> None:
+        if self._closed:
+            raise RuntimeError("plugin test harness is single-use")
+        if self._started:
+            raise RuntimeError("plugin test harness is already started")
+        await self._events.start()
+        try:
+            await self._manager.setup(
+                {self.definition.manifest.id: self.definition},
+                {self.definition.manifest.id: self._config},
+            )
+            await self._manager.start()
+        except BaseException:
+            try:
+                if self._manager.loaded:
+                    await self._manager.stop()
+            finally:
+                await self._events.aclose()
+                self._closed = True
+            raise
+        self._started = True
+
+    async def stop(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if not self._started:
+            await self._events.aclose()
+            return
+        self._started = False
+        errors: list[BaseException] = []
+        try:
+            await self._manager.stop()
+        except BaseException as error:
+            errors.append(error)
+        try:
+            await self._events.aclose()
+        except BaseException as error:
+            errors.append(error)
+        if errors:
+            raise BaseExceptionGroup("plugin test harness shutdown failed", errors)
+
+    async def __aenter__(self) -> PluginTestHarness:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        await self.stop()
+
+
+class RuntimeTestHarness:
+    """Run one custom child against a real RuntimeSupervisor."""
+
+    def __init__(
+        self,
+        spec: RuntimeSpec,
+        *,
+        event_sink: EventSink | None = None,
+        action_sink: ActionSink | None = None,
+    ) -> None:
+        if spec.command is None or not spec.command:
+            raise ValueError("runtime test harness requires an explicit child command")
+        self.spec = spec
+        self._event_sink = event_sink
+        self._action_sink = action_sink
+        self._child_events: list[tuple[str, dict[str, JsonValue]]] = []
+        self._child_actions: list[tuple[str, dict[str, JsonValue]]] = []
+        self._supervisor = RuntimeSupervisor(
+            logger=get_logger(component="runtime-test"),
+            event_sink=self._record_event,
+            action_sink=self._record_action,
+        )
+        self._supervisor.add(spec)
+        self._started = False
+        self._closed = False
+
+    @property
+    def state(self) -> RuntimeState:
+        return self._supervisor.records[self.spec.id].state
+
+    @property
+    def protocol_version(self) -> ProtocolVersion | None:
+        return self._supervisor.records[self.spec.id].protocol_version
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        return self._supervisor.records[self.spec.id].capabilities
+
+    @property
+    def child_events(self) -> tuple[tuple[str, Mapping[str, JsonValue]], ...]:
+        return tuple(
+            (runtime_id, json_mapping(payload))
+            for runtime_id, payload in self._child_events
+        )
+
+    @property
+    def child_actions(self) -> tuple[tuple[str, Mapping[str, JsonValue]], ...]:
+        return tuple(
+            (runtime_id, json_mapping(payload))
+            for runtime_id, payload in self._child_actions
+        )
+
+    async def start(self) -> None:
+        if self._closed:
+            raise RuntimeError("runtime test harness is single-use")
+        if self._started:
+            raise RuntimeError("runtime test harness is already started")
+        try:
+            await self._supervisor.start()
+        except BaseException:
+            self._closed = True
+            raise
+        self._started = True
+
+    async def stop(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._started:
+            self._started = False
+            await self._supervisor.stop()
+
+    async def dispatch_event(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        correlation_id: str | None = None,
+        timeout_seconds: float = 5.0,
+    ) -> EventAccepted:
+        if not self._started:
+            raise RuntimeError("runtime test harness is not started")
+        return await self._supervisor.dispatch_event(
+            self.spec.id,
+            correlation_id or str(uuid4()),
+            payload,
+            timeout_seconds,
+        )
+
+    async def execute_action(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        correlation_id: str | None = None,
+        timeout_seconds: float = 5.0,
+    ) -> ActionResponse:
+        if not self._started:
+            raise RuntimeError("runtime test harness is not started")
+        return await self._supervisor.execute_action(
+            self.spec.id,
+            correlation_id or str(uuid4()),
+            payload,
+            timeout_seconds,
+        )
+
+    async def _record_event(self, runtime_id: str, payload: dict[str, JsonValue]) -> str:
+        self._child_events.append((runtime_id, json_mapping(payload)))
+        if self._event_sink is None:
+            return "accepted"
+        return await self._event_sink(runtime_id, payload)
+
+    async def _record_action(
+        self, runtime_id: str, payload: dict[str, JsonValue]
+    ) -> ActionSinkResult:
+        self._child_actions.append((runtime_id, json_mapping(payload)))
+        if self._action_sink is None:
+            return ActionSinkResult(ok=True, data={"recorded": True})
+        return await self._action_sink(runtime_id, payload)
+
+    async def __aenter__(self) -> RuntimeTestHarness:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        await self.stop()
+
+
+__all__ = ["PluginTestHarness", "RuntimeTestHarness"]

--- a/tests/test_developer_kit.py
+++ b/tests/test_developer_kit.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from liteyukibot import (
+    PluginContext,
+    PluginDefinition,
+    PluginHandle,
+    PluginManifest,
+    PluginPaths,
+    PluginServices,
+    ServiceKey,
+    ServiceRequirement,
+)
+from liteyukibot.events import (
+    ActionEnvelope,
+    ActorRef,
+    ConversationRef,
+    EventEnvelope,
+    Message,
+    Segment,
+    SendMessage,
+)
+from liteyukibot.exceptions import PluginError, ServiceError
+from liteyukibot.runtime import EventAccepted, RuntimeSpec, RuntimeState
+from liteyukibot.testing import PluginTestHarness, RuntimeTestHarness
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_SOURCE = ROOT / "examples" / "native-plugin" / "src"
+RUNTIME_SOURCE = ROOT / "examples" / "custom-runtime" / "src"
+
+
+def _event(text: str = "hello") -> EventEnvelope:
+    return EventEnvelope(
+        id="event-1",
+        runtime_id="adapter-runtime",
+        adapter="example",
+        bot_id="bot-1",
+        type="message",
+        conversation=ConversationRef(id="conversation-1", type="group"),
+        actor=ActorRef(id="user-1"),
+        message=Message(segments=(Segment(type="text", data={"text": text}),)),
+        reply_token="reply-1",
+    )
+
+
+def _load_example_plugin(monkeypatch: pytest.MonkeyPatch) -> PluginDefinition:
+    monkeypatch.syspath_prepend(str(PLUGIN_SOURCE))
+    sys.modules.pop("liteyukibot_example_plugin", None)
+    module = importlib.import_module("liteyukibot_example_plugin")
+    definition = module.plugin
+    assert isinstance(definition, PluginDefinition)
+    return definition
+
+
+@pytest.mark.asyncio
+async def test_native_plugin_example_uses_real_harness(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    harness = PluginTestHarness(
+        _load_example_plugin(monkeypatch),
+        root=tmp_path,
+        config={"prefix": "answer: "},
+    )
+
+    async with harness:
+        context = harness.context
+        assert isinstance(context.paths, PluginPaths)
+        assert context.paths.data == tmp_path / "data" / "plugins" / "example.echo"
+        assert context.paths.cache == tmp_path / "cache" / "plugins" / "example.echo"
+        assert isinstance(context.services, PluginServices)
+        with pytest.raises(TypeError):
+            cast(dict[str, Any], context.config)["prefix"] = "changed"
+
+        result = await harness.publish(_event())
+        assert result.status == "processed"
+        assert result.handlers_called == 1
+        assert result.failures == ()
+        assert len(harness.recorded_actions) == 1
+        sent = cast(SendMessage, harness.recorded_actions[0].action)
+        assert sent.message.plain_text == "answer: hello"
+
+        direct = ActionEnvelope(
+            runtime_id="adapter-runtime",
+            bot_id="bot-1",
+            action=SendMessage(
+                conversation=ConversationRef(id="conversation-1"),
+                message=Message(segments=(Segment(type="text", data={"text": "direct"}),)),
+            ),
+        )
+        direct_result = await context.actions.execute(direct)
+        assert direct_result.success is True
+        assert harness.recorded_actions[-1] == direct
+
+    assert context.events.closed is True
+    await harness.stop()
+    with pytest.raises(RuntimeError, match="single-use"):
+        await harness.start()
+
+
+@pytest.mark.asyncio
+async def test_plugin_harness_exercises_services_tasks_and_lifecycle(tmp_path: Path) -> None:
+    dependency = ServiceKey("example.dependency")
+    provided = ServiceKey("example.provided")
+    worker_started = asyncio.Event()
+    cancelled = asyncio.Event()
+    lifecycle: list[str] = []
+
+    async def worker() -> None:
+        worker_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    async def setup(context: PluginContext) -> PluginHandle:
+        lifecycle.append("setup")
+        assert context.services.require(dependency) == "stub"
+        context.services.provide(provided, "value")
+        context.tasks.start(worker(), name="worker")
+
+        async def start() -> None:
+            lifecycle.append("start")
+
+        async def stop() -> None:
+            lifecycle.append("stop")
+
+        return PluginHandle(start=start, stop=stop)
+
+    definition = PluginDefinition(
+        manifest=PluginManifest(
+            id="example.services",
+            name="Services",
+            version="1.0.0",
+            provides=(provided,),
+            requires=(ServiceRequirement(dependency),),
+        ),
+        setup=setup,
+    )
+    harness = PluginTestHarness(
+        definition,
+        root=tmp_path,
+        dependencies={dependency: "stub"},
+    )
+
+    async with harness:
+        await worker_started.wait()
+        assert harness.require_service(provided) == "value"
+        assert lifecycle == ["setup", "start"]
+
+    assert lifecycle == ["setup", "start", "stop"]
+    assert cancelled.is_set()
+    assert harness.require_service(dependency) == "stub"
+    with pytest.raises(ServiceError, match="unavailable"):
+        harness.require_service(provided)
+
+
+@pytest.mark.asyncio
+async def test_plugin_harness_cleans_up_failed_setup(tmp_path: Path) -> None:
+    provided = ServiceKey("example.failed")
+    worker_started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def worker() -> None:
+        worker_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    async def setup(context: PluginContext) -> PluginHandle:
+        context.services.provide(provided, object())
+        context.tasks.start(worker(), name="worker")
+        await worker_started.wait()
+        raise RuntimeError("setup failed")
+
+    harness = PluginTestHarness(
+        PluginDefinition(
+            manifest=PluginManifest(
+                id="example.failed",
+                name="Failed",
+                version="1.0.0",
+                provides=(provided,),
+            ),
+            setup=setup,
+        ),
+        root=tmp_path,
+    )
+
+    with pytest.raises(PluginError, match="setup failed"):
+        await harness.start()
+    assert cancelled.is_set()
+    with pytest.raises(ServiceError, match="unavailable"):
+        harness.require_service(provided)
+    with pytest.raises(RuntimeError, match="single-use"):
+        await harness.start()
+
+
+@pytest.mark.asyncio
+async def test_plugin_harness_cleans_up_failed_start(tmp_path: Path) -> None:
+    worker_started = asyncio.Event()
+    cancelled = asyncio.Event()
+    stopped = asyncio.Event()
+
+    async def worker() -> None:
+        worker_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    async def setup(context: PluginContext) -> PluginHandle:
+        context.tasks.start(worker(), name="worker")
+
+        async def start() -> None:
+            await worker_started.wait()
+            raise RuntimeError("start failed")
+
+        async def stop() -> None:
+            stopped.set()
+
+        return PluginHandle(start=start, stop=stop)
+
+    harness = PluginTestHarness(
+        PluginDefinition(
+            manifest=PluginManifest(
+                id="example.start-failure",
+                name="Start failure",
+                version="1.0.0",
+            ),
+            setup=setup,
+        ),
+        root=tmp_path,
+    )
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        await harness.start()
+    assert stopped.is_set()
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_custom_runtime_example_round_trips_events_and_actions() -> None:
+    python_path = str(RUNTIME_SOURCE)
+    existing = os.environ.get("PYTHONPATH")
+    if existing:
+        python_path += os.pathsep + existing
+    spec = RuntimeSpec(
+        id="example-runtime",
+        kind="custom",
+        command=(sys.executable, "-m", "liteyukibot_example_runtime"),
+        env={"PYTHONPATH": python_path},
+        ready_timeout=5,
+        heartbeat_interval=0.05,
+        stale_after=1,
+        shutdown_timeout=2,
+        restart_limit=1,
+    )
+    harness = RuntimeTestHarness(spec)
+
+    async with harness:
+        assert harness.state.value == RuntimeState.READY.value
+        assert harness.protocol_version == 3
+        assert harness.capabilities == frozenset(
+            {"runtime.events.receive", "runtime.actions.send"}
+        )
+
+        accepted = await harness.dispatch_event(
+            _event().model_dump(mode="json"),
+            correlation_id="event-delivery",
+            timeout_seconds=2,
+        )
+        assert accepted == EventAccepted(
+            correlation_id="event-delivery",
+            status="accepted",
+        )
+        assert len(harness.child_actions) == 1
+        runtime_id, payload = harness.child_actions[0]
+        assert runtime_id == "example-runtime"
+        child_action = ActionEnvelope.model_validate(payload)
+        assert cast(SendMessage, child_action.action).message.plain_text == "runtime: hello"
+
+        response = await harness.execute_action(
+            {"command": "ping"},
+            correlation_id="core-action",
+            timeout_seconds=2,
+        )
+        assert response.ok is True
+        assert response.data == {"echo": {"command": "ping"}}
+
+        invalid = await harness.dispatch_event(
+            {"not": "an event"},
+            correlation_id="invalid-event",
+            timeout_seconds=2,
+        )
+        assert invalid.status == "invalid"
+        assert invalid.detail is not None
+
+    assert harness.state.value == RuntimeState.STOPPED.value
+    await harness.stop()
+
+
+def test_runtime_harness_requires_explicit_command() -> None:
+    with pytest.raises(ValueError, match="explicit child command"):
+        RuntimeTestHarness(RuntimeSpec(id="custom", kind="custom"))
+
+
+def test_runtime_spec_rejects_empty_command_arguments() -> None:
+    with pytest.raises(ValueError, match="command arguments"):
+        RuntimeSpec(id="custom", kind="custom", command=())
+    with pytest.raises(ValueError, match="command arguments"):
+        RuntimeSpec(id="custom", kind="custom", command=(sys.executable, ""))
+
+
+def test_public_developer_types_are_importable() -> None:
+    annotations: Mapping[str, object] = {
+        "PluginPaths": PluginPaths,
+        "PluginServices": PluginServices,
+        "PluginTestHarness": PluginTestHarness,
+        "RuntimeTestHarness": RuntimeTestHarness,
+    }
+    assert all(value is not None for value in annotations.values())

--- a/tests/test_runtime_v7.py
+++ b/tests/test_runtime_v7.py
@@ -645,6 +645,52 @@ async def test_disconnect_fails_pending_action(monkeypatch: pytest.MonkeyPatch) 
     assert record.pending_actions == {}
 
 
+@pytest.mark.asyncio
+async def test_duplicate_action_request_does_not_replace_pending_future(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent = asyncio.Event()
+    supervisor = RuntimeSupervisor(logger=FakeLogger())
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="action", kind="custom"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+    )
+    supervisor.records[record.spec.id] = record
+
+    async def hold_action(_record: RuntimeRecord, _message: Any) -> None:
+        sent.set()
+
+    monkeypatch.setattr(supervisor, "_send", hold_action)
+    first = asyncio.create_task(supervisor.execute_action("action", "duplicate", {}))
+    await sent.wait()
+    pending = record.pending_actions["duplicate"]
+
+    with pytest.raises(ValueError, match="duplicate action correlation id"):
+        await supervisor.execute_action("action", "duplicate", {})
+    assert record.pending_actions["duplicate"] is pending
+
+    await supervisor._disconnect(record)
+    with pytest.raises(ConnectionError, match="disconnected"):
+        await first
+    assert record.pending_actions == {}
+
+
+@pytest.mark.asyncio
+async def test_runtime_dispatch_rejects_non_positive_timeouts_before_lookup() -> None:
+    supervisor = RuntimeSupervisor(logger=FakeLogger())
+
+    with pytest.raises(ValueError, match="action timeout must be positive"):
+        await supervisor.execute_action("missing", "action", {}, timeout_seconds=0)
+    with pytest.raises(ValueError, match="action timeout must be positive"):
+        await supervisor.execute_action("missing", "action", {}, timeout_seconds=-1)
+    with pytest.raises(ValueError, match="event timeout must be positive"):
+        await supervisor.dispatch_event("missing", "event", {}, timeout_seconds=0)
+    with pytest.raises(ValueError, match="event timeout must be positive"):
+        await supervisor.dispatch_event("missing", "event", {}, timeout_seconds=-1)
+
+
 def test_runtime_failure_limit_transitions_to_failed() -> None:
     record = RuntimeRecord(
         spec=RuntimeSpec(id="crash", kind="custom", restart_limit=2),


### PR DESCRIPTION
## Summary

- add dependency-free `PluginTestHarness` and `RuntimeTestHarness` conformance helpers backed by the real kernel lifecycle and subprocess protocol
- publish independently buildable native-plugin and custom-runtime examples with focused authoring documentation
- harden supervisor timeout and duplicate Action correlation validation, and complete public plugin/runtime type exports
- verify root/example wheels in an isolated uv environment and extend the three-platform quality matrix
- define alpha protocol governance: iterate v3 directly, reserve v4/v5 for large redesigns, and cap pre-stable protocol numbering at v5

## Validation

- `uv run ruff check src tests scripts examples`
- `uv run mypy`
- `uv run pytest -q` (`147 passed`)
- root and both example sdist/wheel builds
- isolated three-wheel entry-point and runtime subprocess verification
- local Docker build plus `version`, `check`, and UID 10001 smoke tests