### PR TITLE
✨ Add schema-driven command help

### DIFF
--- a/docs/adr/0019-essentials-command-help.md
+++ b/docs/adr/0019-essentials-command-help.md
@@ -1,0 +1,27 @@
+# ADR 0019: Keep Help and Usage Rendering in Essentials
+
+- Status: Accepted
+- Date: 2026-08-10
+
+## Decision
+
+`liteyukibot-v7-essentials` consumes the commands service's visible registrations
+and optional `resolve(event, path)` lookup. The root help command lists only
+visible root commands. `/help <path>` resolves a canonical path or final
+segment alias and renders that command's canonical path, aliases, summary,
+usage, argument schema, and option schema.
+
+Invisible commands are treated as not found, so help does not reveal their
+existence. The status command continues to require the exact
+`liteyukibot.status.read` capability.
+
+Essentials owns the localized plain-text output. A `CommandParseError` from the
+help schema becomes a short language-specific usage error; converter exception
+messages and internal tracebacks never reach the user. Commands remains
+language-neutral and does not choose a formatter or localization system.
+
+## Consequences
+
+The default operational UI demonstrates the structured command contract without
+adding a shared i18n dependency or coupling the kernel to presentation. Other
+plugins can replace essentials or render the same schemas differently.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,3 +22,4 @@ stable-release guarantee.
 16. [Static capability and role policy](0016-capability-permission-policy.md)
 17. [Explicit structured command schemas](0017-structured-command-schema.md)
 18. [Hierarchical command routing](0018-hierarchical-command-routing.md)
+19. [Essentials help and usage rendering](0019-essentials-command-help.md)

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -170,6 +170,6 @@ immutable capability snapshots; `liteyukibot.status.read` replaces role-name
 checks for the essential status command. ADR 0016 records the fail-closed,
 no-wildcard policy. ADR 0017 adds explicit command schemas, deterministic chat
 tokenization, options, and typed converters without handler annotation
-inspection. Hierarchical routing and detailed help remain the next parts of
-this phase. Runtime IPC stays at v3 and the kernel dependency set does not
-change.
+inspection. ADR 0018 adds hierarchical routing and ADR 0019 keeps detailed help
+and localized usage rendering in essentials. Runtime IPC stays at v3 and the
+kernel dependency set does not change.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -120,8 +120,11 @@ annotations are not inspected.
 Registrations are explicitly owned and must be unregistered in the consumer's
 stop callback. `register_many()` is atomic, so a duplicate name or alias leaves
 the previous registry unchanged. Raw argument text is always retained.
-Hierarchical subcommand routing and automatic localized parse-error replies are
-not implemented yet.
+Hierarchical subcommand routing and schema-backed help are supported by
+`CommandSpec(path=("parent",))`; aliases apply only to the final segment.
+Essentials renders visible root commands and `/help <path>` details. Parse
+errors are converted to short localized usage messages without exposing
+converter exceptions.
 
 ## Essentials
 

--- a/packages/commands/src/liteyukibot_commands/service.py
+++ b/packages/commands/src/liteyukibot_commands/service.py
@@ -53,6 +53,8 @@ class CommandService(Protocol):
 
     def visible(self, event: EventEnvelope) -> tuple[CommandRegistration, ...]: ...
 
+    def resolve(self, event: EventEnvelope, path: Sequence[str]) -> CommandRegistration | None: ...
+
 
 @dataclass(frozen=True, slots=True)
 class _RegisteredCommand:
@@ -156,6 +158,14 @@ class _CommandService:
             for registration in self.snapshot()
             if self._allows(event, registration.spec)
         )
+
+    def resolve(self, event: EventEnvelope, path: Sequence[str]) -> CommandRegistration | None:
+        tokens = tuple(item.casefold() for item in path)
+        registration_id = self._paths.get(tokens)
+        if registration_id is None:
+            return None
+        registration = self._commands[registration_id].registration
+        return registration if self._allows(event, registration.spec) else None
 
     async def dispatch(self, event: EventEnvelope) -> HandlerResult | None:
         parsed = self._parse(event)

