### PR TITLE
🚀 Prepare v7.0.0a3 release chain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
         working-directory: LiteyukiBot
         run: |
           uv run python scripts/check_release.py
+          uv run python scripts/check_release.py --package permissions
+          uv run python scripts/check_release.py --package commands
+          uv run python scripts/check_release.py --package essentials
           uv run ruff check src tests scripts examples packages
           uv run mypy
           uv run pytest
@@ -69,7 +72,9 @@ jobs:
         working-directory: LiteyukiBot
         run: |
           uv python install 3.14
-          uv run --no-project --python 3.14 --with "liteyukibot-v7==7.0.0a2" python scripts/verify_published_install.py --expected-version 7.0.0a2
+          uv run --no-project --python 3.14 python scripts/run_isolated_install.py \
+            --with "liteyukibot-v7>=7.0.0a2,<7.0.0a4" \
+            --verifier scripts/verify_published_install.py
 
   nonebot-contract:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,9 +72,7 @@ jobs:
         working-directory: LiteyukiBot
         run: |
           uv python install 3.14
-          uv run --no-project --python 3.14 python scripts/run_isolated_install.py \
-            --with "liteyukibot-v7>=7.0.0a2,<7.0.0a4" \
-            --verifier scripts/verify_published_install.py
+          uv run --no-project --python 3.14 python scripts/run_isolated_install.py --with "liteyukibot-v7>=7.0.0a2,<7.0.0a4" --verifier scripts/verify_published_install.py
 
   nonebot-contract:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-plugins.yaml
+++ b/.github/workflows/publish-plugins.yaml
@@ -1,0 +1,57 @@
+name: Publish LiteyukiBot Plugins
+
+on:
+  push:
+    tags:
+      - "permissions-v*"
+      - "commands-v*"
+      - "essentials-v*"
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Plugin package to publish
+        required: true
+        type: choice
+        options:
+          - permissions
+          - commands
+          - essentials
+      version:
+        description: Exact plugin version to publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('{0}-v{1}', inputs.package, inputs.version) || github.ref_name }}
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.3.2
+        with:
+          version: "0.11.16"
+      - name: Install Python
+        run: uv python install 3.14
+      - name: Resolve and validate release
+        id: release
+        run: >-
+          uv run --no-project --python 3.14 python scripts/check_release.py
+          --tag "$RELEASE_TAG" --github-output "$GITHUB_OUTPUT"
+      - name: Build plugin distribution
+        run: >-
+          uv build --project "${{ steps.release.outputs.project }}"
+          --out-dir dist/release --clear
+      - name: Verify plugin wheel with published dependencies
+        run: |
+          wheel="$(find dist/release -maxdepth 1 -name '*.whl' -print -quit)"
+          uv run --no-project --python 3.14 python scripts/run_isolated_install.py \
+            --with "$wheel" --verifier "${{ steps.release.outputs.verifier }}" -- \
+            --expected-version "${{ steps.release.outputs.version }}"
+      - name: Publish plugin distribution
+        run: uv publish dist/release/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,15 +25,18 @@ jobs:
       - uses: astral-sh/setup-uv@v8.3.2
         with:
           version: "0.11.16"
+      - name: Install Python
+        run: uv python install 3.14
       - name: Require published Yukilog 1.x
-        run: uv run --no-project --with "yukilog>=1,<2" python -c "import yukilog"
+        run: uv run --no-project --python 3.14 --with "yukilog>=1,<2" python -c "import yukilog"
       - name: Validate release identity
-        run: uv run python scripts/check_release.py --tag "$RELEASE_TAG"
+        run: uv run --no-project --python 3.14 python scripts/check_release.py --tag "$RELEASE_TAG"
       - name: Build distribution
         run: |
           uv build
           wheel="$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
-          uv run --no-project --with "$wheel" python scripts/verify_published_install.py --expected-version "${RELEASE_TAG#v}"
+          uv run --no-project --python 3.14 python scripts/run_isolated_install.py \
+            --with "$wheel" --verifier scripts/verify_published_install.py -- \
+            --expected-version "${RELEASE_TAG#v}"
       - name: Publish distribution
