### PR TITLE
Track published 7.0.0a2 baseline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         working-directory: LiteyukiBot
         run: |
           uv python install 3.14
-          uv run --no-project --python 3.14 --with "liteyukibot-v7==7.0.0a1" python scripts/verify_published_install.py --expected-version 7.0.0a1
+          uv run --no-project --python 3.14 --with "liteyukibot-v7==7.0.0a2" python scripts/verify_published_install.py --expected-version 7.0.0a2
 
   nonebot-contract:
     runs-on: ubuntu-latest

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -133,7 +133,7 @@ Phase 2 kernel stabilization is complete. The runtime failure matrix, accepted
 v1 ADRs, three-platform kernel suite, isolated public-PyPI installation checks,
 and informational alpha performance reference form the kernel baseline.
 
-Phase 3 compatibility is complete and targets `7.0.0a2`. It adds reusable child
+Phase 3 compatibility is complete and distributed as `7.0.0a2`. It adds reusable child
 transport, negotiated bidirectional Events and Actions, the bounded v6 message
 matcher bridge, structured NoneBot OneBot/Satori adapter contracts, and the
 plugin/runtime developer kit. The release is published only after the root and

--- a/docs/performance-v7.md
+++ b/docs/performance-v7.md
@@ -2,7 +2,7 @@
 
 ## Published Install Contract
 
-CI installs `liteyukibot-v7==7.0.0a1` from PyPI in an isolated uv environment
+CI installs `liteyukibot-v7==7.0.0a2` from PyPI in an isolated uv environment
 on Ubuntu, Windows, and macOS. It verifies the distribution metadata and imports
 both `liteyukibot` and the `liteyuki` v6 compatibility namespace. The check does
 not use the repository virtual environment or install the source checkout.
@@ -10,7 +10,7 @@ not use the repository virtual environment or install the source checkout.
 Run the same contract locally with:
 
 ```bash
-uv run --no-project --python 3.14 --with "liteyukibot-v7==7.0.0a1" python scripts/verify_published_install.py --expected-version 7.0.0a1
+uv run --no-project --python 3.14 --with "liteyukibot-v7==7.0.0a2" python scripts/verify_published_install.py --expected-version 7.0.0a2
 ```
 
 ## Alpha Reference


### PR DESCRIPTION
## Summary

- update the three-platform public-PyPI install contract from `7.0.0a1` to the now-published `7.0.0a2`
- update the matching local command in the performance reference
- record Phase 3 as distributed rather than only targeted

## Validation

- public PyPI metadata reports `7.0.0a2` with wheel and sdist
- forced-refresh isolated uv install verifies distribution and both import namespaces at `7.0.0a2`
- `uv run ruff check src tests scripts examples`
- `uv run mypy`
- `uv run pytest -q` (`147 passed`)
- workflow YAML parse