### PR TITLE
✨ Expose kernel status service

### DIFF
--- a/docs/adr/0012-kernel-status-service.md
+++ b/docs/adr/0012-kernel-status-service.md
@@ -1,0 +1,48 @@
+# ADR 0012: Expose Kernel Status as a Versioned Service
+
+- Status: Accepted
+- Date: 2026-08-10
+
+## Context
+
+The application already reports process state through its authenticated local
+control channel and optional loopback HTTP API. Native plugins need the same
+operational facts for first-party commands, but reaching into `LiteyukiApp`,
+the plugin manager, or the runtime supervisor would couple them to mutable
+kernel internals.
+
+System resource metrics are platform-specific and are not part of the current
+dependency budget. Runtime wire peers also do not need this process-local
+observability contract.
+
+## Decision
+
+The kernel provides `liteyukibot.kernel.status@1` in the service registry during
+application construction, before plugin discovery and dependency resolution.
+The registered value implements `KernelStatusProvider.snapshot()` and does not
+expose the owning `LiteyukiApp`.
+
+`KernelStatusSnapshot` is a frozen in-process value containing the distribution
+version, application state, monotonic uptime, sorted plugin and runtime states,
+and the outstanding EventBus count. Plugin and runtime mappings are immutable.
+The uptime is zero before startup, advances while the application is running,
+and freezes after shutdown or startup failure.
+
+`LiteyukiApp.status()` remains the JSON-facing compatibility surface for the
+control and HTTP servers. It serializes a fresh snapshot into ordinary
+dictionaries, so no immutable internal mapping is handed to a transport.
+
+The service does not expose restart controls, mutable manager objects, CPU or
+memory metrics, adapter objects, or configuration secrets. It does not change
+Event/Action schemas or the runtime IPC protocol.
+
+## Consequences
+
+Native plugins can declare and resolve an explicit, versioned dependency on
+kernel observability without gaining a general application handle. Status
+rendering remains outside the kernel, allowing first-party or third-party
+plugins to choose their own presentation and access policy.
+
+The snapshot is deliberately small. Adding platform resource metrics or new
+operational controls requires a separate contract and evidence that it belongs
+in the kernel dependency budget.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,3 +15,4 @@ stable-release guarantee.
 9. [NoneBot OneBot and Satori adapter contracts](0009-nonebot-adapter-contracts.md)
 10. [Developer conformance harnesses](0010-developer-kit-contracts.md)
 11. [Pre-stable protocol versioning](0011-pre-stable-protocol-policy.md)
