### PR TITLE
🔖 Prepare plugin alpha 0.2.0a1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ uv sync --extra nonebot --extra satori
 Install the complete first-party plugin chain with:
 
 ```bash
-uv add "liteyukibot-v7-essentials==0.1.0a1"
+uv add "liteyukibot-v7-essentials==0.2.0a1"
 ```
 
 This resolves `liteyukibot-v7-commands` and

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -173,3 +173,7 @@ tokenization, options, and typed converters without handler annotation
 inspection. ADR 0018 adds hierarchical routing and ADR 0019 keeps detailed help
 and localized usage rendering in essentials. Runtime IPC stays at v3 and the
 kernel dependency set does not change.
+
+The Phase 5 plugin contract release is `0.2.0a1` for all three first-party
+distributions. It is published with new immutable plugin tags after the release
+identity and isolated wheel checks pass.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -34,9 +34,9 @@ distribution inside the workflow.
 | Package | Source | Tag |
 | --- | --- | --- |
 | `liteyukibot-v7==7.0.0a3` | `pyproject.toml` | `v7.0.0a3` |
-| `liteyukibot-v7-permissions==0.1.0a1` | `packages/permissions` | `permissions-v0.1.0a1` |
-| `liteyukibot-v7-commands==0.1.0a1` | `packages/commands` | `commands-v0.1.0a1` |
-| `liteyukibot-v7-essentials==0.1.0a1` | `packages/essentials` | `essentials-v0.1.0a1` |
+| `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
+| `liteyukibot-v7-commands==0.2.0a1` | `packages/commands` | `commands-v0.2.0a1` |
+| `liteyukibot-v7-essentials==0.2.0a1` | `packages/essentials` | `essentials-v0.2.0a1` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
 tag that does not exactly match the selected source version and distribution.
@@ -46,9 +46,9 @@ tag that does not exactly match the selected source version and distribution.
 Push and wait for each release before creating the next tag:
 
 1. `v7.0.0a3`;
-2. `permissions-v0.1.0a1`;
-3. `commands-v0.1.0a1`;
-4. `essentials-v0.1.0a1`.
+2. `permissions-v0.2.0a1`;
+3. `commands-v0.2.0a1`;
+4. `essentials-v0.2.0a1`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its
@@ -59,7 +59,7 @@ After the final upload, verify the public dependency chain without a checkout:
 
 ```bash
 uv run --no-project --python 3.14 \
