### PR TITLE
✨ Add hierarchical command routing

### DIFF
--- a/docs/adr/0018-hierarchical-command-routing.md
+++ b/docs/adr/0018-hierarchical-command-routing.md
@@ -1,0 +1,27 @@
+# ADR 0018: Route Commands by Canonical Paths
+
+- Status: Accepted
+- Date: 2026-08-10
+
+## Decision
+
+`CommandSpec` adds an optional canonical parent `path`. A root command remains
+`CommandSpec("echo")`; `CommandSpec("list", path=("plugin",))` registers
+`plugin list`. Aliases apply only to the final segment, never to parent paths.
+
+The registry indexes normalized token tuples and chooses the longest registered
+path from command input. A registered parent may also own a handler. When a
+longer child path is not registered, its remaining tokens stay in the parent's
+raw arguments. Name and alias conflicts are checked within their complete path
+and batch registration remains atomic. Snapshots sort by canonical path.
+
+The invocation keeps its leaf `command` for existing handlers and adds the
+canonical `command_path`. Kernel, runtime IPC, and Event/Action schemas do not
+change.
+
+## Consequences
+
+Subcommands are deterministic without alias expansion ambiguity. Parent aliases
+do not create implicit child aliases; plugins register each intended spelling.
+Automatic parse-error replies and detailed hierarchical help are separate
+consumer-layer work.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,3 +21,4 @@ stable-release guarantee.
 15. [First-party essential commands](0015-first-party-essential-commands.md)
 16. [Static capability and role policy](0016-capability-permission-policy.md)
 17. [Explicit structured command schemas](0017-structured-command-schema.md)
+18. [Hierarchical command routing](0018-hierarchical-command-routing.md)

--- a/packages/commands/src/liteyukibot_commands/models.py
+++ b/packages/commands/src/liteyukibot_commands/models.py
@@ -34,6 +34,7 @@ class CommandSpec:
     usage: str = ""
     permission: str = PUBLIC
     schema: CommandSchema = CommandSchema()
+    path: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         _validate_token("name", self.name)
@@ -57,7 +58,17 @@ class CommandSpec:
             raise ValueError("command permission must be a non-empty trimmed string")
         if not isinstance(self.schema, CommandSchema):
             raise TypeError("command schema must be CommandSchema")
+        if isinstance(self.path, str):
+            raise TypeError("command path must be a sequence of tokens")
+        path = tuple(self.path)
+        for segment in path:
+            _validate_token("path segment", segment)
         object.__setattr__(self, "aliases", aliases)
+        object.__setattr__(self, "path", path)
+
+    @property
+    def command_path(self) -> tuple[str, ...]:
+        return (*self.path, self.name)
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +79,7 @@ class CommandInvocation:
     prefix: str
     raw_arguments: str
     schema: CommandSchema = CommandSchema()
+    command_path: tuple[str, ...] = ()
 
     def parse(self) -> ParsedCommand:
         return parse_command(self.raw_arguments, self.schema)

--- a/packages/commands/src/liteyukibot_commands/service.py
+++ b/packages/commands/src/liteyukibot_commands/service.py
@@ -58,7 +58,7 @@ class CommandService(Protocol):
 class _RegisteredCommand:
     registration: CommandRegistration
     handler: CommandHandler
-    tokens: tuple[str, ...]
+    paths: tuple[tuple[str, ...], ...]
 
 
 class _CommandService:
@@ -72,7 +72,8 @@ class _CommandService:
         self._permissions = permissions
         self._logger = logger
         self._commands: dict[int, _RegisteredCommand] = {}
