### PR TITLE
🐛 Isolate plugin publisher environments

### DIFF
--- a/.github/workflows/publish-plugins.yaml
+++ b/.github/workflows/publish-plugins.yaml
@@ -30,7 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('{0}-v{1}', inputs.package, inputs.version) || github.ref_name }}
-    environment: pypi
+    environment:
+      name: ${{ github.event_name == 'workflow_dispatch' && format('pypi-{0}', inputs.package) || startsWith(github.ref_name, 'permissions-v') && 'pypi-permissions' || startsWith(github.ref_name, 'commands-v') && 'pypi-commands' || 'pypi-essentials' }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.3.2

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -8,15 +8,21 @@ from a clean `v7` commit only after the full CI matrix passes.
 The PyPI publisher settings use:
 
 - owner/repository: `LiteyukiStudio/LiteyukiBot`;
-- environment: `pypi`;
-- root workflow: `publish.yml`;
-- plugin workflow: `publish-plugins.yaml`.
+- root workflow/environment: `publish.yml` / `pypi`;
+- plugin workflow: `publish-plugins.yaml`;
+- one environment per plugin, as listed below.
 
-Before the first plugin upload, create Pending Publishers for:
+Before the first plugin upload, create these Pending Publishers:
 
-- `liteyukibot-v7-permissions`;
-- `liteyukibot-v7-commands`;
-- `liteyukibot-v7-essentials`.
+| Project | GitHub environment |
+| --- | --- |
+| `liteyukibot-v7-permissions` | `pypi-permissions` |
+| `liteyukibot-v7-commands` | `pypi-commands` |
+| `liteyukibot-v7-essentials` | `pypi-essentials` |
+
+PyPI requires different pending project names to use distinct publisher
+identities. The workflow selects the environment from the release tag (or the
+manual dispatch package), while the repository and workflow name stay shared.
 
 Do not create tags until every corresponding publisher is configured. A 404
 from the PyPI JSON endpoint is expected before the first trusted upload; an


### PR DESCRIPTION
Map each plugin release to a distinct GitHub environment and document the matching PyPI pending publisher identity. Validated with actionlint, all three release identity checks, and git diff --check.