+12. [Kernel status service](0012-kernel-status-service.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -29,6 +29,11 @@ entry point returns `PluginDefinition(manifest, setup)`. `setup(context)` is
 async and may return start/stop callbacks. Service contracts use `name@major`
 keys, one provider per key, and a startup dependency graph.
 
+The kernel registers `liteyukibot.kernel.status@1` before plugin topology
+resolution. Its provider exposes only frozen operational snapshots: version,
+application state, monotonic uptime, plugin/runtime states, and EventBus
+backlog. Native plugins do not receive a general `LiteyukiApp` handle.
+
 The public `PluginTestHarness` composes the same manager, event bus, service
 registry, Action path, and managed tasks for single-plugin conformance tests.
 The public `RuntimeTestHarness` launches one real supervised subprocess for
@@ -97,9 +102,10 @@ protocol-v3 Action direction. ADR 0008 defines their v6 message-plugin mapping,
 ADR 0009 defines the NoneBot OneBot/Satori adapter boundary, and ADR 0010
 defines the developer conformance helpers. ADR 0011 governs rapid pre-stable
 iteration: v3 remains the default, small and medium breaking changes revise it
-directly, and only a cross-cutting redesign may consume v4 or v5. No alpha
-protocol version may exceed v5. Existing v1/v2 support is tested but is not a
-compatibility promise before the first stable v7 release.
+directly, and only a cross-cutting redesign may consume v4 or v5. ADR 0012
+defines the process-local kernel status service without changing runtime IPC.
+No alpha protocol version may exceed v5. Existing v1/v2 support is tested but
+is not a compatibility promise before the first stable v7 release.
 
 ## Operations
 
@@ -139,3 +145,7 @@ bounded v6 message matcher bridge, structured NoneBot OneBot/Satori adapter
 contracts, and the plugin/runtime developer kit. Its root and example wheels,
 three-platform quality and published-install jobs, NoneBot contract job, and
 local non-root Docker smoke all passed before publication.
+
+Phase 4 builds first-party capabilities as separately distributable native
+plugins. Its first kernel addition is the versioned read-only status service;
+command routing, access policy, and user-facing rendering remain plugin-owned.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -66,3 +66,25 @@ records the Action and returns a correlated success.
 The harness is single-use and intentionally tests one plugin. Use
 `LiteyukiApp` or the kernel components directly for multi-plugin topology and
 full configuration tests.
+
+## Kernel status
+
+Plugins that need operational state declare the versioned kernel service rather
+than importing or retaining `LiteyukiApp`:
+
+```python
+from typing import cast
+
+from liteyukibot import KERNEL_STATUS_SERVICE, KernelStatusProvider
+
+provider = cast(
+    KernelStatusProvider,
+    context.services.require(KERNEL_STATUS_SERVICE),
+)
+snapshot = provider.snapshot()
+```
+
+Add `ServiceRequirement(KERNEL_STATUS_SERVICE)` to the plugin manifest before
+requiring it. Snapshots are immutable and contain only kernel version, state,
+uptime, plugin/runtime states, and outstanding event count. Presentation and
+access policy belong to the consuming plugin.

--- a/src/liteyukibot/__init__.py
+++ b/src/liteyukibot/__init__.py
@@ -11,9 +11,13 @@ from .plugins import (
     PluginServices,
 )
 from .services import ServiceKey, ServiceRegistry, ServiceRequirement
+from .status import KERNEL_STATUS_SERVICE, KernelStatusProvider, KernelStatusSnapshot
 
 __all__ = [
     "LiteyukiApp",
+    "KERNEL_STATUS_SERVICE",
+    "KernelStatusProvider",
+    "KernelStatusSnapshot",
     "PluginContext",
     "PluginDefinition",
     "PluginHandle",

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping
 from enum import StrEnum
+from time import monotonic
 from typing import Any
 
+from ._version import __version__
 from .config import AppSettings
 from .control import ControlServer
 from .events import ActionEnvelope, ActionResult, EventBus, EventEnvelope
@@ -15,6 +17,7 @@ from .logging import Logger, configure_logging, get_logger, shutdown_logging
 from .plugins import PluginManager
 from .runtime import ActionSinkResult, RuntimeSpec, RuntimeSupervisor
 from .services import ServiceRegistry
+from .status import KERNEL_STATUS_SERVICE, KernelStatusSnapshot
 
 
 class AppState(StrEnum):
@@ -60,6 +63,14 @@ class ActionService:
             error_code="RUNTIME_ACTION_FAILED",
             error_message=response.error or "runtime rejected the action",
         )
+
+
+class _AppStatusProvider:
+    def __init__(self, app: LiteyukiApp) -> None:
+        self._app = app
+
+    def snapshot(self) -> KernelStatusSnapshot:
+        return self._app.status_snapshot()
 
 
 class LiteyukiApp:
@@ -110,6 +121,8 @@ class LiteyukiApp:
         self._runtimes_started = False
         self._control_started = False
         self._http_started = False
+        self._started_at: float | None = None
+        self._stopped_at: float | None = None
         v6_runtime_ids: list[str] = []
 
         for runtime_id, runtime in settings.runtimes.items():
@@ -139,11 +152,18 @@ class LiteyukiApp:
                 self._forward_v6_event,
                 name="runtime.v6",
             )
+        self.services.provide(
+            KERNEL_STATUS_SERVICE,
+            _AppStatusProvider(self),
+            provider="liteyukibot.kernel",
+        )
 
     async def start(self) -> None:
         if self.state is not AppState.CREATED:
             raise RuntimeError(f"application cannot start from state {self.state}")
         self.state = AppState.STARTING
+        self._started_at = monotonic()
+        self._stopped_at = None
         try:
             if self._logging_owned:
                 self.logger = configure_logging(self.settings.logging)
