### PR TITLE
✨ Add structured command schemas

### DIFF
--- a/docs/adr/0014-first-party-command-service.md
+++ b/docs/adr/0014-first-party-command-service.md
@@ -1,6 +1,6 @@
 # ADR 0014: Route Native Commands Through a Plugin Service
 
-- Status: Accepted
+- Status: Superseded in part by ADR 0017
 - Date: 2026-08-10
 
 ## Context

--- a/docs/adr/0017-structured-command-schema.md
+++ b/docs/adr/0017-structured-command-schema.md
@@ -1,0 +1,68 @@
+# ADR 0017: Use Explicit Structured Command Schemas
+
+- Status: Accepted
+- Date: 2026-08-10
+
+## Context
+
+ADR 0014 introduced deterministic root-command routing but intentionally left
+all arguments as one raw string. Native plugins now need reusable quoting,
+options, conversion, and help metadata. Letting each handler choose shell
+parsers or infer behavior from Python annotations would produce incompatible
+grammars and hidden dependency-injection rules.
+
+The command layer must remain protocol-neutral and dependency-light. Chat input
+is not a platform shell, and parser behavior must be identical on Linux,
+Windows, and macOS.
+
+## Decision
+
+`liteyukibot.commands@1` adds an explicit `CommandSchema` composed of frozen
+`ArgumentSpec` and `OptionSpec` values. `CommandSpec` carries the schema and
+`CommandInvocation.parse()` parses its preserved `raw_arguments`. Commands
+without a schema continue to receive the same raw text and are not parsed
+automatically; explicitly parsing unmodeled input reports an unexpected
+argument.
+
+The tokenizer has one platform-independent chat grammar:
+
+- Unicode whitespace separates tokens;
+- single and double quotes preserve whitespace and permit empty tokens;
+- backslash escapes exactly the next character;
+- unterminated quotes and trailing escapes are errors.
+
+Options support `--name value`, `--name=value`, one-character short aliases,
+boolean flags, repeatable values, repeatable flag counts, required options, and
+the `--` terminator. Short-option aggregation is not supported. Positionals
+support required, optional, and final variadic arguments.
+
+Conversion is explicit. A spec stores a callable from string to object; the
+package provides string, base-10 integer, float, and strict `true`/`false`
+converters. Handler annotations are never inspected. Conversion failures retain
+their exception chain for diagnostics and expose only a stable
+`CommandParseError` code, subject, and token to consumers.
+
+`ParsedCommand` freezes the top-level argument and option mappings. Repeated
+values are tuples. A custom converter owns the mutability and semantics of the
+object it returns; the command package does not recursively rewrite arbitrary
+third-party values.
+
+Schema validation rejects ambiguous definitions before registration: invalid
+names, duplicate argument or option names, duplicate short aliases, required
+arguments after optional arguments, and non-final variadic arguments.
+
+This decision does not yet make router-side parsing mandatory or define
+localized usage-error replies. Handlers opt in through `invocation.parse()`.
+Hierarchical routing and automatic parse-error handling are separate follow-up
+changes so this parser can be tested independently.
+
+## Consequences
+
+Plugins share one deterministic grammar without adding Click, Typer, shell
+semantics, or annotation-driven magic. Schemas can later drive detailed help
+without importing handler internals.
+
+Custom converters must be synchronous and should be side-effect free. Network
+or database lookup belongs in the async handler after structural parsing.
+Subcommands, parent-path aliases, localized error rendering, and mention
+activation remain outside this record.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,4 @@ stable-release guarantee.
 14. [First-party command service](0014-first-party-command-service.md)
 15. [First-party essential commands](0015-first-party-essential-commands.md)
 16. [Static capability and role policy](0016-capability-permission-policy.md)
