### PR TITLE
Prepare LiteyukiBot 7.0.0a2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 7.0.0a2 - 2026-08-09
+
+The second v7 alpha completes kernel stabilization and the first bounded
+message-plugin compatibility phase:
+
 - completed Phase 2 kernel stabilization with accepted v1 ADRs, deterministic
   runtime failure coverage, and cross-platform published-install verification;
 - recorded informational alpha performance references on Linux, macOS, and Windows;
@@ -24,6 +29,10 @@
   installable examples, and explicit lifecycle/single-reader authoring guidance.
 - bounded pre-stable protocol numbering at v5 and made v3 the direct iteration
   target without an alpha backwards-compatibility guarantee.
+
+This remains a rapid-iteration pre-release. Protocol v3 is the current direct
+development target and may change without backwards-compatibility shims under
+ADR 0011.
 
 ## 7.0.0a1 - 2026-08-04
 

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -131,5 +131,11 @@ the `pyproject.toml` version, the release tag, and the built wheel metadata.
 
 Phase 2 kernel stabilization is complete. The runtime failure matrix, accepted
 v1 ADRs, three-platform kernel suite, isolated public-PyPI installation checks,
-and informational alpha performance reference now form the baseline for the
-next compatibility phase.
+and informational alpha performance reference form the kernel baseline.
+
+Phase 3 compatibility is complete and targets `7.0.0a2`. It adds reusable child
+transport, negotiated bidirectional Events and Actions, the bounded v6 message
+matcher bridge, structured NoneBot OneBot/Satori adapter contracts, and the
+plugin/runtime developer kit. The release is published only after the root and
+example wheels, three-platform quality and published-install jobs, NoneBot
+contract job, and local non-root Docker smoke all pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a1"
+version = "7.0.0a2"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -242,7 +242,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a1"
+version = "7.0.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- bump the LiteyukiBot v7 project and lock identity from `7.0.0a1` to `7.0.0a2`
- finalize the Phase 2/3 compatibility work as the second alpha release notes
- record Phase 3 completion and the exact release gate in the architecture document
- retain the CI public-PyPI baseline at the already-published `7.0.0a1` until this PR is merged and the `v7.0.0a2` tag publishes

## Validation

- `uv run python scripts/check_release.py --tag v7.0.0a2`
- `uv run ruff check src tests scripts examples`
- `uv run mypy`
- `uv run pytest -q` (`147 passed`)
- root and both example sdist/wheel builds
- isolated `7.0.0a2` distribution/namespace and developer-kit verification
- local Docker `version`, `check`, and UID 10001 smoke tests

## Post-merge

Create tag `v7.0.0a2` on the squash merge commit, wait for the Trusted Publisher workflow, then verify the public PyPI artifact in a new uv environment.