-  --with "liteyukibot-v7-essentials==0.1.0a1" \
+  --with "liteyukibot-v7-essentials==0.2.0a1" \
   python -c "import importlib.metadata as m; print(m.version('liteyukibot-v7'))"
 ```
 

--- a/packages/commands/pyproject.toml
+++ b/packages/commands/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-commands"
-version = "0.1.0a1"
+version = "0.2.0a1"
 description = "Protocol-neutral command routing for LiteyukiBot v7 native plugins."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -11,7 +11,7 @@ authors = [
 ]
 dependencies = [
     "liteyukibot-v7>=7.0.0a3,<8",
-    "liteyukibot-v7-permissions>=0.1.0a1,<0.2",
+    "liteyukibot-v7-permissions>=0.2.0a1,<0.3",
 ]
 
 [project.entry-points."liteyukibot.plugins"]

--- a/packages/commands/src/liteyukibot_commands/__init__.py
+++ b/packages/commands/src/liteyukibot_commands/__init__.py
@@ -29,7 +29,7 @@ from .service import COMMAND_SERVICE, CommandService
 try:
     __version__ = version("liteyukibot-v7-commands")
 except PackageNotFoundError:
-    __version__ = "0.1.0a1"
+    __version__ = "0.2.0a1"
 
 plugin = create_plugin(__version__)
 

--- a/packages/commands/tests/test_commands.py
+++ b/packages/commands/tests/test_commands.py
@@ -325,7 +325,7 @@ async def test_command_plugin_service_is_removed_on_stop(tmp_path: Path) -> None
 
 def test_command_plugin_manifest_declares_permission_dependency() -> None:
     assert plugin.manifest.id == "liteyukibot.commands"
-    assert plugin.manifest.version == "0.1.0a1"
+    assert plugin.manifest.version == "0.2.0a1"
     assert plugin.manifest.provides == (COMMAND_SERVICE,)
     assert tuple(item.key for item in plugin.manifest.requires) == (PERMISSION_SERVICE,)
 

--- a/packages/essentials/pyproject.toml
+++ b/packages/essentials/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-essentials"
-version = "0.1.0a1"
+version = "0.2.0a1"
 description = "Essential help and status commands for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -11,7 +11,7 @@ authors = [
 ]
 dependencies = [
     "liteyukibot-v7>=7.0.0a3,<8",
-    "liteyukibot-v7-commands>=0.1.0a1,<0.2",
+    "liteyukibot-v7-commands>=0.2.0a1,<0.3",
 ]
 
 [project.entry-points."liteyukibot.plugins"]

--- a/packages/essentials/src/liteyukibot_essentials/__init__.py
+++ b/packages/essentials/src/liteyukibot_essentials/__init__.py
@@ -8,7 +8,7 @@ from .render import Language, render_help, render_status
 try:
     __version__ = version("liteyukibot-v7-essentials")
 except PackageNotFoundError:
-    __version__ = "0.1.0a1"
+    __version__ = "0.2.0a1"
 
 plugin = create_plugin(__version__)
 

--- a/packages/essentials/tests/test_essentials.py
+++ b/packages/essentials/tests/test_essentials.py
@@ -318,7 +318,7 @@ async def test_help_resolves_visible_hierarchical_aliases_and_renders_schema(tmp
 
 def test_essentials_manifest_declares_only_required_services() -> None:
     assert plugin.manifest.id == "liteyukibot.essentials"
-    assert plugin.manifest.version == "0.1.0a1"
+    assert plugin.manifest.version == "0.2.0a1"
     assert plugin.manifest.provides == ()
     assert tuple(item.key for item in plugin.manifest.requires) == (
         COMMAND_SERVICE,

--- a/packages/permissions/pyproject.toml
+++ b/packages/permissions/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-permissions"
-version = "0.1.0a1"
+version = "0.2.0a1"
 description = "Versioned access policy service for LiteyukiBot v7 native plugins."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/permissions/src/liteyukibot_permissions/__init__.py
+++ b/packages/permissions/src/liteyukibot_permissions/__init__.py
@@ -8,7 +8,7 @@ from .service import PERMISSION_SERVICE, PUBLIC, PermissionService, PermissionSn
 try:
     __version__ = version("liteyukibot-v7-permissions")
 except PackageNotFoundError:
-    __version__ = "0.1.0a1"
+    __version__ = "0.2.0a1"
 
 plugin = create_plugin(__version__)
 

--- a/packages/permissions/tests/test_permissions.py
+++ b/packages/permissions/tests/test_permissions.py
@@ -237,5 +237,5 @@ def test_permission_snapshot_requires_public_capability() -> None:
 
 def test_permission_plugin_manifest_publishes_versioned_service() -> None:
     assert plugin.manifest.id == "liteyukibot.permissions"
-    assert plugin.manifest.version == "0.1.0a1"
+    assert plugin.manifest.version == "0.2.0a1"
     assert plugin.manifest.provides == (PERMISSION_SERVICE,)

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -28,9 +28,9 @@ def test_import_namespaces_use_distribution_version() -> None:
     ("name", "tag"),
     [
         ("root", "v7.0.0a3"),
-        ("permissions", "permissions-v0.1.0a1"),
-        ("commands", "commands-v0.1.0a1"),
-        ("essentials", "essentials-v0.1.0a1"),
+        ("permissions", "permissions-v0.2.0a1"),
+        ("commands", "commands-v0.2.0a1"),
+        ("essentials", "essentials-v0.2.0a1"),
     ],
 )
 def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> None:
@@ -48,9 +48,9 @@ def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> No
         (ReleaseIdentity("liteyukibot", "7.0.0a3"), "root", None, "project.name"),
         (ReleaseIdentity("liteyukibot-v7", "7.0.0a3"), "root", "v7.0.0a2", "release tag"),
         (
-            ReleaseIdentity("liteyukibot-v7-commands", "0.1.0a1"),
+            ReleaseIdentity("liteyukibot-v7-commands", "0.2.0a1"),
             "commands",
-            "permissions-v0.1.0a1",
+            "permissions-v0.2.0a1",
             "release tag",
         ),
     ],

--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ dev = [
 
 [[package]]
 name = "liteyukibot-v7-commands"
-version = "0.1.0a1"
+version = "0.2.0a1"
 source = { editable = "packages/commands" }
 dependencies = [
     { name = "liteyukibot-v7" },
@@ -321,7 +321,7 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-essentials"
-version = "0.1.0a1"
+version = "0.2.0a1"
 source = { editable = "packages/essentials" }
 dependencies = [
     { name = "liteyukibot-v7" },
@@ -336,7 +336,7 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-permissions"
-version = "0.1.0a1"
+version = "0.2.0a1"
 source = { editable = "packages/permissions" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Summary\n- bump first-party permissions, commands, and essentials distributions to 0.2.0a1\n- update dependency ranges, lockfile, release identities, docs, and install expectations\n- preserve ordered plugin release validation for the existing PyPI trusted publishers\n\n## Validation\n- uv run ruff check src tests scripts examples packages\n- uv run mypy\n- uv run pytest -q (220 passed, 20 skipped)\n- uv build --all-packages --out-dir dist/workspace --clear\n\nAfter merge, publish immutable tags in dependency order: permissions, commands, essentials.