@@ -185,11 +205,13 @@ class LiteyukiApp:
                 await self._cleanup()
             except BaseException as cleanup_error:
                 start_error.add_note(f"startup cleanup also failed: {cleanup_error}")
+            self._freeze_uptime()
             raise
 
     async def stop(self) -> None:
         if self.state in {AppState.STOPPED, AppState.CREATED}:
             self.state = AppState.STOPPED
+            self._freeze_uptime()
             return
         if self.state is AppState.STOPPING:
             return
@@ -201,6 +223,8 @@ class LiteyukiApp:
             raise
         else:
             self.state = AppState.STOPPED
+        finally:
+            self._freeze_uptime()
 
     async def run(self) -> None:
         await self.start()
@@ -216,17 +240,32 @@ class LiteyukiApp:
     async def __aexit__(self, *_exc_info: object) -> None:
         await self.stop()
 
+    def status_snapshot(self) -> KernelStatusSnapshot:
+        return KernelStatusSnapshot(
+            version=__version__,
+            state=self.state.value,
+            uptime_seconds=self._uptime_seconds(),
+            plugins={
+                plugin_id: plugin.state.value for plugin_id, plugin in self.plugins.loaded.items()
+            },
+            runtimes={
+                runtime_id: record.state.value for runtime_id, record in self.runtimes.records.items()
+            },
+            events_outstanding=self.events.outstanding,
+        )
+
     def status(self) -> dict[str, Any]:
-        return {
-            "state": self.state,
-            "plugins": {
-                plugin_id: plugin.state for plugin_id, plugin in self.plugins.loaded.items()
-            },
-            "runtimes": {
-                runtime_id: record.state for runtime_id, record in self.runtimes.records.items()
-            },
-            "events_outstanding": self.events.outstanding,
-        }
+        return self.status_snapshot().as_dict()
+
+    def _uptime_seconds(self) -> float:
+        if self._started_at is None:
+            return 0.0
+        end = self._stopped_at if self._stopped_at is not None else monotonic()
+        return max(0.0, end - self._started_at)
+
+    def _freeze_uptime(self) -> None:
+        if self._started_at is not None and self._stopped_at is None:
+            self._stopped_at = monotonic()
 
     async def _cleanup(self) -> None:
         self._accepting_events = False