+17. [Explicit structured command schemas](0017-structured-command-schema.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -168,6 +168,8 @@ Phase 5 evolves the first-party plugin contracts without expanding the kernel.
 Its permission service resolves static roles and exact-principal grants into
 immutable capability snapshots; `liteyukibot.status.read` replaces role-name
 checks for the essential status command. ADR 0016 records the fail-closed,
-no-wildcard policy. Structured command parsing and hierarchical help remain the
-next parts of this phase. Runtime IPC stays at v3 and the kernel dependency set
-does not change.
+no-wildcard policy. ADR 0017 adds explicit command schemas, deterministic chat
+tokenization, options, and typed converters without handler annotation
+inspection. Hierarchical routing and detailed help remain the next parts of
+this phase. Runtime IPC stays at v3 and the kernel dependency set does not
+change.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -112,12 +112,16 @@ The first-party `liteyukibot-v7-commands` package provides
 handler. The handler receives `CommandInvocation` and returns the kernel's
 `HandlerResult`; `invocation.reply()` builds a correlated `SendMessage` result.
 The invocation also exposes the actual matched `prefix`, the canonical command
-name, the alias used, and unparsed argument text.
+name, the alias used, and unparsed argument text. Attach an explicit
+`CommandSchema` to the spec and call `invocation.parse()` for shared quoting,
+positionals, options, flags, repeatable values, and typed conversion. Handler
+annotations are not inspected.
 
 Registrations are explicitly owned and must be unregistered in the consumer's
 stop callback. `register_many()` is atomic, so a duplicate name or alias leaves
-the previous registry unchanged. The alpha parser supplies unparsed argument
-text and does not implement options, subcommands, or typed conversion.
+the previous registry unchanged. Raw argument text is always retained.
+Hierarchical subcommand routing and automatic localized parse-error replies are
+not implemented yet.
 
 ## Essentials
 

--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -3,9 +3,9 @@
 `liteyukibot-v7-commands` provides the versioned `liteyukibot.commands@1`
 service and a protocol-neutral EventBus command router.
 
-The alpha parser recognizes configurable non-empty prefixes, command names,
-and aliases. It deliberately leaves options, subcommands, and typed argument
-parsing to command handlers.
+The parser recognizes configurable non-empty prefixes, command names, aliases,
+and explicit argument/option schemas. Hierarchical subcommand routing remains a
+separate alpha step.
 
 ```toml
 [plugins]
@@ -18,3 +18,29 @@ prefixes = ["/"]
 Consumers register `CommandSpec` and a synchronous or asynchronous handler.
 The handler receives `CommandInvocation`, including the normalized command and
 unparsed argument text, and returns the kernel's `HandlerResult`.
+
+```python
+from liteyukibot_commands import (
+    ArgumentSpec,
+    CommandSchema,
+    CommandSpec,
+    OptionSpec,
+    integer_value,
+)
+
+spec = CommandSpec(
+    "echo",
+    schema=CommandSchema(
+        arguments=(ArgumentSpec("text"),),
+        options=(OptionSpec("times", aliases=("n",), converter=integer_value, default=1),),
+    ),
+)
+
+def echo(invocation):
+    parsed = invocation.parse()
+    return invocation.reply(str(parsed.arguments["text"]) * int(parsed.options["times"]))
+```
+
+Quoting, escaping, `--name value`, `--name=value`, short aliases, flags,
+repeatable options, `--`, and conversion failures have platform-independent
+semantics. Parsing errors expose stable codes through `CommandParseError`.

--- a/packages/commands/src/liteyukibot_commands/__init__.py
+++ b/packages/commands/src/liteyukibot_commands/__init__.py
@@ -9,6 +9,20 @@ from .models import (
     CommandRegistration,
     CommandSpec,
 )
+from .parsing import (
+    ArgumentSpec,
+    CommandParseError,
+    CommandSchema,
+    OptionSpec,
+    ParsedCommand,
+    ValueConverter,
+    boolean_value,
+    float_value,
+    integer_value,
+    parse_command,
+    string_value,
+    tokenize_command,
+)
 from .plugin import create_plugin
 from .service import COMMAND_SERVICE, CommandService
 
@@ -21,12 +35,24 @@ plugin = create_plugin(__version__)
 
 __all__ = [
     "COMMAND_SERVICE",
+    "ArgumentSpec",
     "CommandBinding",
     "CommandHandler",
     "CommandInvocation",
+    "CommandParseError",
     "CommandRegistration",
     "CommandService",
+    "CommandSchema",
     "CommandSpec",
+    "OptionSpec",
+    "ParsedCommand",
+    "ValueConverter",
     "__version__",
     "plugin",
+    "boolean_value",
+    "float_value",
+    "integer_value",
+    "parse_command",
+    "string_value",
+    "tokenize_command",
 ]

--- a/packages/commands/src/liteyukibot_commands/models.py
+++ b/packages/commands/src/liteyukibot_commands/models.py
@@ -16,6 +16,8 @@ from liteyukibot.events import (
     SendMessage,
 )
 
+from .parsing import CommandSchema, ParsedCommand, parse_command
+
 
 def _validate_token(name: str, value: str) -> None:
     if not isinstance(value, str):
@@ -31,6 +33,7 @@ class CommandSpec:
     summary: str = ""
     usage: str = ""
     permission: str = PUBLIC
+    schema: CommandSchema = CommandSchema()
 
     def __post_init__(self) -> None:
         _validate_token("name", self.name)
@@ -52,6 +55,8 @@ class CommandSpec:
             raise TypeError("command permission must be a string")
         if not self.permission or self.permission != self.permission.strip():
             raise ValueError("command permission must be a non-empty trimmed string")
+        if not isinstance(self.schema, CommandSchema):
+            raise TypeError("command schema must be CommandSchema")
         object.__setattr__(self, "aliases", aliases)
 
 
@@ -62,6 +67,10 @@ class CommandInvocation:
     invoked_as: str
     prefix: str
     raw_arguments: str
+    schema: CommandSchema = CommandSchema()
+
+    def parse(self) -> ParsedCommand:
+        return parse_command(self.raw_arguments, self.schema)
 
     def reply(self, message: Message | str) -> HandlerResult:
         if isinstance(message, str):

--- a/packages/commands/src/liteyukibot_commands/parsing.py
+++ b/packages/commands/src/liteyukibot_commands/parsing.py
@@ -1,0 +1,349 @@
+"""Explicit command tokenization, schemas, and typed value parsing."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+type ValueConverter = Callable[[str], object]
+
+
+def _validate_name(kind: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"command {kind} must be a string")
+    if (
+        not value
+        or value != value.strip()
+        or any(character.isspace() for character in value)
+        or value.startswith("-")
+        or "=" in value
+    ):
+        raise ValueError(f"command {kind} must be a non-empty token without whitespace, leading dashes, or equals")
+    return value
+
+
+def string_value(value: str) -> str:
+    return value
+
+
+def integer_value(value: str) -> int:
+    return int(value, 10)
+
+
+def float_value(value: str) -> float:
+    return float(value)
+
+
+def boolean_value(value: str) -> bool:
+    normalized = value.casefold()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise ValueError("boolean value must be true or false")
+
+
+@dataclass(frozen=True, slots=True)
+class ArgumentSpec:
+    name: str
+    converter: ValueConverter = string_value
+    required: bool = True
+    default: object = None
+    variadic: bool = False
+    metavar: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_name("argument name", self.name)
+        if not callable(self.converter):
+            raise TypeError(f"command argument {self.name} converter must be callable")
+        if not isinstance(self.required, bool) or not isinstance(self.variadic, bool):
+            raise TypeError(f"command argument {self.name} required and variadic must be booleans")
+        if self.required and self.default is not None:
+            raise ValueError(f"required command argument {self.name} must not have a default")
+        if self.variadic and self.default is not None:
+            raise ValueError(f"variadic command argument {self.name} must not have a default")
+        if not isinstance(self.metavar, str):
+            raise TypeError(f"command argument {self.name} metavar must be a string")
+
+
+@dataclass(frozen=True, slots=True)
+class OptionSpec:
+    name: str
+    aliases: tuple[str, ...] = ()
+    converter: ValueConverter = string_value
+    required: bool = False
+    flag: bool = False
+    repeatable: bool = False
+    default: object = None
+    metavar: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_name("option name", self.name)
+        if isinstance(self.aliases, str):
+            raise TypeError(f"command option {self.name} aliases must be a sequence")
+        aliases = tuple(self.aliases)
+        seen: set[str] = set()
+        for alias in aliases:
+            _validate_name(f"option {self.name} alias", alias)
+            if len(alias) != 1:
+                raise ValueError(f"command option {self.name} alias must be one character")
+            if alias in seen:
+                raise ValueError(f"command option {self.name} has duplicate alias {alias}")
+            seen.add(alias)
+        if not callable(self.converter):
+            raise TypeError(f"command option {self.name} converter must be callable")
+        if not all(isinstance(value, bool) for value in (self.required, self.flag, self.repeatable)):
+            raise TypeError(f"command option {self.name} required, flag, and repeatable must be booleans")
+        if (self.flag or self.repeatable) and self.default is not None:
+            raise ValueError(f"flag or repeatable command option {self.name} must not have a default")
+        if not isinstance(self.metavar, str):
+            raise TypeError(f"command option {self.name} metavar must be a string")
+        object.__setattr__(self, "aliases", aliases)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandSchema:
+    arguments: tuple[ArgumentSpec, ...] = ()
+    options: tuple[OptionSpec, ...] = ()
+
+    def __post_init__(self) -> None:
+        if isinstance(self.arguments, (str, bytes)) or isinstance(self.options, (str, bytes)):
+            raise TypeError("command schema arguments and options must be sequences")
+        arguments = tuple(self.arguments)
+        options = tuple(self.options)
+        if any(not isinstance(item, ArgumentSpec) for item in arguments):
+            raise TypeError("command schema arguments must contain ArgumentSpec")
+        if any(not isinstance(item, OptionSpec) for item in options):
+            raise TypeError("command schema options must contain OptionSpec")
+
+        argument_names: set[str] = set()
+        optional_seen = False
+        for index, argument in enumerate(arguments):
+            if argument.name in argument_names:
+                raise ValueError(f"duplicate command argument name: {argument.name}")
+            argument_names.add(argument.name)
+            if argument.variadic and index != len(arguments) - 1:
+                raise ValueError(f"variadic command argument {argument.name} must be last")
+            if optional_seen and argument.required:
+                raise ValueError(f"required command argument {argument.name} must not follow an optional argument")
+            optional_seen = optional_seen or not argument.required
+
+        option_names: set[str] = set()
+        aliases: set[str] = set()
+        for option in options:
+            if option.name in option_names:
+                raise ValueError(f"duplicate command option name: {option.name}")
+            option_names.add(option.name)
+            conflict = next((alias for alias in option.aliases if alias in aliases), None)
+            if conflict is not None:
+                raise ValueError(f"duplicate command option alias: {conflict}")
+            aliases.update(option.aliases)
+
+        object.__setattr__(self, "arguments", arguments)
+        object.__setattr__(self, "options", options)
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedCommand:
+    arguments: Mapping[str, object]
+    options: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "arguments", MappingProxyType(dict(self.arguments)))
+        object.__setattr__(self, "options", MappingProxyType(dict(self.options)))
+
+
+class CommandParseError(ValueError):
+    def __init__(self, code: str, *, subject: str | None = None, token: str | None = None) -> None:
+        self.code = code
+        self.subject = subject
+        self.token = token
+        parts = [code]
+        if subject is not None:
+            parts.append(subject)
+        if token is not None:
+            parts.append(repr(token))
+        super().__init__(": ".join(parts))
+
+
+def tokenize_command(value: str) -> tuple[str, ...]:
+    if not isinstance(value, str):
+        raise TypeError("command input must be a string")
+    tokens: list[str] = []
+    buffer: list[str] = []
+    quote: str | None = None
+    escaping = False
+    started = False
+    for character in value:
+        if escaping:
+            buffer.append(character)
+            escaping = False
+            started = True
+            continue
+        if character == "\\":
+            escaping = True
+            started = True
+            continue
+        if quote is not None:
+            if character == quote:
+                quote = None
+            else:
+                buffer.append(character)
+            started = True
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            started = True
+            continue
+        if character.isspace():
+            if started:
+                tokens.append("".join(buffer))
+                buffer.clear()
+                started = False
+            continue
+        buffer.append(character)
+        started = True
+    if escaping:
+        raise CommandParseError("trailing_escape")
+    if quote is not None:
+        raise CommandParseError("unterminated_quote", token=quote)
+    if started:
+        tokens.append("".join(buffer))
+    return tuple(tokens)
+
+
+def _converted(converter: ValueConverter, value: str, *, subject: str) -> object:
+    try:
+        return converter(value)
+    except Exception as error:
+        raise CommandParseError("invalid_value", subject=subject, token=value) from error
+
+
+def _option_value(option: OptionSpec, value: str) -> object:
+    return _converted(option.converter, value, subject=f"--{option.name}")
+
+
+def _default_option(option: OptionSpec) -> object:
+    if option.flag:
+        return 0 if option.repeatable else False
+    if option.repeatable:
+        return ()
+    return option.default
+
+
+def parse_command(value: str, schema: CommandSchema) -> ParsedCommand:
+    if not isinstance(schema, CommandSchema):
+        raise TypeError("command schema must be CommandSchema")
+    tokens = tokenize_command(value)
+    long_options = {option.name: option for option in schema.options}
+    short_options = {alias: option for option in schema.options for alias in option.aliases}
+    parsed_options: dict[str, object] = {}
+    repeated: dict[str, list[object]] = {}
+    positional: list[str] = []
+    options_enabled = True
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if options_enabled and token == "--":
+            options_enabled = False
+            index += 1
+            continue
+
+        option: OptionSpec | None = None
+        inline_value: str | None = None
+        if options_enabled and token.startswith("--") and len(token) > 2:
+            name, separator, inline = token[2:].partition("=")
+            option = long_options.get(name)
+            inline_value = inline if separator else None
+        elif options_enabled and token.startswith("-") and len(token) > 1:
+            name, separator, inline = token[1:].partition("=")
+            option = short_options.get(name)
+            inline_value = inline if separator else None
+
+        if options_enabled and token.startswith("-") and token != "-":
+            if option is None:
+                raise CommandParseError("unknown_option", token=token)
+            if option.flag:
+                if inline_value is not None:
+                    raise CommandParseError("unexpected_option_value", subject=option.name, token=inline_value)
+                if option.repeatable:
+                    current = parsed_options.get(option.name, 0)
+                    if not isinstance(current, int):
+                        raise RuntimeError(f"command option {option.name} flag count is not an integer")
+                    parsed_options[option.name] = current + 1
+                elif option.name in parsed_options:
+                    raise CommandParseError("duplicate_option", subject=option.name)
+                else:
+                    parsed_options[option.name] = True
+                index += 1
+                continue
+
+            if not option.repeatable and option.name in parsed_options:
+                raise CommandParseError("duplicate_option", subject=option.name)
+            if inline_value is None:
+                index += 1
+                if index >= len(tokens):
+                    raise CommandParseError("missing_option_value", subject=option.name)
+                inline_value = tokens[index]
+            converted = _option_value(option, inline_value)
+            if option.repeatable:
+                repeated.setdefault(option.name, []).append(converted)
+            else:
+                parsed_options[option.name] = converted
+            index += 1
+            continue
+
+        positional.append(token)
+        index += 1
+
+    for name, values in repeated.items():
+        parsed_options[name] = tuple(values)
+    for option in schema.options:
+        if option.name not in parsed_options:
+            if option.required:
+                raise CommandParseError("missing_option", subject=option.name)
+            parsed_options[option.name] = _default_option(option)
+
+    parsed_arguments: dict[str, object] = {}
+    position = 0
+    for argument in schema.arguments:
+        if argument.variadic:
+            remaining = positional[position:]
+            if argument.required and not remaining:
+                raise CommandParseError("missing_argument", subject=argument.name)
+            parsed_arguments[argument.name] = tuple(
+                _converted(argument.converter, item, subject=argument.name) for item in remaining
+            )
+            position = len(positional)
+            continue
+        if position >= len(positional):
+            if argument.required:
+                raise CommandParseError("missing_argument", subject=argument.name)
+            parsed_arguments[argument.name] = argument.default
+            continue
+        parsed_arguments[argument.name] = _converted(
+            argument.converter,
+            positional[position],
+            subject=argument.name,
+        )
+        position += 1
+    if position < len(positional):
+        raise CommandParseError("unexpected_argument", token=positional[position])
+    return ParsedCommand(parsed_arguments, parsed_options)
+
+
+__all__ = [
+    "ArgumentSpec",
+    "CommandParseError",
+    "CommandSchema",
+    "OptionSpec",
+    "ParsedCommand",
+    "ValueConverter",
+    "boolean_value",
+    "float_value",
+    "integer_value",
+    "parse_command",
+    "string_value",
+    "tokenize_command",
+]

--- a/packages/commands/src/liteyukibot_commands/service.py
+++ b/packages/commands/src/liteyukibot_commands/service.py
@@ -163,6 +163,7 @@ class _CommandService:
             invoked_as=invoked_as,
             prefix=prefix,
             raw_arguments=raw_arguments,
+            schema=spec.schema,
         )
         try:
             result: Any = registered.handler(invocation)

--- a/packages/commands/tests/test_commands.py
+++ b/packages/commands/tests/test_commands.py
@@ -7,9 +7,13 @@ from typing import Any, cast
 import pytest
 from liteyukibot_commands import (
     COMMAND_SERVICE,
+    ArgumentSpec,
     CommandInvocation,
+    CommandSchema,
     CommandService,
     CommandSpec,
+    OptionSpec,
+    integer_value,
     plugin,
 )
 from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, PermissionSnapshot, Principal
@@ -82,6 +86,7 @@ async def test_command_router_dispatches_alias_and_preserves_arguments(tmp_path:
         service = cast(CommandService, harness.require_service(COMMAND_SERVICE))
 
         async def echo(invocation: CommandInvocation) -> HandlerResult:
+            parsed = invocation.parse()
             observed.append(
                 (
                     invocation.command,
@@ -90,9 +95,22 @@ async def test_command_router_dispatches_alias_and_preserves_arguments(tmp_path:
                     invocation.raw_arguments,
                 )
             )
+            assert parsed.arguments == {"values": ("Hello", "world")}
+            assert parsed.options == {"times": 1}
             return invocation.reply(f"echo: {invocation.raw_arguments}")
 
-        service.register(CommandSpec("echo", aliases=("E",)), echo, owner="tests.echo")
+        service.register(
+            CommandSpec(
+                "echo",
+                aliases=("E",),
+                schema=CommandSchema(
+                    arguments=(ArgumentSpec("values", required=False, variadic=True),),
+                    options=(OptionSpec("times", converter=integer_value, default=1),),
+                ),
+            ),
+            echo,
+            owner="tests.echo",
+        )
         result = await harness.publish(message_event("  /e Hello  world  "))
 
         assert result.stopped is True

--- a/packages/commands/tests/test_parsing.py
+++ b/packages/commands/tests/test_parsing.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import MappingProxyType
+from typing import cast
+
+import pytest
+from liteyukibot_commands import (
+    ArgumentSpec,
+    CommandParseError,
+    CommandSchema,
+    OptionSpec,
+    ValueConverter,
+    boolean_value,
+    float_value,
+    integer_value,
+    parse_command,
+    tokenize_command,
+)
+
+
+def test_tokenizer_preserves_chat_arguments_without_shell_mode() -> None:
+    assert tokenize_command("  alpha\t'hello world' \"\" escaped\\ value 中文  ") == (
+        "alpha",
+        "hello world",
+        "",
+        "escaped value",
+        "中文",
+    )
+    assert tokenize_command("'single \\' quote' \"double \\\" quote\"") == (
+        "single ' quote",
+        'double " quote',
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "code"),
+    [
+        ("value\\", "trailing_escape"),
+        ("'value", "unterminated_quote"),
+        ('"value', "unterminated_quote"),
+    ],
+)
+def test_tokenizer_reports_stable_errors(value: str, code: str) -> None:
+    with pytest.raises(CommandParseError) as raised:
+        tokenize_command(value)
+
+    assert raised.value.code == code
+
+
+def test_schema_parses_typed_arguments_options_flags_and_repeats() -> None:
+    schema = CommandSchema(
+        arguments=(
+            ArgumentSpec("count", converter=integer_value),
+            ArgumentSpec("label", required=False, default="default"),
+            ArgumentSpec("items", converter=float_value, required=False, variadic=True),
+        ),
+        options=(
+            OptionSpec("name", aliases=("n",), required=True),
+            OptionSpec("enabled", aliases=("e",), converter=boolean_value),
+            OptionSpec("verbose", aliases=("v",), flag=True),
+            OptionSpec("tag", aliases=("t",), repeatable=True),
+            OptionSpec("debug", aliases=("d",), flag=True, repeatable=True),
+        ),
+    )
+
+    parsed = parse_command(
+        "3 title 1.5 2 --name=alpha -e false -v -t one --tag two -d -d",
+        schema,
+    )
+
+    assert parsed.arguments == {"count": 3, "label": "title", "items": (1.5, 2.0)}
+    assert parsed.options == {
+        "name": "alpha",
+        "enabled": False,
+        "verbose": True,
+        "tag": ("one", "two"),
+        "debug": 2,
+    }
+    assert isinstance(parsed.arguments, MappingProxyType)
+    assert isinstance(parsed.options, MappingProxyType)
+    with pytest.raises(TypeError):
+        parsed.options["name"] = "changed"
+
+
+def test_parser_applies_defaults_and_option_terminator() -> None:
+    schema = CommandSchema(
+        arguments=(ArgumentSpec("value"),),
+        options=(
+            OptionSpec("limit", aliases=("l",), converter=integer_value, default=10),
+            OptionSpec("quiet", aliases=("q",), flag=True),
+            OptionSpec("include", aliases=("i",), repeatable=True),
+        ),
+    )
+
+    parsed = parse_command("-- --literal", schema)
+
+    assert parsed.arguments == {"value": "--literal"}
+    assert parsed.options == {"limit": 10, "quiet": False, "include": ()}
+
+
+def test_parser_consumes_negative_option_values() -> None:
+    schema = CommandSchema(options=(OptionSpec("offset", aliases=("o",), converter=integer_value),))
+
+    assert parse_command("--offset -2", schema).options["offset"] == -2
+    assert parse_command("-o=-3", schema).options["offset"] == -3
+
+
+@pytest.mark.parametrize(
+    ("value", "schema", "code", "subject"),
+    [
+        ("--missing", CommandSchema(), "unknown_option", None),
+        ("--name", CommandSchema(options=(OptionSpec("name"),)), "missing_option_value", "name"),
+        (
+            "--name one --name two",
+            CommandSchema(options=(OptionSpec("name"),)),
+            "duplicate_option",
+            "name",
+        ),
+        (
+            "",
+            CommandSchema(options=(OptionSpec("name", required=True),)),
+            "missing_option",
+            "name",
+        ),
+        ("", CommandSchema(arguments=(ArgumentSpec("value"),)), "missing_argument", "value"),
+        ("one two", CommandSchema(arguments=(ArgumentSpec("value"),)), "unexpected_argument", None),
+        (
+            "invalid",
+            CommandSchema(arguments=(ArgumentSpec("value", converter=integer_value),)),
+            "invalid_value",
+            "value",
+        ),
+        (
+            "--verbose=true",
+            CommandSchema(options=(OptionSpec("verbose", flag=True),)),
+            "unexpected_option_value",
+            "verbose",
+        ),
+    ],
+)
+def test_parser_reports_stable_error_codes(
+    value: str,
+    schema: CommandSchema,
+    code: str,
+    subject: str | None,
+) -> None:
+    with pytest.raises(CommandParseError) as raised:
+        parse_command(value, schema)
+
+    assert raised.value.code == code
+    assert raised.value.subject == subject
+    if code == "invalid_value":
+        assert isinstance(raised.value.__cause__, ValueError)
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: ArgumentSpec("bad name"), "argument name"),
+        (lambda: ArgumentSpec("value", converter=cast(ValueConverter, 1)), "converter must be callable"),
+        (lambda: ArgumentSpec("value", default=1), "must not have a default"),
+        (lambda: ArgumentSpec("values", variadic=True, default=()), "must not have a default"),
+        (lambda: OptionSpec("bad=name"), "option name"),
+        (lambda: OptionSpec("name", aliases=("long",)), "must be one character"),
+        (lambda: OptionSpec("name", aliases=("n", "n")), "duplicate alias"),
+        (lambda: OptionSpec("name", flag=True, default=False), "must not have a default"),
+        (
+            lambda: CommandSchema(arguments=(ArgumentSpec("one"), ArgumentSpec("one"))),
+            "duplicate command argument",
+        ),
+        (
+            lambda: CommandSchema(
+                arguments=(
+                    ArgumentSpec("optional", required=False),
+                    ArgumentSpec("required"),
+                )
+            ),
+            "must not follow an optional",
+        ),
+        (
+            lambda: CommandSchema(
+                arguments=(
+                    ArgumentSpec("values", required=False, variadic=True),
+                    ArgumentSpec("after", required=False),
+                )
+            ),
+            "must be last",
+        ),
+        (
+            lambda: CommandSchema(options=(OptionSpec("one", aliases=("x",)), OptionSpec("two", aliases=("x",)))),
+            "duplicate command option alias",
+        ),
+    ],
+)
+def test_schema_rejects_ambiguous_definitions(factory: Callable[[], object], message: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        factory()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("true", True), ("TRUE", True), ("false", False), ("False", False)],
+)
+def test_strict_boolean_converter(value: str, expected: bool) -> None:
+    assert boolean_value(value) is expected
+
+
+def test_strict_boolean_converter_rejects_implicit_values() -> None:
+    with pytest.raises(ValueError, match="true or false"):
+        boolean_value("yes")

--- a/scripts/verify_commands_install.py
+++ b/scripts/verify_commands_install.py
@@ -12,8 +12,17 @@ from typing import cast
 
 import liteyukibot_commands
 import liteyukibot_permissions
-from liteyukibot_commands import COMMAND_SERVICE, CommandInvocation, CommandService, CommandSpec
-from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, Principal
+from liteyukibot_commands import (
+    COMMAND_SERVICE,
+    ArgumentSpec,
+    CommandInvocation,
+    CommandSchema,
+    CommandService,
+    CommandSpec,
+    OptionSpec,
+    integer_value,
+)
+from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, PermissionSnapshot, Principal
 
 import liteyukibot
 from liteyukibot import PluginDefinition
@@ -36,6 +45,9 @@ class PublicPermissions:
         if event.actor is None:
             return None
         return Principal(event.runtime_id, event.bot_id, event.actor.id)
+
+    def resolve(self, event: EventEnvelope) -> PermissionSnapshot:
+        return PermissionSnapshot(self.principal(event), frozenset(), frozenset({PUBLIC}))
 
     def allows(self, _event: EventEnvelope, permission: str) -> bool:
         return permission == PUBLIC
@@ -75,7 +87,7 @@ async def verify(expected_version: str | None = None) -> None:
         type="message",
         conversation=ConversationRef(id="conversation"),
         actor=ActorRef(id="user"),
-        message=Message(segments=(Segment(type="text", data={"text": "/echo wheel"}),)),
+        message=Message(segments=(Segment(type="text", data={"text": '/echo "wheel value" --times 2'}),)),
         reply_token="reply-token",
     )
     with tempfile.TemporaryDirectory() as directory:
@@ -87,14 +99,27 @@ async def verify(expected_version: str | None = None) -> None:
             service = cast(CommandService, harness.require_service(COMMAND_SERVICE))
 
             def echo(invocation: CommandInvocation) -> HandlerResult:
-                return invocation.reply(invocation.raw_arguments)
+                parsed = invocation.parse()
+                text = cast(str, parsed.arguments["text"])
+                times = cast(int, parsed.options["times"])
+                return invocation.reply(text * times)
 
-            service.register(CommandSpec("echo"), echo, owner="wheel-verifier")
+            service.register(
+                CommandSpec(
+                    "echo",
+                    schema=CommandSchema(
+                        arguments=(ArgumentSpec("text"),),
+                        options=(OptionSpec("times", converter=integer_value, default=1),),
+                    ),
+                ),
+                echo,
+                owner="wheel-verifier",
+            )
             result = await harness.publish(event)
             if not result.stopped or len(harness.recorded_actions) != 1:
                 raise RuntimeError("installed command router did not stop and reply")
             action = harness.recorded_actions[0].action
-            if not isinstance(action, SendMessage) or action.message.plain_text != "wheel":
+            if not isinstance(action, SendMessage) or action.message.plain_text != "wheel valuewheel value":
                 raise RuntimeError("installed command router produced an invalid reply")
 
     observed = {


### PR DESCRIPTION
## Summary

- add a platform-independent chat command tokenizer and explicit argument/option schemas
- expose typed converters, immutable parse results, and stable parse errors
- package-test the schema through a real command invocation and document ADR 0017

## Validation

- 217 passed, 20 skipped
- Ruff and strict mypy
- all workspace package builds
- isolated commands wheel and full essentials topology verification