-        run: |
-          uv publish
+        run: uv publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## 7.0.0a3 - 2026-08-10
+
+The third v7 alpha establishes the first-party native plugin foundation:
+
+- added the immutable `liteyukibot.kernel.status@1` service without changing
+  runtime IPC protocol v3;
+- added independently distributable permissions, commands, and essentials
+  packages in one uv workspace with no new third-party runtime dependencies;
+- added exact-principal `public`/`operator` policy, atomic protocol-neutral
+  command routing, permission-filtered help, and operator-only kernel status;
+- added Chinese and English plain-text essentials rendering while keeping
+  localization outside the kernel;
+- added real three-plugin topology tests, isolated wheel installation checks,
+  multi-package release identity validation, and Trusted Publisher workflows.
+
+The plugin packages begin at `0.1.0a1`. Their required publication order is
+root, permissions, commands, then essentials.
+
 ## 7.0.0a2 - 2026-08-09
 
 The second v7 alpha completes kernel stabilization and the first bounded

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a2`. Kernel stabilization and
-the first bounded compatibility phase are complete. Runtime protocol v3 remains
-an alpha contract and may change under ADR 0011 before the first stable release.
+The current pre-release is `liteyukibot-v7==7.0.0a3`. Kernel stabilization,
+the first bounded compatibility phase, and the first-party plugin foundation
+are complete. Runtime protocol v3 remains an alpha contract and may change
+under ADR 0011 before the first stable release.
 
 ## Current Foundation
 
@@ -22,6 +23,8 @@ an alpha contract and may change under ADR 0011 before the first stable release.
 - authenticated framed JSON IPC and supervised subprocess runtimes;
 - NoneBot2 plugin hosting and a deliberately bounded v6 compatibility shim;
 - local authenticated CLI control and an optional loopback-only HTTP status API.
+- read-only kernel status plus separately distributable permission, command,
+  help, and operator-status plugins.
 
 ## Requirements
 
@@ -47,6 +50,15 @@ uv sync --extra http
 uv sync --extra nonebot --extra onebot
 uv sync --extra nonebot --extra satori
 ```
+
+Install the complete first-party plugin chain with:
+
+```bash
+uv add "liteyukibot-v7-essentials==0.1.0a1"
+```
+
+This resolves `liteyukibot-v7-commands` and
+`liteyukibot-v7-permissions`; enable all three plugin IDs in configuration.
 
 Use `liteyuki.example.toml` as a configuration reference. CLI overrides must
 precede the subcommand, for example:
@@ -89,6 +101,8 @@ uv run python scripts/run_essentials_install.py
 The architecture overview is documented in `docs/architecture/v7.md`; accepted
 architecture contracts are indexed in `docs/adr/README.md`; the v6 compatibility
 boundary is documented in `docs/migration-v6.md`.
+
+Release maintainers should follow `docs/development/releasing.md`.
 
 Plugin and runtime authors should start with the installable examples and their
 focused guides:

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -159,3 +159,7 @@ keeps argument parsing and user-facing commands outside the kernel.
 provide permission-filtered help and operator-only status as plain text. Its
 small Chinese/English dictionary remains package-local rather than establishing
 a premature kernel localization contract.