-        self._tokens: dict[str, int] = {}
+        self._paths: dict[tuple[str, ...], int] = {}
+        self._max_path_length = 0
         self._next_id = 0
 
     def register(
@@ -96,30 +97,34 @@ class _CommandService:
         if not pending:
             return ()
 
-        claimed = set(self._tokens)
-        prepared: list[tuple[CommandSpec, CommandHandler, tuple[str, ...]]] = []
+        claimed = set(self._paths)
+        prepared: list[tuple[CommandSpec, CommandHandler, tuple[tuple[str, ...], ...]]] = []
         for spec, handler in pending:
             if not isinstance(spec, CommandSpec):
                 raise TypeError("command binding must contain CommandSpec")
             if not callable(handler):
                 raise TypeError(f"handler for command {spec.name} must be callable")
-            raw_tokens = (spec.name, *spec.aliases)
+            raw_tokens = (*spec.path, spec.name, *spec.aliases)
             if any(token.startswith(prefix) for token in raw_tokens for prefix in self._prefixes):
                 raise ValueError(f"command {spec.name} names and aliases must not include a prefix")
-            tokens = tuple(token.casefold() for token in raw_tokens)
-            conflict = next((token for token in tokens if token in claimed), None)
+            paths = (
+                tuple(token.casefold() for token in spec.command_path),
+                *(tuple(token.casefold() for token in (*spec.path, alias)) for alias in spec.aliases),
+            )
+            conflict = next((path for path in paths if path in claimed), None)
             if conflict is not None:
-                raise ValueError(f"command name or alias is already registered: {conflict}")
-            claimed.update(tokens)
-            prepared.append((spec, handler, tokens))
+                raise ValueError(f"command name or alias is already registered: {' '.join(conflict)}")
+            claimed.update(paths)
+            prepared.append((spec, handler, paths))
 
         registrations: list[CommandRegistration] = []
-        for spec, handler, tokens in prepared:
+        for spec, handler, paths in prepared:
             registration = CommandRegistration(self._next_id, owner, spec)
             self._next_id += 1
-            self._commands[registration.id] = _RegisteredCommand(registration, handler, tokens)
-            for token in tokens:
-                self._tokens[token] = registration.id
+            self._commands[registration.id] = _RegisteredCommand(registration, handler, paths)
+            for path in paths:
+                self._paths[path] = registration.id
+                self._max_path_length = max(self._max_path_length, len(path))
             registrations.append(registration)
         return tuple(registrations)
 
@@ -128,8 +133,9 @@ class _CommandService:
         if registered is None or registered.registration != registration:
             return False
         del self._commands[registration.id]
-        for token in registered.tokens:
-            self._tokens.pop(token, None)
+        for path in registered.paths:
+            self._paths.pop(path, None)
+        self._max_path_length = max((len(path) for path in self._paths), default=0)
         return True
 
     def snapshot(self) -> tuple[CommandRegistration, ...]:
@@ -137,7 +143,10 @@ class _CommandService:
             item.registration
             for item in sorted(
                 self._commands.values(),
-                key=lambda item: (item.registration.spec.name.casefold(), item.registration.id),
+                key=lambda item: (
+                    tuple(segment.casefold() for segment in item.registration.spec.command_path),
+                    item.registration.id,
+                ),
             )
         )
 
@@ -164,6 +173,7 @@ class _CommandService:
             prefix=prefix,
             raw_arguments=raw_arguments,
             schema=spec.schema,
+            command_path=spec.command_path,
         )
         try:
             result: Any = registered.handler(invocation)
@@ -211,13 +221,31 @@ class _CommandService:
         body = text[len(prefix) :]
         if not body or body[0].isspace():
             return None
