### PR TITLE
✨ Add capability permission policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ under ADR 0011 before the first stable release.
 - authenticated framed JSON IPC and supervised subprocess runtimes;
 - NoneBot2 plugin hosting and a deliberately bounded v6 compatibility shim;
 - local authenticated CLI control and an optional loopback-only HTTP status API.
-- read-only kernel status plus separately distributable permission, command,
-  help, and operator-status plugins.
+- read-only kernel status plus separately distributable capability, command,
+  help, and protected-status plugins.
 
 ## Requirements
 

--- a/docs/adr/0013-first-party-permission-service.md
+++ b/docs/adr/0013-first-party-permission-service.md
@@ -1,6 +1,6 @@
 # ADR 0013: Keep Access Policy in a First-Party Plugin
 
-- Status: Accepted
+- Status: Superseded in part by ADR 0016
 - Date: 2026-08-10
 
 ## Context

--- a/docs/adr/0015-first-party-essential-commands.md
+++ b/docs/adr/0015-first-party-essential-commands.md
@@ -1,6 +1,6 @@
 # ADR 0015: Keep Essential Commands in a Consumer Plugin
 
-- Status: Accepted
+- Status: Superseded in part by ADR 0016
 - Date: 2026-08-10
 
 ## Context

--- a/docs/adr/0016-capability-permission-policy.md
+++ b/docs/adr/0016-capability-permission-policy.md
@@ -1,0 +1,61 @@
+# ADR 0016: Resolve Static Roles into Exact Capabilities
+
+- Status: Accepted
+- Date: 2026-08-10
+
+## Context
+
+ADR 0013 established a first-party permission service outside the kernel and
+deliberately limited its first alpha to `public` and `operator`. Native plugins
+now need independent permissions without teaching the kernel about users or
+forcing every privileged command into one broad operator category.
+
+The project remains in rapid alpha development. Keeping both an operator
+allowlist and a capability model would create two policy languages before
+either is stable. Dynamic policy, persistence, wildcard selectors, and role
+inheritance would also add ownership and migration questions that the current
+static application configuration does not answer.
+
+## Decision
+
+`liteyukibot-v7-permissions` continues to provide
+`liteyukibot.permissions@1`. The consumer call shape remains
+`allows(event, capability)`, but the `operator` constant and `operators`
+configuration are removed. This record replaces the policy details in ADR
+0013 and the status permission in ADR 0015; the package and kernel boundaries
+established there remain unchanged.
+
+A principal is still the exact `(runtime_id, bot_id, actor_id)` tuple. Static
+configuration defines named roles as sets of capability tokens and grants roles
+or direct capabilities to exact principals. Roles do not inherit from other
+roles. Grants are additive and cannot contain deny entries or wildcards.
+
+The service exposes `resolve(event) -> PermissionSnapshot`. The frozen snapshot
+contains the resolved principal, role names, and fully expanded capabilities.
+Every event has the reserved `public` capability; an event without an actor has
+no principal or other capability. Plugins check capability names and never
+role names.
+
+Role names and capabilities are case-sensitive, trimmed, non-empty tokens
+without whitespace. `public` cannot be configured explicitly. Duplicate
+entries, duplicate principals, empty roles or grants, undefined roles, unknown
+fields, and malformed values fail plugin setup. Runtime checks are exact and
+fail closed. An ordinary missing capability is not logged as a warning.
+
+Role expansion is completed once during setup. Runtime resolution performs no
+I/O, mutation, inheritance traversal, or adapter-specific lookup. The service
+is application policy for trusted in-process plugins, not a sandbox boundary.
+
+## Consequences
+
+Deployments can group capabilities without coupling plugins to deployment role
+names. Permission snapshots are suitable for diagnostics and tests while
+remaining deeply immutable.
+
+Existing alpha configurations using `operators` must migrate to `roles` and
+`grants`. This is an intentional pre-stable contract correction; the runtime
+does not maintain dual configuration paths.
+
+Persistent policy, remote updates, deny rules, wildcard scopes, role
+inheritance, and adapter superuser imports remain future work. They require a
+new decision because they change conflict resolution and operational ownership.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@ stable-release guarantee.
 13. [First-party permission service](0013-first-party-permission-service.md)
 14. [First-party command service](0014-first-party-command-service.md)
 15. [First-party essential commands](0015-first-party-essential-commands.md)