--- a/src/liteyukibot/status.py
+++ b/src/liteyukibot/status.py
@@ -1,0 +1,66 @@
+"""Read-only kernel status contract for native plugins."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Protocol
+
+from .services import ServiceKey
+
+KERNEL_STATUS_SERVICE = ServiceKey("liteyukibot.kernel.status", 1)
+
+
+def _freeze_states(name: str, states: Mapping[str, str]) -> Mapping[str, str]:
+    normalized: dict[str, str] = {}
+    for identifier, state in states.items():
+        if not isinstance(identifier, str) or not identifier:
+            raise ValueError(f"{name} identifiers must be non-empty strings")
+        if not isinstance(state, str) or not state:
+            raise ValueError(f"{name} states must be non-empty strings")
+        normalized[identifier] = state
+    return MappingProxyType(dict(sorted(normalized.items())))
+
+
+@dataclass(frozen=True, slots=True)
+class KernelStatusSnapshot:
+    version: str
+    state: str
+    uptime_seconds: float
+    plugins: Mapping[str, str] = field(default_factory=dict)
+    runtimes: Mapping[str, str] = field(default_factory=dict)
+    events_outstanding: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.version:
+            raise ValueError("kernel version must not be empty")
+        if not self.state:
+            raise ValueError("kernel state must not be empty")
+        if self.uptime_seconds < 0:
+            raise ValueError("kernel uptime must not be negative")
+        if self.events_outstanding < 0:
+            raise ValueError("outstanding event count must not be negative")
+        object.__setattr__(self, "plugins", _freeze_states("plugin", self.plugins))
+        object.__setattr__(self, "runtimes", _freeze_states("runtime", self.runtimes))
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "state": self.state,
+            "uptime_seconds": self.uptime_seconds,
+            "plugins": dict(self.plugins),
+            "runtimes": dict(self.runtimes),
+            "events_outstanding": self.events_outstanding,
+        }
+
+
+class KernelStatusProvider(Protocol):
+    def snapshot(self) -> KernelStatusSnapshot: ...
+
+
+__all__ = [
+    "KERNEL_STATUS_SERVICE",
+    "KernelStatusProvider",
+    "KernelStatusSnapshot",
+]

--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -12,6 +12,8 @@ from urllib.request import urlopen
 
 import pytest
 
+import liteyukibot.app as app_module
+from liteyukibot import __version__
 from liteyukibot.app import AppState, LiteyukiApp
 from liteyukibot.config import (
     AppSettings,
@@ -34,6 +36,7 @@ from liteyukibot.exceptions import PluginError
 from liteyukibot.plugins import PluginDefinition, PluginHandle, PluginManifest
 from liteyukibot.runtime.protocol import EventAccepted
 from liteyukibot.services import ServiceKey, ServiceRequirement
+from liteyukibot.status import KERNEL_STATUS_SERVICE
 
 
 class FakeLogger:
@@ -54,6 +57,98 @@ class FakeLogger:
 
     def exception(self, message: str, *args: Any, **kwargs: Any) -> None:
         pass
+
+
+def test_kernel_status_service_is_available_before_plugin_resolution(tmp_path: Path) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache")
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+
+    provider = app.services.require(KERNEL_STATUS_SERVICE)
+    snapshot = provider.snapshot()
+
+    assert app.services.provider_for(KERNEL_STATUS_SERVICE) == "liteyukibot.kernel"
+    assert snapshot.version == __version__
+    assert snapshot.state == "created"
+    assert snapshot.uptime_seconds == 0
+    assert snapshot.plugins == {}
+    assert snapshot.runtimes == {}
+    assert snapshot.events_outstanding == 0
+    with pytest.raises(TypeError):
+        cast(dict[str, str], snapshot.plugins)["unexpected"] = "ready"
+
+
+@pytest.mark.asyncio
+async def test_kernel_status_uptime_freezes_after_stop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = [10.0]
+    monkeypatch.setattr(app_module, "monotonic", lambda: now[0])
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache")
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+
+    await app.start()
+    now[0] = 12.5
+    assert app.status_snapshot().uptime_seconds == 2.5
+
+    now[0] = 15.0
+    await app.stop()
+    now[0] = 99.0
+
+    snapshot = app.status_snapshot()
+    assert snapshot.state == "stopped"
+    assert snapshot.uptime_seconds == 5.0
+
+
+@pytest.mark.asyncio
+async def test_kernel_status_uptime_freezes_after_startup_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = [20.0]
+    monkeypatch.setattr(app_module, "monotonic", lambda: now[0])
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache")
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+
+    async def fail_start() -> None:
+        now[0] = 23.0
+        raise RuntimeError("startup failed")
+
+    monkeypatch.setattr(app.events, "start", fail_start)
+
+    with pytest.raises(RuntimeError, match="startup failed"):
+        await app.start()
+
+    now[0] = 99.0
+    snapshot = app.status_snapshot()
+    assert snapshot.state == "failed"
+    assert snapshot.uptime_seconds == 3.0
+
+
+def test_plugin_topology_can_require_kernel_status(tmp_path: Path) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache")
+    )
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+
+    async def setup(_context: Any) -> None:
+        return None
+
+    definition = PluginDefinition(
+        PluginManifest(
+            id="status-consumer",
+            name="Status consumer",
+            version="1",
+            requires=(ServiceRequirement(KERNEL_STATUS_SERVICE),),
+        ),
+        setup,
+    )
+
+    assert app.plugins.resolve_order({"status-consumer": definition}) == ("status-consumer",)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expose `liteyukibot.kernel.status@1` before native plugin topology resolution
- provide immutable, sorted status snapshots with monotonic uptime that freezes on stop or startup failure
- retain JSON status behavior for local control and HTTP consumers
- document the contract in ADR 0012 and the native plugin guide

## Validation
- `uv run ruff check src tests scripts examples`
- `uv run mypy`
- `uv run pytest` (151 passed)
- `uv build --clear`
- isolated wheel install and public status API smoke test from `tmp/`