+
+Phase 4 is released as `7.0.0a3`; the three plugin distributions begin at
+`0.1.0a1`. Release identities and tag prefixes are fixed per package, and the
+dependency chain is published in root, permissions, commands, essentials order.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -1,0 +1,61 @@
+# Releasing v7 Packages
+
+v7 uses PyPI Trusted Publishing and immutable, package-specific tags. Release
+from a clean `v7` commit only after the full CI matrix passes.
+
+## Trusted Publishers
+
+The PyPI publisher settings use:
+
+- owner/repository: `LiteyukiStudio/LiteyukiBot`;
+- environment: `pypi`;
+- root workflow: `publish.yml`;
+- plugin workflow: `publish-plugins.yaml`.
+
+Before the first plugin upload, create Pending Publishers for:
+
+- `liteyukibot-v7-permissions`;
+- `liteyukibot-v7-commands`;
+- `liteyukibot-v7-essentials`.
+
+Do not create tags until every corresponding publisher is configured. A 404
+from the PyPI JSON endpoint is expected before the first trusted upload; an
+existing project owned elsewhere is a release blocker, not a reason to rename a
+distribution inside the workflow.
+
+## Identities
+
+| Package | Source | Tag |
+| --- | --- | --- |
+| `liteyukibot-v7==7.0.0a3` | `pyproject.toml` | `v7.0.0a3` |
+| `liteyukibot-v7-permissions==0.1.0a1` | `packages/permissions` | `permissions-v0.1.0a1` |
+| `liteyukibot-v7-commands==0.1.0a1` | `packages/commands` | `commands-v0.1.0a1` |
+| `liteyukibot-v7-essentials==0.1.0a1` | `packages/essentials` | `essentials-v0.1.0a1` |
+
+`scripts/check_release.py` owns this mapping. Both publish workflows reject a
+tag that does not exactly match the selected source version and distribution.
+
+## Order
+
+Push and wait for each release before creating the next tag:
+
+1. `v7.0.0a3`;
+2. `permissions-v0.1.0a1`;
+3. `commands-v0.1.0a1`;
+4. `essentials-v0.1.0a1`.
+
+Each plugin workflow builds only its selected project, installs that wheel in a
+temporary uv environment against already published dependencies, exercises its
+real entry point, then uploads that package. This makes an out-of-order release
+fail before publication.
+
+After the final upload, verify the public dependency chain without a checkout:
+
+```bash
+uv run --no-project --python 3.14 \
+  --with "liteyukibot-v7-essentials==0.1.0a1" \
+  python -c "import importlib.metadata as m; print(m.version('liteyukibot-v7'))"
+```
+
+Never move or reuse a release tag. Correct source and publish a new pre-release
+version when an uploaded artifact is wrong.

--- a/docs/performance-v7.md
+++ b/docs/performance-v7.md
@@ -2,15 +2,19 @@
 
 ## Published Install Contract
 
-CI installs `liteyukibot-v7==7.0.0a2` from PyPI in an isolated uv environment
-on Ubuntu, Windows, and macOS. It verifies the distribution metadata and imports
-both `liteyukibot` and the `liteyuki` v6 compatibility namespace. The check does
-not use the repository virtual environment or install the source checkout.
+CI installs the newest published `liteyukibot-v7` in the
+`>=7.0.0a2,<7.0.0a4` release window from PyPI in an isolated uv environment on
+Ubuntu, Windows, and macOS. It verifies that distribution metadata and both the
+`liteyukibot` and `liteyuki` compatibility namespaces report the same version.
+The check does not use the repository virtual environment or install the source
+checkout, and remains valid before and after the a3 upload.
 
 Run the same contract locally with:
 
 ```bash
-uv run --no-project --python 3.14 --with "liteyukibot-v7==7.0.0a2" python scripts/verify_published_install.py --expected-version 7.0.0a2
+uv run --no-project --python 3.14 python scripts/run_isolated_install.py \
+  --with "liteyukibot-v7>=7.0.0a2,<7.0.0a4" \
+  --verifier scripts/verify_published_install.py
 ```
 
 ## Alpha Reference

--- a/liteyuki.example.toml
+++ b/liteyuki.example.toml
@@ -15,6 +15,22 @@ json_lines = false
 enabled = []
 local_modules = []
 
+# After installing liteyukibot-v7-essentials, enable:
+# enabled = [
+#   "liteyukibot.permissions",
+#   "liteyukibot.commands",
+#   "liteyukibot.essentials",
+# ]
+
+[plugins.config."liteyukibot.permissions"]
+operators = []
+
+[plugins.config."liteyukibot.commands"]
+prefixes = ["/"]
+
+[plugins.config."liteyukibot.essentials"]
+language = "zh-CN"
+
 [http]
 enabled = false
 host = "127.0.0.1"

--- a/packages/commands/pyproject.toml
+++ b/packages/commands/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a2,<8",
+    "liteyukibot-v7>=7.0.0a3,<8",
     "liteyukibot-v7-permissions>=0.1.0a1,<0.2",
 ]
 

--- a/packages/essentials/pyproject.toml
+++ b/packages/essentials/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a2,<8",
+    "liteyukibot-v7>=7.0.0a3,<8",
     "liteyukibot-v7-commands>=0.1.0a1,<0.2",
 ]
 