+16. [Static capability and role policy](0016-capability-permission-policy.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -163,3 +163,11 @@ a premature kernel localization contract.
 Phase 4 is released as `7.0.0a3`; the three plugin distributions begin at
 `0.1.0a1`. Release identities and tag prefixes are fixed per package, and the
 dependency chain is published in root, permissions, commands, essentials order.
+
+Phase 5 evolves the first-party plugin contracts without expanding the kernel.
+Its permission service resolves static roles and exact-principal grants into
+immutable capability snapshots; `liteyukibot.status.read` replaces role-name
+checks for the essential status command. ADR 0016 records the fail-closed,
+no-wildcard policy. Structured command parsing and hierarchical help remain the
+next parts of this phase. Runtime IPC stays at v3 and the kernel dependency set
+does not change.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -96,11 +96,13 @@ The first-party `liteyukibot-v7-permissions` package provides
 `PermissionService` from `liteyukibot_permissions`, declare the service in
 their manifest, and call `allows(event, permission)`.
 
-The alpha implementation recognizes `public` and `operator`. Operators are
-exact runtime, bot, and actor triples configured under
-`plugins.config."liteyukibot.permissions"`. Unknown permission strings are
-denied. The service is application policy for trusted plugins; it is not a
-sandbox boundary.
+The alpha implementation maps exact runtime, bot, and actor principals to
+static named roles and exact capability tokens configured under
+`plugins.config."liteyukibot.permissions"`. Every event has `public`;
+`resolve(event)` exposes a frozen diagnostic snapshot and unknown capabilities
+are denied. Plugins check capabilities rather than deployment role names. The
+service is application policy for trusted plugins; it is not a sandbox
+boundary.
 
 ## Commands
 
@@ -120,11 +122,12 @@ text and does not implement options, subcommands, or typed conversion.
 ## Essentials
 
 `liteyukibot-v7-essentials` is a consumer plugin, not a kernel feature. It
-registers public `help`/`帮助` and operator-only `status`/`状态`, renders only
-protocol-neutral text, and provides no service. Enable permissions and commands
-before essentials in deployment configuration. Help filters registrations
-through the command service for the current event; status reads the immutable
-kernel status provider.
+registers public `help`/`帮助` and capability-protected `status`/`状态`, renders
+only protocol-neutral text, and provides no service. Status requires
+`liteyukibot.status.read`. Enable permissions and commands before essentials in
+deployment configuration. Help filters registrations through the command
+service for the current event; status reads the immutable kernel status
+provider.
 
 The `language` setting accepts `zh-CN` or `en`. This dictionary is intentionally
 local to the package and does not define a localization API for other plugins.

--- a/liteyuki.example.toml
+++ b/liteyuki.example.toml
@@ -23,7 +23,10 @@ local_modules = []
 # ]
 
 [plugins.config."liteyukibot.permissions"]
-operators = []
+grants = []
+
+[plugins.config."liteyukibot.permissions".roles]
+operator = ["liteyukibot.status.read"]
 
 [plugins.config."liteyukibot.commands"]
 prefixes = ["/"]

--- a/packages/commands/tests/test_commands.py
+++ b/packages/commands/tests/test_commands.py
@@ -12,7 +12,7 @@ from liteyukibot_commands import (
     CommandSpec,
     plugin,
 )
-from liteyukibot_permissions import OPERATOR, PERMISSION_SERVICE, PUBLIC, Principal
+from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, PermissionSnapshot, Principal
 
 from liteyukibot import LiteyukiApp
 from liteyukibot.config import AppSettings, CoreSettings, PluginSettings
@@ -29,6 +29,8 @@ from liteyukibot.exceptions import PluginError, ServiceError
 from liteyukibot.logging import get_logger
 from liteyukibot.testing import PluginTestHarness
 
+ADMIN = "tests.admin"
+
 
 class PermissionStub:
     def principal(self, event: EventEnvelope) -> Principal | None:
@@ -36,10 +38,15 @@ class PermissionStub:
             return None
         return Principal(event.runtime_id, event.bot_id, event.actor.id)
 
+    def resolve(self, event: EventEnvelope) -> PermissionSnapshot:
+        principal = self.principal(event)
+        capabilities = {PUBLIC}
+        if event.actor is not None and event.actor.id == "operator":
+            capabilities.add(ADMIN)
+        return PermissionSnapshot(principal, frozenset(), frozenset(capabilities))
+
     def allows(self, event: EventEnvelope, permission: str) -> bool:
-        if permission == PUBLIC:
-            return True
-        return permission == OPERATOR and event.actor is not None and event.actor.id == "operator"
+        return self.resolve(event).allows(permission)
 
 
 def message_event(text: str, *, actor_id: str = "user") -> EventEnvelope:
@@ -159,7 +166,7 @@ async def test_recognized_denied_and_failed_commands_stop_propagation(tmp_path: 
             calls.append("invalid")
             return "not a HandlerResult"
 
-        service.register(CommandSpec("denied", permission=OPERATOR), denied, owner="tests")
+        service.register(CommandSpec("denied", permission=ADMIN), denied, owner="tests")
         service.register(CommandSpec("failed"), failed, owner="tests")
         service.register(CommandSpec("invalid"), invalid, owner="tests")  # type: ignore[arg-type]
 
@@ -182,7 +189,7 @@ async def test_visible_commands_are_sorted_and_permission_filtered(tmp_path: Pat
             return None
 
         service.register(CommandSpec("zeta"), handler, owner="tests")
-        service.register(CommandSpec("admin", permission=OPERATOR), handler, owner="tests")
+        service.register(CommandSpec("admin", permission=ADMIN), handler, owner="tests")
         service.register(CommandSpec("alpha"), handler, owner="tests")
 
         user_commands = service.visible(message_event("unused"))

--- a/packages/essentials/README.md
+++ b/packages/essentials/README.md
@@ -5,8 +5,8 @@ commands for native LiteyukiBot v7 deployments.
 
 The plugin adds no service. It consumes `liteyukibot.commands@1` and the
 kernel's `liteyukibot.kernel.status@1` snapshot service. Help only lists
-commands visible to the current actor; status requires the `operator`
-permission.
+commands visible to the current actor; status requires the
+`liteyukibot.status.read` capability.
 
 ```toml
 [plugins]

--- a/packages/essentials/src/liteyukibot_essentials/plugin.py
+++ b/packages/essentials/src/liteyukibot_essentials/plugin.py
@@ -21,7 +21,7 @@ from liteyukibot.status import KERNEL_STATUS_SERVICE, KernelStatusProvider
 from .render import Language, messages, render_help, render_status
 
 _PUBLIC_PERMISSION = "public"
-_OPERATOR_PERMISSION = "operator"
+_STATUS_READ_CAPABILITY = "liteyukibot.status.read"
 
 
 def _language(config: Mapping[str, Any]) -> Language:
@@ -62,7 +62,7 @@ async def setup(context: PluginContext) -> PluginHandle:
                 "status",
                 aliases=("状态",),
                 summary=text.status_summary,
-                permission=_OPERATOR_PERMISSION,
+                permission=_STATUS_READ_CAPABILITY,
             ),
             status_command,
         ),

--- a/packages/essentials/tests/test_essentials.py
+++ b/packages/essentials/tests/test_essentials.py
@@ -7,7 +7,7 @@ import pytest
 from liteyukibot_commands import COMMAND_SERVICE, CommandService
 from liteyukibot_commands.service import create_command_service
 from liteyukibot_essentials import plugin, render_status
-from liteyukibot_permissions import OPERATOR, PERMISSION_SERVICE, PUBLIC, Principal
+from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, PermissionSnapshot, Principal
 
 from liteyukibot import KERNEL_STATUS_SERVICE, LiteyukiApp
 from liteyukibot.config import AppSettings, CoreSettings, PluginSettings
@@ -26,6 +26,8 @@ from liteyukibot.logging import get_logger
 from liteyukibot.status import KernelStatusSnapshot
 from liteyukibot.testing import PluginTestHarness
 
+STATUS_READ = "liteyukibot.status.read"
+
 
 class PermissionStub:
     def principal(self, event: EventEnvelope) -> Principal | None:
@@ -33,10 +35,15 @@ class PermissionStub:
             return None
         return Principal(event.runtime_id, event.bot_id, event.actor.id)
 
+    def resolve(self, event: EventEnvelope) -> PermissionSnapshot:
+        principal = self.principal(event)
+        capabilities = {PUBLIC}
+        if event.actor is not None and event.actor.id == "operator":
+            capabilities.add(STATUS_READ)
+        return PermissionSnapshot(principal, frozenset(), frozenset(capabilities))
+
     def allows(self, event: EventEnvelope, permission: str) -> bool:
-        if permission == PUBLIC:
-            return True
-        return permission == OPERATOR and event.actor is not None and event.actor.id == "operator"
+        return self.resolve(event).allows(permission)
 
 
 class StatusStub:
@@ -149,11 +156,13 @@ async def test_three_plugin_topology_filters_help_and_correlates_status(tmp_path
             ),
             config={
                 "liteyukibot.permissions": {
-                    "operators": [
+                    "roles": {"operator": [STATUS_READ]},
+                    "grants": [
                         {
                             "runtime_id": "runtime",
                             "bot_id": "bot",
                             "actor_id": "operator",
+                            "roles": ["operator"],
                         }
                     ]
                 },

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -3,21 +3,27 @@
 `liteyukibot-v7-permissions` provides the versioned
 `liteyukibot.permissions@1` service for native LiteyukiBot v7 plugins.
 
-The alpha contract recognizes `public` and `operator`. Operators are exact
-`runtime_id`, `bot_id`, and `actor_id` triples; wildcards and actor-only global
+The service resolves exact `runtime_id`, `bot_id`, and `actor_id` principals
+into named roles and capability tokens. Wildcards and actor-only global
 identities are intentionally unsupported.
 
 ```toml
 [plugins]
 enabled = ["liteyukibot.permissions"]
 
-[plugins.config."liteyukibot.permissions"]
-operators = [
-  { runtime_id = "nonebot", bot_id = "10000", actor_id = "20000" },
-]
+[plugins.config."liteyukibot.permissions".roles]
+operator = ["liteyukibot.status.read", "example.echo.manage"]
+
+[[plugins.config."liteyukibot.permissions".grants]]
+runtime_id = "nonebot"
+bot_id = "10000"
+actor_id = "20000"
+roles = ["operator"]
+capabilities = ["example.echo.use"]
 ```
 
 Consumers declare `ServiceRequirement(PERMISSION_SERVICE)` and resolve a
-`PermissionService` from their plugin context. Unknown permission strings are
-denied, allowing a later capability model without changing the service method
-signature.
+`PermissionService` from their plugin context. `allows(event, capability)`
+performs an exact, fail-closed check. `resolve(event)` returns a frozen snapshot
+for diagnostics. Every event has `public`; plugins check capabilities rather
+than deployment role names.

--- a/packages/permissions/src/liteyukibot_permissions/__init__.py
+++ b/packages/permissions/src/liteyukibot_permissions/__init__.py
@@ -3,7 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .plugin import create_plugin
-from .service import OPERATOR, PERMISSION_SERVICE, PUBLIC, PermissionService, Principal
+from .service import PERMISSION_SERVICE, PUBLIC, PermissionService, PermissionSnapshot, Principal
 
 try:
     __version__ = version("liteyukibot-v7-permissions")
@@ -13,10 +13,10 @@ except PackageNotFoundError:
 plugin = create_plugin(__version__)
 
 __all__ = [
-    "OPERATOR",
     "PERMISSION_SERVICE",
     "PUBLIC",
     "PermissionService",
+    "PermissionSnapshot",
     "Principal",
     "__version__",
     "plugin",

--- a/packages/permissions/src/liteyukibot_permissions/plugin.py
+++ b/packages/permissions/src/liteyukibot_permissions/plugin.py
@@ -8,7 +8,7 @@ from .service import PERMISSION_SERVICE, create_permission_service
 
 
 async def setup(context: PluginContext) -> None:
-    service = create_permission_service(context.config, context.logger)
+    service = create_permission_service(context.config)
     context.services.provide(PERMISSION_SERVICE, service)
 
 

--- a/packages/permissions/src/liteyukibot_permissions/service.py
+++ b/packages/permissions/src/liteyukibot_permissions/service.py
@@ -1,4 +1,4 @@
-"""Permission identities and access checks."""
+"""Permission identities, capability grants, and access checks."""
 
 from __future__ import annotations
 
@@ -10,12 +10,15 @@ from liteyukibot.events import EventEnvelope
 from liteyukibot.services import ServiceKey
 
 PUBLIC = "public"
-OPERATOR = "operator"
 PERMISSION_SERVICE = ServiceKey("liteyukibot.permissions", 1)
 
 
-class _Logger(Protocol):
-    def warning(self, message: str, *args: Any, **kwargs: Any) -> None: ...
+def _validate_token(kind: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"permission {kind} must be a string")
+    if not value or value != value.strip() or any(character.isspace() for character in value):
+        raise ValueError(f"permission {kind} must be a non-empty token without whitespace")
+    return value
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,16 +39,40 @@ class Principal:
                 raise ValueError(f"principal {name} must be a non-empty trimmed string")
 
 
+@dataclass(frozen=True, slots=True)
+class PermissionSnapshot:
+    principal: Principal | None
+    roles: frozenset[str]
+    capabilities: frozenset[str]
+
+    def __post_init__(self) -> None:
+        roles = frozenset(self.roles)
+        capabilities = frozenset(self.capabilities)
+        for role in roles:
+            _validate_token("snapshot role", role)
+        for capability in capabilities:
+            _validate_token("snapshot capability", capability)
+        if PUBLIC not in capabilities:
+            raise ValueError("permission snapshot must include public capability")
+        object.__setattr__(self, "roles", roles)
+        object.__setattr__(self, "capabilities", capabilities)
+
+    def allows(self, capability: str) -> bool:
+        return capability in self.capabilities
+
+
 class PermissionService(Protocol):
     def principal(self, event: EventEnvelope) -> Principal | None: ...
 
-    def allows(self, event: EventEnvelope, permission: str) -> bool: ...
+    def resolve(self, event: EventEnvelope) -> PermissionSnapshot: ...
+
+    def allows(self, event: EventEnvelope, capability: str) -> bool: ...
 
 
 class _ConfiguredPermissionService:
-    def __init__(self, operators: frozenset[Principal], logger: _Logger) -> None:
-        self._operators = operators
-        self._logger = logger
+    def __init__(self, snapshots: Mapping[Principal, PermissionSnapshot]) -> None:
+        self._snapshots = dict(snapshots)
+        self._anonymous = PermissionSnapshot(None, frozenset(), frozenset({PUBLIC}))
 
     def principal(self, event: EventEnvelope) -> Principal | None:
         if event.actor is None:
@@ -56,63 +83,141 @@ class _ConfiguredPermissionService:
             actor_id=event.actor.id,
         )
 
-    def allows(self, event: EventEnvelope, permission: str) -> bool:
-        if permission == PUBLIC:
-            return True
-        if permission == OPERATOR:
-            principal = self.principal(event)
-            return principal is not None and principal in self._operators
-        self._logger.warning(
-            "unknown permission {} denied",
-            permission,
-            event_id=event.id,
-            runtime=event.runtime_id,
-            bot_id=event.bot_id,
+    def resolve(self, event: EventEnvelope) -> PermissionSnapshot:
+        principal = self.principal(event)
+        if principal is None:
+            return self._anonymous
+        return self._snapshots.get(
+            principal,
+            PermissionSnapshot(principal, frozenset(), frozenset({PUBLIC})),
         )
-        return False
+
+    def allows(self, event: EventEnvelope, capability: str) -> bool:
+        if not isinstance(capability, str):
+            return False
+        if not capability or capability != capability.strip() or any(character.isspace() for character in capability):
+            return False
+        return self.resolve(event).allows(capability)
 
 
-def create_permission_service(
-    config: Mapping[str, Any],
-    logger: _Logger,
-) -> PermissionService:
-    unknown = set(config) - {"operators"}
+def _parse_token_sequence(value: object, *, location: str, kind: str) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise TypeError(f"permission {location} must be a sequence of strings")
+    parsed: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        token = _validate_token(f"{location}[{index}] {kind}", item)
+        if token in seen:
+            raise ValueError(f"permission {location}[{index}] duplicates {kind} {token}")
+        seen.add(token)
+        parsed.append(token)
+    return tuple(parsed)
+
+
+def _parse_roles(value: object) -> dict[str, frozenset[str]]:
+    if not isinstance(value, Mapping):
+        raise TypeError("permission roles must be an object")
+    roles: dict[str, frozenset[str]] = {}
+    for raw_name, raw_capabilities in value.items():
+        name = _validate_token("role name", raw_name)
+        capabilities = _parse_token_sequence(
+            raw_capabilities,
+            location=f"roles.{name}",
+            kind="capability",
+        )
+        if not capabilities:
+            raise ValueError(f"permission role {name} must contain at least one capability")
+        if PUBLIC in capabilities:
+            raise ValueError(f"permission role {name} must not grant reserved capability {PUBLIC}")
+        roles[name] = frozenset(capabilities)
+    return roles
+
+
+def _invalid_fields(location: str, actual: set[object], required: set[str], optional: set[str]) -> ValueError:
+    missing = sorted(required - actual)
+    extra = sorted(str(item) for item in actual - required - optional)
+    details: list[str] = []
+    if missing:
+        details.append(f"missing {', '.join(missing)}")
+    if extra:
+        details.append(f"unknown {', '.join(extra)}")
+    return ValueError(f"permission {location} has invalid fields: {'; '.join(details)}")
+
+
+def _parse_grants(
+    value: object,
+    roles: Mapping[str, frozenset[str]],
+) -> dict[Principal, PermissionSnapshot]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise TypeError("permission grants must be a sequence of objects")
+    snapshots: dict[Principal, PermissionSnapshot] = {}
+    required = {"runtime_id", "bot_id", "actor_id"}
+    optional = {"roles", "capabilities"}
+    for index, raw_grant in enumerate(value):
+        location = f"grants[{index}]"
+        if not isinstance(raw_grant, Mapping):
+            raise TypeError(f"permission {location} must be an object")
+        actual = set(raw_grant)
+        invalid_fields = (
+            not all(isinstance(field, str) for field in actual)
+            or not required <= actual
+            or bool(actual - required - optional)
+        )
+        if invalid_fields:
+            raise _invalid_fields(location, actual, required, optional)
+
+        principal = Principal(
+            runtime_id=raw_grant["runtime_id"],
+            bot_id=raw_grant["bot_id"],
+            actor_id=raw_grant["actor_id"],
+        )
+        if principal in snapshots:
+            raise ValueError(f"permission {location} duplicates an earlier principal")
+
+        assigned_roles = _parse_token_sequence(
+            raw_grant.get("roles", ()),
+            location=f"{location}.roles",
+            kind="role",
+        )
+        direct_capabilities = _parse_token_sequence(
+            raw_grant.get("capabilities", ()),
+            location=f"{location}.capabilities",
+            kind="capability",
+        )
+        if not assigned_roles and not direct_capabilities:
+            raise ValueError(f"permission {location} must assign at least one role or capability")
+        unknown_roles = sorted(set(assigned_roles) - roles.keys())
+        if unknown_roles:
+            raise ValueError(f"permission {location} references unknown roles: {', '.join(unknown_roles)}")
+        if PUBLIC in direct_capabilities:
+            raise ValueError(f"permission {location} must not grant reserved capability {PUBLIC}")
+
+        capabilities = {PUBLIC, *direct_capabilities}
+        for role in assigned_roles:
+            capabilities.update(roles[role])
+        snapshots[principal] = PermissionSnapshot(
+            principal=principal,
+            roles=frozenset(assigned_roles),
+            capabilities=frozenset(capabilities),
+        )
+    return snapshots
+
+
+def create_permission_service(config: Mapping[str, Any]) -> PermissionService:
+    if not all(isinstance(key, str) for key in config):
+        raise TypeError("permission config keys must be strings")
+    unknown = set(config) - {"roles", "grants"}
     if unknown:
         raise ValueError(f"unknown permission config keys: {', '.join(sorted(unknown))}")
-
-    raw_operators = config.get("operators", ())
-    if not isinstance(raw_operators, Sequence) or isinstance(raw_operators, (str, bytes)):
-        raise TypeError("permission operators must be a sequence of objects")
-
-    operators: set[Principal] = set()
-    for index, raw_operator in enumerate(raw_operators):
-        if not isinstance(raw_operator, Mapping):
-            raise TypeError(f"permission operators[{index}] must be an object")
-        expected = {"runtime_id", "bot_id", "actor_id"}
-        actual = set(raw_operator)
-        if actual != expected:
-            missing = sorted(expected - actual)
-            extra = sorted(actual - expected)
-            details: list[str] = []
-            if missing:
-                details.append(f"missing {', '.join(missing)}")
-            if extra:
-                details.append(f"unknown {', '.join(extra)}")
-            raise ValueError(f"permission operators[{index}] has invalid fields: {'; '.join(details)}")
-        values = {name: raw_operator[name] for name in expected}
-        if any(not isinstance(value, str) for value in values.values()):
-            raise TypeError(f"permission operators[{index}] fields must be strings")
-        principal = Principal(**values)
-        if principal in operators:
-            raise ValueError(f"permission operators[{index}] duplicates an earlier identity")
-        operators.add(principal)
-    return _ConfiguredPermissionService(frozenset(operators), logger)
+    roles = _parse_roles(config.get("roles", {}))
+    snapshots = _parse_grants(config.get("grants", ()), roles)
+    return _ConfiguredPermissionService(snapshots)
 
 
 __all__ = [
-    "OPERATOR",
     "PERMISSION_SERVICE",
     "PUBLIC",
     "PermissionService",
+    "PermissionSnapshot",
     "Principal",
 ]

--- a/packages/permissions/tests/test_permissions.py
+++ b/packages/permissions/tests/test_permissions.py
@@ -5,10 +5,10 @@ from typing import cast
 
 import pytest
 from liteyukibot_permissions import (
-    OPERATOR,
     PERMISSION_SERVICE,
     PUBLIC,
     PermissionService,
+    PermissionSnapshot,
     Principal,
     plugin,
 )
@@ -16,6 +16,9 @@ from liteyukibot_permissions import (
 from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
 from liteyukibot.exceptions import PluginError, ServiceError
 from liteyukibot.testing import PluginTestHarness
+
+STATUS_READ = "liteyukibot.status.read"
+PLUGIN_MANAGE = "example.plugin.manage"
 
 
 def event(*, runtime_id: str = "nonebot", bot_id: str = "bot-1", actor_id: str | None = "user-1") -> EventEnvelope:
@@ -29,64 +32,187 @@ def event(*, runtime_id: str = "nonebot", bot_id: str = "bot-1", actor_id: str |
     )
 
 
-@pytest.mark.asyncio
-async def test_permission_service_matches_exact_operator_identity(tmp_path: Path) -> None:
-    config = {
-        "operators": [
-            {"runtime_id": "nonebot", "bot_id": "bot-1", "actor_id": "user-1"},
-        ]
+def permission_config() -> dict[str, object]:
+    return {
+        "roles": {
+            "operator": [STATUS_READ, PLUGIN_MANAGE],
+            "auditor": [STATUS_READ],
+        },
+        "grants": [
+            {
+                "runtime_id": "nonebot",
+                "bot_id": "bot-1",
+                "actor_id": "user-1",
+                "roles": ["operator"],
+                "capabilities": ["example.echo.use"],
+            }
+        ],
     }
-    async with PluginTestHarness(plugin, root=tmp_path, config=config) as harness:
+
+
+@pytest.mark.asyncio
+async def test_permission_service_resolves_roles_and_exact_capabilities(tmp_path: Path) -> None:
+    async with PluginTestHarness(plugin, root=tmp_path, config=permission_config()) as harness:
         service = cast(PermissionService, harness.require_service(PERMISSION_SERVICE))
 
-        assert service.principal(event()) == Principal("nonebot", "bot-1", "user-1")
-        assert service.allows(event(actor_id=None), PUBLIC) is True
-        assert service.allows(event(), OPERATOR) is True
-        assert service.allows(event(runtime_id="other"), OPERATOR) is False
-        assert service.allows(event(bot_id="bot-2"), OPERATOR) is False
-        assert service.allows(event(actor_id="user-2"), OPERATOR) is False
-        assert service.allows(event(actor_id=None), OPERATOR) is False
-        assert service.allows(event(), "plugin.manage") is False
+        snapshot = service.resolve(event())
+        assert snapshot == PermissionSnapshot(
+            Principal("nonebot", "bot-1", "user-1"),
+            frozenset({"operator"}),
+            frozenset({PUBLIC, STATUS_READ, PLUGIN_MANAGE, "example.echo.use"}),
+        )
+        assert service.principal(event()) == snapshot.principal
+        assert service.allows(event(), PUBLIC) is True
+        assert service.allows(event(), STATUS_READ) is True
+        assert service.allows(event(), "example.echo.use") is True
+        assert service.allows(event(), "missing.capability") is False
 
     with pytest.raises(ServiceError, match="unavailable"):
         harness.require_service(PERMISSION_SERVICE)
 
 
 @pytest.mark.asyncio
+async def test_permission_service_isolates_principals_and_anonymous_events(tmp_path: Path) -> None:
+    async with PluginTestHarness(plugin, root=tmp_path, config=permission_config()) as harness:
+        service = cast(PermissionService, harness.require_service(PERMISSION_SERVICE))
+
+        for denied in (
+            event(runtime_id="other"),
+            event(bot_id="bot-2"),
+            event(actor_id="user-2"),
+        ):
+            snapshot = service.resolve(denied)
+            assert snapshot.principal is not None
+            assert snapshot.roles == frozenset()
+            assert snapshot.capabilities == frozenset({PUBLIC})
+            assert service.allows(denied, STATUS_READ) is False
+
+        anonymous = service.resolve(event(actor_id=None))
+        assert anonymous.principal is None
+        assert anonymous.roles == frozenset()
+        assert anonymous.capabilities == frozenset({PUBLIC})
+        assert service.allows(event(actor_id=None), PUBLIC) is True
+        assert service.allows(event(actor_id=None), STATUS_READ) is False
+
+
+@pytest.mark.asyncio
+async def test_permission_snapshot_is_deeply_immutable(tmp_path: Path) -> None:
+    async with PluginTestHarness(plugin, root=tmp_path, config=permission_config()) as harness:
+        service = cast(PermissionService, harness.require_service(PERMISSION_SERVICE))
+        snapshot = service.resolve(event())
+
+        with pytest.raises(AttributeError):
+            snapshot.roles.add("other")  # type: ignore[attr-defined]
+        with pytest.raises(AttributeError):
+            snapshot.capabilities.add("other")  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("config", "message"),
     [
-        ({"unknown": True}, "unknown permission config keys"),
-        ({"operators": "user-1"}, "must be a sequence"),
-        ({"operators": ["user-1"]}, "must be an object"),
+        ({"operators": []}, "unknown permission config keys"),
+        ({"roles": []}, "roles must be an object"),
+        ({"roles": {"operator": []}}, "must contain at least one capability"),
+        ({"roles": {"operator": [PUBLIC]}}, "must not grant reserved capability public"),
+        ({"roles": {"operator": [STATUS_READ, STATUS_READ]}}, "duplicates capability"),
+        ({"roles": {"bad role": [STATUS_READ]}}, "without whitespace"),
+        ({"grants": "user-1"}, "grants must be a sequence"),
+        ({"grants": ["user-1"]}, "grants[0] must be an object"),
         (
-            {"operators": [{"runtime_id": "nonebot", "bot_id": "bot-1"}]},
+            {"grants": [{"runtime_id": "nonebot", "bot_id": "bot-1", "roles": ["operator"]}]},
             "missing actor_id",
         ),
         (
             {
-                "operators": [
-                    {"runtime_id": "nonebot", "bot_id": "bot-1", "actor_id": "user-1"},
-                    {"runtime_id": "nonebot", "bot_id": "bot-1", "actor_id": "user-1"},
-                ]
+                "roles": {"operator": [STATUS_READ]},
+                "grants": [
+                    {
+                        "runtime_id": "nonebot",
+                        "bot_id": "bot-1",
+                        "actor_id": "user-1",
+                        "roles": ["operator"],
+                        "unknown": True,
+                    }
+                ],
             },
-            "duplicates an earlier identity",
+            "unknown unknown",
         ),
         (
             {
-                "operators": [
-                    {"runtime_id": " nonebot", "bot_id": "bot-1", "actor_id": "user-1"},
+                "roles": {"operator": [STATUS_READ]},
+                "grants": [
+                    {
+                        "runtime_id": "nonebot",
+                        "bot_id": "bot-1",
+                        "actor_id": "user-1",
+                        "roles": ["operator"],
+                    },
+                    {
+                        "runtime_id": "nonebot",
+                        "bot_id": "bot-1",
+                        "actor_id": "user-1",
+                        "capabilities": [PLUGIN_MANAGE],
+                    },
+                ],
+            },
+            "duplicates an earlier principal",
+        ),
+        (
+            {"grants": [{"runtime_id": "nonebot", "bot_id": "bot-1", "actor_id": "user-1"}]},
+            "must assign at least one role or capability",
+        ),
+        (
+            {
+                "grants": [
+                    {
+                        "runtime_id": "nonebot",
+                        "bot_id": "bot-1",
+                        "actor_id": "user-1",
+                        "roles": ["missing"],
+                    }
+                ]
+            },
+            "references unknown roles: missing",
+        ),
+        (
+            {
+                "grants": [
+                    {
+                        "runtime_id": "nonebot",
+                        "bot_id": "bot-1",
+                        "actor_id": "user-1",
+                        "capabilities": [PUBLIC],
+                    }
+                ]
+            },
+            "must not grant reserved capability public",
+        ),
+        (
+            {
+                "grants": [
+                    {
+                        "runtime_id": " nonebot",
+                        "bot_id": "bot-1",
+                        "actor_id": "user-1",
+                        "capabilities": [STATUS_READ],
+                    }
                 ]
             },
             "non-empty trimmed string",
         ),
         (
             {
-                "operators": [
-                    {"runtime_id": "nonebot", "bot_id": 1, "actor_id": "user-1"},
+                "grants": [
+                    {
+                        "runtime_id": "nonebot",
+                        "bot_id": "bot-1",
+                        "actor_id": "user-1",
+                        "capabilities": ["bad capability"],
+                    }
                 ]
             },
-            "fields must be strings",
+            "without whitespace",
         ),
     ],
 )
@@ -102,6 +228,11 @@ async def test_permission_plugin_rejects_invalid_configuration(
 
     assert raised.value.__cause__ is not None
     assert message in str(raised.value.__cause__)
+
+
+def test_permission_snapshot_requires_public_capability() -> None:
+    with pytest.raises(ValueError, match="must include public"):
+        PermissionSnapshot(None, frozenset(), frozenset())
 
 
 def test_permission_plugin_manifest_publishes_versioned_service() -> None:

--- a/scripts/verify_essentials_install.py
+++ b/scripts/verify_essentials_install.py
@@ -89,11 +89,13 @@ async def verify(expected_version: str | None = None) -> None:
                 ),
                 config={
                     "liteyukibot.permissions": {
-                        "operators": [
+                        "roles": {"operator": ["liteyukibot.status.read"]},
+                        "grants": [
                             {
                                 "runtime_id": "runtime",
                                 "bot_id": "bot",
                                 "actor_id": "operator",
+                                "roles": ["operator"],
                             }
                         ]
                     },
@@ -124,13 +126,13 @@ async def verify(expected_version: str | None = None) -> None:
             if not isinstance(message, SendMessage):
                 raise TypeError("installed help command did not produce SendMessage")
             if "/status" in message.message.plain_text or "Available commands:" not in message.message.plain_text:
-                raise RuntimeError("installed help command did not filter operator commands")
+                raise RuntimeError("installed help command did not filter protected commands")
             if help_action.event_id != user_help.id or message.reply_token != user_help.reply_token:
                 raise RuntimeError("installed help reply lost event correlation")
 
             result = await app.events.publish(_event("/status", "operator"))
             if not result.stopped or len(actions) != 2:
-                raise RuntimeError("installed operator status command did not reply")
+                raise RuntimeError("installed capability-protected status command did not reply")
             status_message = actions[-1].action
             if not isinstance(status_message, SendMessage) or not status_message.message.plain_text.startswith(
                 "LiteyukiBot 7.0.0a3\nState: ready"

--- a/scripts/verify_permissions_install.py
+++ b/scripts/verify_permissions_install.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import cast
 
 import liteyukibot_permissions
-from liteyukibot_permissions import OPERATOR, PERMISSION_SERVICE, PermissionService
+from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService
 
 import liteyukibot
 from liteyukibot import PluginDefinition
@@ -48,10 +48,17 @@ async def verify(expected_version: str | None = None) -> None:
     _verify_import_sources()
 
     definition = _installed_plugin()
+    capability = "verify.status.read"
     config = {
-        "operators": [
-            {"runtime_id": "runtime", "bot_id": "bot", "actor_id": "operator"},
-        ]
+        "roles": {"operator": [capability]},
+        "grants": [
+            {
+                "runtime_id": "runtime",
+                "bot_id": "bot",
+                "actor_id": "operator",
+                "roles": ["operator"],
+            },
+        ],
     }
     event = EventEnvelope(
         runtime_id="runtime",
@@ -64,8 +71,8 @@ async def verify(expected_version: str | None = None) -> None:
     with tempfile.TemporaryDirectory() as directory:
         async with PluginTestHarness(definition, root=Path(directory), config=config) as harness:
             service = cast(PermissionService, harness.require_service(PERMISSION_SERVICE))
-            if not service.allows(event, OPERATOR):
-                raise RuntimeError("installed permission service rejected its configured operator")
+            if not service.allows(event, capability):
+                raise RuntimeError("installed permission service rejected its configured capability")
 
     observed = {
         "liteyukibot-v7": importlib.metadata.version("liteyukibot-v7"),


### PR DESCRIPTION
## Summary

- replace the alpha operator allowlist with exact capability roles and grants
- expose immutable permission snapshots and protect status with a namespaced capability
- document the breaking alpha configuration migration in ADR 0016

## Validation

- 185 passed, 20 skipped
- Ruff and strict mypy
- all workspace package builds
- isolated permissions, commands, and essentials wheel verification
- example configuration check