--- a/packages/essentials/src/liteyukibot_essentials/plugin.py
+++ b/packages/essentials/src/liteyukibot_essentials/plugin.py
@@ -7,8 +7,11 @@ from typing import Any, cast
 
 from liteyukibot_commands import (
     COMMAND_SERVICE,
+    ArgumentSpec,
     CommandBinding,
     CommandInvocation,
+    CommandParseError,
+    CommandSchema,
     CommandService,
     CommandSpec,
 )
@@ -18,7 +21,7 @@ from liteyukibot.events import HandlerResult
 from liteyukibot.services import ServiceRequirement
 from liteyukibot.status import KERNEL_STATUS_SERVICE, KernelStatusProvider
 
-from .render import Language, messages, render_help, render_status
+from .render import Language, messages, render_help, render_parse_error, render_status
 
 _PUBLIC_PERMISSION = "public"
 _STATUS_READ_CAPABILITY = "liteyukibot.status.read"
@@ -41,8 +44,27 @@ async def setup(context: PluginContext) -> PluginHandle:
     text = messages(language)
 
     def help_command(invocation: CommandInvocation) -> HandlerResult:
+        try:
+            parsed = invocation.parse()
+        except CommandParseError as error:
+            return invocation.reply(render_parse_error(error, language=language))
+        target = cast(tuple[str, ...], parsed.arguments["path"])
         visible = command_service.visible(invocation.event)
-        return invocation.reply(render_help(visible, prefix=invocation.prefix, language=language))
+        if target:
+            registration = command_service.resolve(invocation.event, target)
+            if registration is None:
+                visible = ()
+            else:
+                visible = (registration,)
+                target = registration.spec.command_path
+        return invocation.reply(
+            render_help(
+                visible,
+                prefix=invocation.prefix,
+                language=language,
+                target=target or None,
+            )
+        )
 
     def status_command(invocation: CommandInvocation) -> HandlerResult:
         return invocation.reply(render_status(status_provider.snapshot(), language=language))
@@ -54,6 +76,9 @@ async def setup(context: PluginContext) -> PluginHandle:
                 aliases=("帮助",),
                 summary=text.help_summary,
                 permission=_PUBLIC_PERMISSION,
+                schema=CommandSchema(
+                    arguments=(ArgumentSpec("path", required=False, variadic=True),),
+                ),
             ),
             help_command,
         ),

--- a/packages/essentials/src/liteyukibot_essentials/render.py
+++ b/packages/essentials/src/liteyukibot_essentials/render.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 
-from liteyukibot_commands import CommandRegistration
+from liteyukibot_commands import ArgumentSpec, CommandParseError, CommandRegistration, OptionSpec
 
 from liteyukibot.status import KernelStatusSnapshot
 
@@ -25,6 +25,14 @@ class _Messages:
     runtimes: str
     seconds: str
     empty: str