--- a/packages/essentials/tests/test_essentials.py
+++ b/packages/essentials/tests/test_essentials.py
@@ -42,7 +42,7 @@ class PermissionStub:
 class StatusStub:
     def snapshot(self) -> KernelStatusSnapshot:
         return KernelStatusSnapshot(
-            version="7.0.0a2",
+            version="7.0.0a3",
             state="ready",
             uptime_seconds=12.5,
             plugins={"zeta": "ready", "alpha": "stopped"},
@@ -123,7 +123,7 @@ def test_english_status_is_stable_and_sorted() -> None:
 
     assert rendered == "\n".join(
         (
-            "LiteyukiBot 7.0.0a2",
+            "LiteyukiBot 7.0.0a3",
             "State: ready",
             "Uptime: 12.500 seconds",
             "Outstanding events: 3",
@@ -203,7 +203,7 @@ async def test_three_plugin_topology_filters_help_and_correlates_status(tmp_path
         status_result = await app.events.publish(status_event)
         assert status_result.stopped is True
         status_action = cast(SendMessage, recorded[-1].action)
-        assert status_action.message.plain_text.startswith("LiteyukiBot 7.0.0a2\n状态: ready")
+        assert status_action.message.plain_text.startswith("LiteyukiBot 7.0.0a3\n状态: ready")
         assert "\n插件:\n- liteyukibot.commands: ready\n- liteyukibot.essentials: ready\n" in (
             status_action.message.plain_text
         )

--- a/packages/permissions/pyproject.toml
+++ b/packages/permissions/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a2,<8",
+    "liteyukibot-v7>=7.0.0a3,<8",
 ]
 
 [project.entry-points."liteyukibot.plugins"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a2"
+version = "7.0.0a3"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -1,15 +1,14 @@
-"""Validate the source release identity before building or publishing."""
+"""Validate source release identities before building or publishing."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import tomllib
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
-EXPECTED_DISTRIBUTION = "liteyukibot-v7"
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -17,6 +16,56 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 class ReleaseIdentity:
     distribution: str
     version: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseProject:
+    name: str
+    project_dir: str
+    distribution: str
+    tag_prefix: str
+    tag_selector: str
+    verifier: str
+
+    @property
+    def project_file(self) -> Path:
+        return PROJECT_ROOT / self.project_dir / "pyproject.toml"
+
+
+RELEASE_PROJECTS: dict[str, ReleaseProject] = {
+    "root": ReleaseProject(
+        name="root",
+        project_dir=".",
+        distribution="liteyukibot-v7",
+        tag_prefix="v",
+        tag_selector="v7.",
+        verifier="scripts/verify_published_install.py",
+    ),
+    "permissions": ReleaseProject(
+        name="permissions",
+        project_dir="packages/permissions",
+        distribution="liteyukibot-v7-permissions",
+        tag_prefix="permissions-v",
+        tag_selector="permissions-v",
+        verifier="scripts/verify_permissions_install.py",
+    ),
+    "commands": ReleaseProject(
+        name="commands",
+        project_dir="packages/commands",
+        distribution="liteyukibot-v7-commands",
+        tag_prefix="commands-v",
+        tag_selector="commands-v",
+        verifier="scripts/verify_commands_install.py",
+    ),
+    "essentials": ReleaseProject(
+        name="essentials",
+        project_dir="packages/essentials",
+        distribution="liteyukibot-v7-essentials",
+        tag_prefix="essentials-v",
+        tag_selector="essentials-v",
+        verifier="scripts/verify_essentials_install.py",
+    ),
+}
 
 
 def read_release_identity(project_file: Path) -> ReleaseIdentity:
@@ -34,26 +83,61 @@ def read_release_identity(project_file: Path) -> ReleaseIdentity:
     return ReleaseIdentity(distribution=distribution, version=version)
 
 
-def validate_release(identity: ReleaseIdentity, *, tag: str | None = None) -> None:
-    if identity.distribution != EXPECTED_DISTRIBUTION:
+def project_for_tag(tag: str) -> ReleaseProject:
+    matches = tuple(project for project in RELEASE_PROJECTS.values() if tag.startswith(project.tag_selector))
+    if len(matches) != 1:
+        raise RuntimeError(f"release tag {tag!r} does not select exactly one project")
+    return matches[0]
+
+
+def validate_release(
+    identity: ReleaseIdentity,
+    *,
+    project: ReleaseProject = RELEASE_PROJECTS["root"],
+    tag: str | None = None,
+) -> None:
+    if identity.distribution != project.distribution:
         raise RuntimeError(
-            f"expected project.name={EXPECTED_DISTRIBUTION!r}, got {identity.distribution!r}"
+            f"expected project.name={project.distribution!r}, got {identity.distribution!r}"
         )
     if tag is not None:
-        expected_tag = f"v{identity.version}"
+        expected_tag = f"{project.tag_prefix}{identity.version}"
         if tag != expected_tag:
             raise RuntimeError(f"expected release tag {expected_tag!r}, got {tag!r}")
 
 
+def _result(project: ReleaseProject, identity: ReleaseIdentity) -> dict[str, str]:
+    return {
+        "package": project.name,
+        "project": project.project_dir,
+        "distribution": identity.distribution,
+        "version": identity.version,
+        "verifier": project.verifier,
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--project", type=Path, default=PROJECT_ROOT / "pyproject.toml")
+    parser.add_argument("--package", choices=tuple(RELEASE_PROJECTS))
     parser.add_argument("--tag")
+    parser.add_argument("--github-output", type=Path)
     args = parser.parse_args()
 
-    identity = read_release_identity(args.project)
-    validate_release(identity, tag=args.tag)
-    print(json.dumps(asdict(identity), sort_keys=True))
+    if args.package is not None:
+        project = RELEASE_PROJECTS[args.package]
+    elif args.tag is not None:
+        project = project_for_tag(args.tag)
+    else:
+        project = RELEASE_PROJECTS["root"]
+    identity = read_release_identity(project.project_file)
+    validate_release(identity, project=project, tag=args.tag)
+    result = _result(project, identity)
+
+    if args.github_output is not None:
+        with args.github_output.open("a", encoding="utf-8") as output:
+            for name, value in result.items():
+                output.write(f"{name}={value}\n")
+    print(json.dumps(result, sort_keys=True))
     return 0
 
 

--- a/scripts/run_isolated_install.py
+++ b/scripts/run_isolated_install.py
@@ -1,0 +1,66 @@
+"""Run an installed-artifact verifier from a temporary non-project directory."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+
+_ISOLATION_VARIABLES = (
+    "VIRTUAL_ENV",
+    "PYTHONPATH",
+    "UV_PROJECT_ENVIRONMENT",
+    "UV_WORKING_DIRECTORY",
+)
+
+
+def _requirement(value: str) -> str:
+    if not value:
+        raise ValueError("install requirement must not be empty")
+    candidate = Path(value)
+    if not candidate.exists():
+        return value
+    if not candidate.is_file():
+        raise ValueError(f"local install requirement must be a file: {candidate}")
+    return str(candidate.resolve())
+
+
+def _clean_environment(environment: Mapping[str, str]) -> dict[str, str]:
+    cleaned = dict(environment)
+    for name in _ISOLATION_VARIABLES:
+        cleaned.pop(name, None)
+    return cleaned
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--with", dest="requirements", action="append", required=True)
+    parser.add_argument("--verifier", type=Path, required=True)
+    parser.add_argument("verifier_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv executable was not found")
+    verifier = args.verifier.resolve()
+    if not verifier.is_file():
+        raise ValueError(f"verifier must be a file: {verifier}")
+    command = [uv, "run", "--no-project", "--python", "3.14"]
+    for requirement in args.requirements:
+        command.extend(("--with", _requirement(requirement)))
+    verifier_args = args.verifier_args
+    if verifier_args[:1] == ["--"]:
+        verifier_args = verifier_args[1:]
+    command.extend(("python", str(verifier), *verifier_args))
+    environment = _clean_environment(os.environ)
+    with tempfile.TemporaryDirectory() as directory:
+        subprocess.run(command, cwd=directory, env=environment, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_commands_install.py
+++ b/scripts/verify_commands_install.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import importlib.metadata
 import json
@@ -64,7 +65,7 @@ def _installed_plugin() -> PluginDefinition:
     return candidate
 
 
-async def verify() -> None:
+async def verify(expected_version: str | None = None) -> None:
     _verify_import_sources()
     definition = _installed_plugin()
     event = EventEnvelope(
@@ -104,8 +105,13 @@ async def verify() -> None:
             "liteyukibot-v7-commands",
         )
     }
+    if expected_version is not None and observed["liteyukibot-v7-commands"] != expected_version:
+        raise RuntimeError(f"expected liteyukibot-v7-commands {expected_version}; observed {observed}")
     print(json.dumps(observed, sort_keys=True))
 
 
 if __name__ == "__main__":
-    asyncio.run(verify())
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-version")
+    arguments = parser.parse_args()
+    asyncio.run(verify(arguments.expected_version))

--- a/scripts/verify_essentials_install.py
+++ b/scripts/verify_essentials_install.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import importlib.metadata
 import json
@@ -73,7 +74,7 @@ def _event(text: str, actor_id: str) -> EventEnvelope:
     )
 
 
-async def verify() -> None:
+async def verify(expected_version: str | None = None) -> None:
     _verify_import_sources()
     _verify_entry_points()
     with tempfile.TemporaryDirectory() as directory:
@@ -132,7 +133,7 @@ async def verify() -> None:
                 raise RuntimeError("installed operator status command did not reply")
             status_message = actions[-1].action
             if not isinstance(status_message, SendMessage) or not status_message.message.plain_text.startswith(
-                "LiteyukiBot 7.0.0a2\nState: ready"
+                "LiteyukiBot 7.0.0a3\nState: ready"
             ):
                 raise RuntimeError("installed status command produced invalid text")
         finally:
@@ -147,8 +148,15 @@ async def verify() -> None:
             "liteyukibot-v7-essentials",
         )
     }
+    if expected_version is not None and observed["liteyukibot-v7-essentials"] != expected_version:
+        raise RuntimeError(
+            f"expected liteyukibot-v7-essentials {expected_version}; observed {observed}"
+        )
     print(json.dumps(observed, sort_keys=True))
 
 
 if __name__ == "__main__":
-    asyncio.run(verify())
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-version")
+    arguments = parser.parse_args()
+    asyncio.run(verify(arguments.expected_version))

--- a/scripts/verify_permissions_install.py
+++ b/scripts/verify_permissions_install.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import importlib.metadata
 import json
@@ -43,7 +44,7 @@ def _installed_plugin() -> PluginDefinition:
     return candidate
 
 
-async def verify() -> None:
+async def verify(expected_version: str | None = None) -> None:
     _verify_import_sources()
 
     definition = _installed_plugin()
@@ -72,8 +73,15 @@ async def verify() -> None:
             "liteyukibot-v7-permissions"
         ),
     }