-        parts = body.split(maxsplit=1)
-        invoked_as = parts[0]
-        command_id = self._tokens.get(invoked_as.casefold())
-        if command_id is None:
-            return None
-        raw_arguments = "" if len(parts) == 1 else parts[1]
-        return self._commands[command_id], invoked_as, prefix, raw_arguments
+        tokens = _command_tokens(body)
+        for length in range(min(self._max_path_length, len(tokens)), 0, -1):
+            candidate = tuple(token.casefold() for token, _, _ in tokens[:length])
+            command_id = self._paths.get(candidate)
+            if command_id is None:
+                continue
+            _, _, end = tokens[length - 1]
+            return self._commands[command_id], body[:end], prefix, body[end:].lstrip()
+        return None
+
+
+def _command_tokens(value: str) -> tuple[tuple[str, int, int], ...]:
+    tokens: list[tuple[str, int, int]] = []
+    start = 0
+    while start < len(value):
+        while start < len(value) and value[start].isspace():
+            start += 1
+        if start == len(value):
+            break
+        end = start
+        while end < len(value) and not value[end].isspace():
+            end += 1
+        tokens.append((value[start:end], start, end))
+        start = end
+    return tuple(tokens)
 
 
 def create_command_service(

--- a/packages/commands/tests/test_commands.py
+++ b/packages/commands/tests/test_commands.py
@@ -144,6 +144,65 @@ async def test_command_router_uses_longest_prefix_and_ignores_unknown_input(tmp_
 
 
 @pytest.mark.asyncio
+async def test_command_router_matches_longest_hierarchical_path_and_preserves_parent_fallback(tmp_path: Path) -> None:
+    calls: list[tuple[str, tuple[str, ...], str, str]] = []
+    async with make_harness(tmp_path) as harness:
+        service = cast(CommandService, harness.require_service(COMMAND_SERVICE))
+
+        def parent(invocation: CommandInvocation) -> None:
+            calls.append((invocation.command, invocation.command_path, invocation.invoked_as, invocation.raw_arguments))
+
+        def child(invocation: CommandInvocation) -> None:
+            calls.append((invocation.command, invocation.command_path, invocation.invoked_as, invocation.raw_arguments))
+
+        service.register_many(
+            (
+                (CommandSpec("plugin"), parent),
+                (CommandSpec("list", aliases=("ls",), path=("plugin",)), child),
+            ),
+            owner="tests.hierarchy",
+        )
+
+        child_result = await harness.publish(message_event("/plugin list   --all"))
+        alias_result = await harness.publish(message_event("/plugin ls value"))
+        parent_result = await harness.publish(message_event("/plugin unknown value"))
+
+        assert child_result.stopped is True
+        assert alias_result.stopped is True
+        assert parent_result.stopped is True
+        assert calls == [
+            ("list", ("plugin", "list"), "plugin list", "--all"),
+            ("list", ("plugin", "list"), "plugin ls", "value"),
+            ("plugin", ("plugin",), "plugin", "unknown value"),
+        ]
+        assert [item.spec.command_path for item in service.snapshot()] == [
+            ("plugin",),
+            ("plugin", "list"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_hierarchical_registration_rejects_same_path_or_alias_atomically(tmp_path: Path) -> None:
+    async with make_harness(tmp_path) as harness:
+        service = cast(CommandService, harness.require_service(COMMAND_SERVICE))
+
+        def handler(_invocation: CommandInvocation) -> None:
+            return None
+
+        parent = service.register(CommandSpec("plugin"), handler, owner="tests.hierarchy")
+        with pytest.raises(ValueError, match="plugin list"):
+            service.register_many(
+                (
+                    (CommandSpec("list", path=("plugin",)), handler),
+                    (CommandSpec("show", aliases=("list",), path=("plugin",)), handler),
+                ),
+                owner="tests.hierarchy",
+            )
+
+        assert service.snapshot() == (parent,)
+
+
+@pytest.mark.asyncio
 async def test_command_registration_is_atomic_and_explicitly_owned(tmp_path: Path) -> None:
     async with make_harness(tmp_path) as harness:
         service = cast(CommandService, harness.require_service(COMMAND_SERVICE))
@@ -250,6 +309,8 @@ def test_command_spec_rejects_invalid_and_duplicate_tokens() -> None:
         CommandSpec("echo", aliases=("ECHO",))
     with pytest.raises(ValueError, match="permission"):
         CommandSpec("echo", permission="")
+    with pytest.raises(TypeError, match="path"):
+        CommandSpec("echo", path=cast(tuple[str, ...], "parent"))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds canonical parent paths, leaf aliases, longest-path dispatch, parent fallback, and atomic conflict detection. Validation: command tests, Ruff, strict mypy.