+    command_not_found: str
+    invalid_command: str
+    aliases: str
+    usage: str
+    arguments: str
+    options: str
+    required: str
+    optional: str
 
 
 _MESSAGES: dict[Language, _Messages] = {
@@ -39,6 +47,14 @@ _MESSAGES: dict[Language, _Messages] = {
         runtimes="运行时",
         seconds="秒",
         empty="无",
+        command_not_found="未找到可用命令",
+        invalid_command="命令参数无效",
+        aliases="别名",
+        usage="用法",
+        arguments="参数",
+        options="选项",
+        required="必填",
+        optional="可选",
     ),
     "en": _Messages(
         help_summary="Show available commands",
@@ -51,6 +67,14 @@ _MESSAGES: dict[Language, _Messages] = {
         runtimes="Runtimes",
         seconds="seconds",
         empty="none",
+        command_not_found="Command not found",
+        invalid_command="Invalid command arguments",
+        aliases="Aliases",
+        usage="Usage",
+        arguments="Arguments",
+        options="Options",
+        required="required",
+        optional="optional",
     ),
 }
 
@@ -64,11 +88,36 @@ def render_help(
     *,
     prefix: str,
     language: Language,
+    target: tuple[str, ...] | None = None,
 ) -> str:
     text = messages(language)
     lines = [text.help_header]
+    selected = registrations if target is None else tuple(
+        registration for registration in registrations if registration.spec.command_path == target
+    )
+    if target is not None and not selected:
+        return text.command_not_found
+    if target is not None:
+        registration = selected[0]
+        spec = registration.spec
+        label = prefix + " ".join(spec.command_path)
+        lines = [label]
+        if spec.aliases:
+            lines.append(
+                text.aliases + ": " + ", ".join(prefix + " ".join((*spec.path, alias)) for alias in spec.aliases)
+            )
+        if spec.summary:
+            lines.append(spec.summary)
+        lines.append(f"{text.usage}: {spec.usage or _usage(label, spec.schema.arguments, spec.schema.options)}")
+        if spec.schema.arguments:
+            lines.append(text.arguments + ":")
+            lines.extend(_render_argument(argument, text) for argument in spec.schema.arguments)
+        if spec.schema.options:
+            lines.append(text.options + ":")
+            lines.extend(_render_option(option, text) for option in spec.schema.options)
+        return "\n".join(lines)
     ordered = sorted(
-        registrations,
+        (item for item in selected if not item.spec.path),
         key=lambda item: (item.spec.name.casefold(), item.id),
     )
     for registration in ordered:
@@ -79,6 +128,38 @@ def render_help(
             label = f"{label} ({aliases})"
         lines.append(f"{label} - {spec.summary}" if spec.summary else label)
     return "\n".join(lines)
+
+
+def render_parse_error(error: CommandParseError, *, language: Language) -> str:
+    return messages(language).invalid_command
+
+
+def _usage(label: str, arguments: tuple[ArgumentSpec, ...], options: tuple[OptionSpec, ...]) -> str:
+    positional = []
+    for argument in arguments:
+        name = argument.metavar or argument.name.upper()
+        if argument.variadic:
+            name = f"{name}..."
+        positional.append(f"<{name}>" if argument.required else f"[{name}]")
+    option_usage = []
+    for option in options:
+        label_text = f"--{option.name}" if option.flag else f"--{option.name} {option.metavar or option.name.upper()}"
+        option_usage.append(label_text if option.required else f"[{label_text}]")
+    return " ".join((label, *positional, *option_usage))
+
+
+def _render_argument(argument: ArgumentSpec, text: _Messages) -> str:
+    label = argument.metavar or argument.name
+    requirement = text.required if argument.required else text.optional
+    suffix = "..." if argument.variadic else ""
+    return f"- {label}{suffix} ({requirement})"
+
+
+def _render_option(option: OptionSpec, text: _Messages) -> str:
+    labels = [f"--{option.name}", *(f"-{alias}" for alias in option.aliases)]
+    requirement = text.required if option.required else text.optional
+    suffix = " repeatable" if option.repeatable else ""
+    return f"- {', '.join(labels)} ({requirement}{suffix})"
 
 
 def render_status(snapshot: KernelStatusSnapshot, *, language: Language) -> str:
@@ -103,4 +184,4 @@ def _render_states(states: Mapping[str, str], *, empty: str) -> tuple[str, ...]:
     return tuple(f"- {identifier}: {state}" for identifier, state in items)
 
 
-__all__ = ["Language", "messages", "render_help", "render_status"]
+__all__ = ["Language", "messages", "render_help", "render_parse_error", "render_status"]

--- a/packages/essentials/tests/test_essentials.py
+++ b/packages/essentials/tests/test_essentials.py
@@ -4,7 +4,15 @@ from pathlib import Path
 from typing import cast
 
 import pytest
-from liteyukibot_commands import COMMAND_SERVICE, CommandService
+from liteyukibot_commands import (
+    COMMAND_SERVICE,
+    ArgumentSpec,
+    CommandSchema,
+    CommandService,
+    CommandSpec,
+    OptionSpec,
+    integer_value,
+)
 from liteyukibot_commands.service import create_command_service
 from liteyukibot_essentials import plugin, render_status
 from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, PermissionSnapshot, Principal
@@ -222,6 +230,90 @@ async def test_three_plugin_topology_filters_help_and_correlates_status(tmp_path
         await app.stop()
 
     assert commands.snapshot() == ()
+
+
+@pytest.mark.asyncio
+async def test_help_resolves_visible_hierarchical_aliases_and_renders_schema(tmp_path: Path) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
+        plugins=PluginSettings(
+            enabled=(
+                "liteyukibot.permissions",
+                "liteyukibot.commands",
+                "liteyukibot.essentials",
+            ),
+            config={"liteyukibot.essentials": {"language": "en"}},
+        ),
+    )
+    recorded: list[ActionEnvelope] = []
+
+    async def record_action(action: ActionEnvelope) -> ActionResult:
+        recorded.append(action)
+        return ActionResult(action_id=action.action_id, success=True)
+
+    app = LiteyukiApp(settings, logger=get_logger(component="essentials-help"))
+    app.events._action_executor = record_action
+    await app.start()
+    try:
+        commands = cast(CommandService, app.services.require(COMMAND_SERVICE))
+
+        def handler(_invocation: object) -> None:
+            return None
+
+        commands.register_many(
+            (
+                (CommandSpec("plugin", summary="Manage plugins"), handler),
+                (
+                    CommandSpec(
+                        "list",
+                        aliases=("ls",),
+                        path=("plugin",),
+                        summary="List installed plugins",
+                        schema=CommandSchema(
+                            arguments=(ArgumentSpec("filter", required=False),),
+                            options=(
+                                OptionSpec("limit", aliases=("n",), converter=integer_value, default=10),
+                                OptionSpec("verbose", aliases=("v",), flag=True),
+                            ),
+                        ),
+                    ),
+                    handler,
+                ),
+                (CommandSpec("hidden", permission=STATUS_READ), handler),
+            ),
+            owner="tests.help",
+        )
+
+        root = await app.events.publish(message_event("/help"))
+        detail = await app.events.publish(message_event("/help plugin ls"))
+        missing = await app.events.publish(message_event("/help hidden"))
+
+        assert root.stopped is True
+        assert detail.stopped is True
+        assert missing.stopped is True
+        assert cast(SendMessage, recorded[0].action).message.plain_text == "\n".join(
+            (
+                "Available commands:",
+                "/help (/帮助) - Show available commands",
+                "/plugin - Manage plugins",
+            )
+        )
+        assert cast(SendMessage, recorded[1].action).message.plain_text == "\n".join(
+            (
+                "/plugin list",
+                "Aliases: /plugin ls",
+                "List installed plugins",
+                "Usage: /plugin list [FILTER] [--limit LIMIT] [--verbose]",
+                "Arguments:",
+                "- filter (optional)",
+                "Options:",
+                "- --limit, -n (optional)",
+                "- --verbose, -v (optional)",
+            )
+        )
+        assert cast(SendMessage, recorded[2].action).message.plain_text == "Command not found"
+    finally:
+        await app.stop()
 
 
 def test_essentials_manifest_declares_only_required_services() -> None:


### PR DESCRIPTION
## Summary

- add command-service path resolution for essentials
- render root and detailed help from visible schemas, aliases, options, and arguments
- keep status capability-protected and parse errors localized without leaking converter details

## Validation

- 220 passed, 20 skipped
- Ruff and strict mypy
- all workspace builds
- isolated essentials wheel topology verification