+    if expected_version is not None and observed["liteyukibot-v7-permissions"] != expected_version:
+        raise RuntimeError(
+            f"expected liteyukibot-v7-permissions {expected_version}; observed {observed}"
+        )
     print(json.dumps(observed, sort_keys=True))
 
 
 if __name__ == "__main__":
-    asyncio.run(verify())
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-version")
+    arguments = parser.parse_args()
+    asyncio.run(verify(arguments.expected_version))

--- a/scripts/verify_published_install.py
+++ b/scripts/verify_published_install.py
@@ -6,10 +6,18 @@ import argparse
 import importlib
 import importlib.metadata
 import json
+from pathlib import Path
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _module_version(module_name: str) -> str:
     module = importlib.import_module(module_name)
+    module_file = getattr(module, "__file__", None)
+    if not isinstance(module_file, str):
+        raise RuntimeError(f"{module_name} does not expose __file__")
+    if Path(module_file).resolve().is_relative_to(SOURCE_ROOT):
+        raise RuntimeError(f"workspace source import detected: {module_file}")
     version = getattr(module, "__version__", None)
     if not isinstance(version, str):
         raise RuntimeError(f"{module_name} does not expose a string __version__")
@@ -19,22 +27,24 @@ def _module_version(module_name: str) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--distribution", default="liteyukibot-v7")
-    parser.add_argument("--expected-version", required=True)
+    parser.add_argument("--expected-version")
     args = parser.parse_args()
 
+    distribution_version = importlib.metadata.version(args.distribution)
+    expected_version = args.expected_version or distribution_version
     observed = {
-        args.distribution: importlib.metadata.version(args.distribution),
+        args.distribution: distribution_version,
         "liteyukibot": _module_version("liteyukibot"),
         "liteyuki": _module_version("liteyuki"),
     }
     mismatches = {
-        name: version for name, version in observed.items() if version != args.expected_version
+        name: version for name, version in observed.items() if version != expected_version
     }
     if mismatches:
         rendered = ", ".join(f"{name}={version}" for name, version in mismatches.items())
-        raise RuntimeError(f"expected {args.expected_version}; observed {rendered}")
+        raise RuntimeError(f"expected {expected_version}; observed {rendered}")
 
-    print(json.dumps({"expected": args.expected_version, "observed": observed}, sort_keys=True))
+    print(json.dumps({"expected": expected_version, "observed": observed}, sort_keys=True))
     return 0
 
 

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -4,7 +4,14 @@ import importlib.metadata
 from pathlib import Path
 
 import pytest
-from scripts.check_release import ReleaseIdentity, read_release_identity, validate_release
+from scripts.check_release import (
+    RELEASE_PROJECTS,
+    ReleaseIdentity,
+    project_for_tag,
+    read_release_identity,
+    validate_release,
+)
+from scripts.run_isolated_install import _clean_environment, _requirement
 
 import liteyuki
 import liteyukibot
@@ -17,24 +24,69 @@ def test_import_namespaces_use_distribution_version() -> None:
     assert liteyuki.__version__ == expected
 
 
-def test_current_release_identity_accepts_matching_tag() -> None:
-    identity = read_release_identity(Path("pyproject.toml"))
+@pytest.mark.parametrize(
+    ("name", "tag"),
+    [
+        ("root", "v7.0.0a3"),
+        ("permissions", "permissions-v0.1.0a1"),
+        ("commands", "commands-v0.1.0a1"),
+        ("essentials", "essentials-v0.1.0a1"),
+    ],
+)
+def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> None:
+    project = RELEASE_PROJECTS[name]
+    identity = read_release_identity(project.project_file)
 
-    validate_release(identity, tag=f"v{identity.version}")
-    assert identity.distribution == "liteyukibot-v7"
+    validate_release(identity, project=project, tag=tag)
+    assert identity.distribution == project.distribution
+    assert project_for_tag(tag) == project
 
 
 @pytest.mark.parametrize(
-    ("identity", "tag", "message"),
+    ("identity", "project_name", "tag", "message"),
     [
-        (ReleaseIdentity("liteyukibot", "7.0.0a2"), None, "project.name"),
-        (ReleaseIdentity("liteyukibot-v7", "7.0.0a2"), "v7.0.0a1", "release tag"),
+        (ReleaseIdentity("liteyukibot", "7.0.0a3"), "root", None, "project.name"),
+        (ReleaseIdentity("liteyukibot-v7", "7.0.0a3"), "root", "v7.0.0a2", "release tag"),
+        (
+            ReleaseIdentity("liteyukibot-v7-commands", "0.1.0a1"),
+            "commands",
+            "permissions-v0.1.0a1",
+            "release tag",
+        ),
     ],
 )
 def test_release_identity_rejects_mismatches(
     identity: ReleaseIdentity,
+    project_name: str,
     tag: str | None,
     message: str,
 ) -> None:
     with pytest.raises(RuntimeError, match=message):
-        validate_release(identity, tag=tag)
+        validate_release(identity, project=RELEASE_PROJECTS[project_name], tag=tag)
+
+
+@pytest.mark.parametrize("tag", ["v6.9.0", "plugin-v0.1.0", ""])
+def test_release_tag_must_select_a_known_project(tag: str) -> None:
+    with pytest.raises(RuntimeError, match="does not select"):
+        project_for_tag(tag)
+
+
+def test_isolated_install_environment_removes_workspace_inheritance() -> None:
+    cleaned = _clean_environment(
+        {
+            "PATH": "bin",
+            "VIRTUAL_ENV": "workspace/.venv",
+            "PYTHONPATH": "workspace/src",
+            "UV_PROJECT_ENVIRONMENT": "workspace/.venv",
+            "UV_WORKING_DIRECTORY": "workspace",
+        }
+    )
+
+    assert cleaned == {"PATH": "bin"}
+
+
+def test_isolated_install_rejects_empty_and_directory_requirements(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        _requirement("")
+    with pytest.raises(ValueError, match="must be a file"):
+        _requirement(str(tmp_path))

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a2"
+version = "7.0.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- bump the root release to 7.0.0a3 and require it from all first-party plugin packages
- add fixed four-package release identities, Trusted Publisher workflows, and ordered isolated verification
- harden published-install checks against inherited workspace environments and document the exact release procedure

## Validation
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv run pytest (173 passed, 20 skipped)
- uv build --all-packages --out-dir dist/workspace --clear
- four staged isolated wheel verification chains
- public PyPI range verification resolved 7.0.0a2 outside the workspace
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- docker build -t liteyukibot-v7:a3-test .
- non-root container version/config smoke