### PR TITLE
✨ Add resource management contract

### DIFF
--- a/docs/adr/0020-resource-management-contract.md
+++ b/docs/adr/0020-resource-management-contract.md
@@ -1,0 +1,31 @@
+# ADR 0020: Native Resource Management Contract
+
+## Status
+
+Accepted for the alpha resource/profile chapter.
+
+## Decision
+
+The optional `liteyukibot.resources@1` plugin provides a registry for
+declarative resource fields. It owns path resolution, field capability checks,
+and the inspect/set/delete operation boundary. A resource provider owns its
+data, storage, transactions, and migrations.
+
+Resources target an exact `(runtime_id, bot_id, actor_id)` principal. A command
+without `--actor` targets the event actor. A different actor is rejected unless
+the field declares the capability for the requested operation and the current
+principal has that capability. Runtime and bot IDs cannot be overridden.
+
+The registry is optional and does not modify kernel Event/Action models,
+runtime IPC, or the command service contract. Plugins that do not use the
+declarative layer may continue registering commands directly.
+
+## Consequences
+
+- Profile and future business plugins can reuse one command and authorization
+  convention without sharing a database abstraction.
+- Resource providers remain independently testable and may choose SQLite,
+  files, remote storage, or memory.
+- Cross-principal access is explicit per operation and fail-closed.
+- The alpha API may be revised directly; no v6 `sudo` or superuser compatibility
+  is promised.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,3 +23,4 @@ stable-release guarantee.
 17. [Explicit structured command schemas](0017-structured-command-schema.md)
 18. [Hierarchical command routing](0018-hierarchical-command-routing.md)
 19. [Essentials help and usage rendering](0019-essentials-command-help.md)
+20. [Native resource management contract](0020-resource-management-contract.md)

--- a/packages/resources/LICENSE
+++ b/packages/resources/LICENSE
@@ -1,0 +1,1 @@
+LiteyukiBot is licensed under the Liteyuki Open Source License (LSO).

--- a/packages/resources/README.md
+++ b/packages/resources/README.md
@@ -1,0 +1,10 @@
+# LiteyukiBot v7 Resources
+
+`liteyukibot-v7-resources` provides the optional
+`liteyukibot.resources@1` service for declarative, protocol-neutral resource
+management in native plugins.
+
+The service owns resource registration, field validation, principal targeting,
+and capability checks. Resource providers own their data and persistence. The
+first-party profile plugin uses this contract without requiring resources to
+own a database or a kernel storage service.

--- a/packages/resources/pyproject.toml
+++ b/packages/resources/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "liteyukibot-v7-resources"
+version = "0.1.0a1"
+description = "Declarative resource management contracts for LiteyukiBot v7 plugins."
+readme = "README.md"
+requires-python = ">=3.14"
+license = "LicenseRef-LSO"
+license-files = ["LICENSE"]
+authors = [
+    { name = "LiteyukiStudio" },
+]
+dependencies = [
+    "liteyukibot-v7>=7.0.0a3,<8",
+    "liteyukibot-v7-permissions>=0.2.0a1,<0.3",
+]
+
+[project.entry-points."liteyukibot.plugins"]
+"liteyukibot.resources" = "liteyukibot_resources:plugin"
+
+[build-system]
+requires = ["uv_build>=0.11.32,<0.12"]
+build-backend = "uv_build"
+
+[tool.uv.sources]
+liteyukibot-v7 = { workspace = true }
+liteyukibot-v7-permissions = { workspace = true }
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "liteyukibot_resources"

--- a/packages/resources/src/liteyukibot_resources/__init__.py
+++ b/packages/resources/src/liteyukibot_resources/__init__.py
@@ -1,0 +1,33 @@
+"""Declarative resource management for LiteyukiBot v7 plugins."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+from .models import (
+    ResourceField,
+    ResourceOperation,
+    ResourceProvider,
+    ResourceRegistration,
+    ResourceSpec,
+)
+from .plugin import create_plugin
+from .service import RESOURCE_SERVICE, ResourceError, ResourceService
+
+try:
+    __version__ = version("liteyukibot-v7-resources")
+except PackageNotFoundError:
+    __version__ = "0.1.0a1"
+
+plugin = create_plugin(__version__)
+
+__all__ = [
+    "RESOURCE_SERVICE",
+    "ResourceField",
+    "ResourceError",
+    "ResourceOperation",
+    "ResourceProvider",
+    "ResourceRegistration",
+    "ResourceService",
+    "ResourceSpec",
+    "__version__",
+    "plugin",
+]

--- a/packages/resources/src/liteyukibot_resources/models.py
+++ b/packages/resources/src/liteyukibot_resources/models.py
@@ -1,0 +1,118 @@
+"""Public resource declaration and provider contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from liteyukibot_permissions import Principal
+
+type ResourceOperation = Literal["inspect", "set", "delete"]
+type ResourceConverter = Callable[[str], object]
+
+
+def _token(kind: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"resource {kind} must be a string")
+    if not value or value != value.strip() or any(character.isspace() for character in value):
+        raise ValueError(f"resource {kind} must be a non-empty token without whitespace")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceField:
+    name: str
+    converter: ResourceConverter
+    description: str = ""
+    readable: bool = True
+    settable: bool = True
+    deletable: bool = True
+    inspect_capability: str | None = None
+    set_capability: str | None = None
+    delete_capability: str | None = None
+
+    def __post_init__(self) -> None:
+        _token("field name", self.name)
+        if not callable(self.converter):
+            raise TypeError(f"resource field {self.name} converter must be callable")
+        if not isinstance(self.description, str):
+            raise TypeError(f"resource field {self.name} description must be a string")
+        for operation, enabled in (
+            ("readable", self.readable),
+            ("settable", self.settable),
+            ("deletable", self.deletable),
+        ):
+            if not isinstance(enabled, bool):
+                raise TypeError(f"resource field {self.name} {operation} must be a boolean")
+        for operation, capability in (
+            ("inspect", self.inspect_capability),
+            ("set", self.set_capability),
+            ("delete", self.delete_capability),
+        ):
+            if capability is not None:
+                _token(f"field {self.name} {operation} capability", capability)
+        if not any((self.readable, self.settable, self.deletable)):
+            raise ValueError(f"resource field {self.name} must enable at least one operation")
+
+    def capability_for(self, operation: ResourceOperation) -> str | None:
+        return {
+            "inspect": self.inspect_capability,
+            "set": self.set_capability,
+            "delete": self.delete_capability,
+        }[operation]
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceSpec:
+    name: str
+    path: tuple[str, ...] = ()
+    summary: str = ""
+    fields: tuple[ResourceField, ...] = ()
+
+    def __post_init__(self) -> None:
+        _token("name", self.name)
+        if isinstance(self.path, str):
+            raise TypeError("resource path must be a sequence of tokens")
+        path = tuple(self.path)
+        for segment in path:
+            _token("path segment", segment)
+        if not isinstance(self.summary, str):
+            raise TypeError("resource summary must be a string")
+        if any(not isinstance(field, ResourceField) for field in self.fields):
+            raise TypeError("resource fields must contain ResourceField values")
+        fields = tuple(self.fields)
+        names = [field.name.casefold() for field in fields]
+        if len(names) != len(set(names)):
+            raise ValueError(f"resource {self.name} fields must not contain duplicates")
+        object.__setattr__(self, "path", path)
+        object.__setattr__(self, "fields", fields)
+
+    @property
+    def resource_path(self) -> tuple[str, ...]:
+        return (*self.path, self.name)
+
+
+class ResourceProvider(Protocol):
+    def inspect(self, principal: Principal, field: ResourceField) -> Awaitable[object]: ...
+
+    def set(self, principal: Principal, field: ResourceField, value: object) -> Awaitable[None]: ...
+
+    def delete(self, principal: Principal, field: ResourceField) -> Awaitable[None]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceRegistration:
+    id: int
+    owner: str
+    spec: ResourceSpec
+
+
+__all__ = [
+    "ResourceConverter",
+    "ResourceField",
+    "ResourceOperation",
+    "ResourceProvider",
+    "ResourceRegistration",
+    "ResourceSpec",
+]

--- a/packages/resources/src/liteyukibot_resources/plugin.py
+++ b/packages/resources/src/liteyukibot_resources/plugin.py
@@ -1,0 +1,34 @@
+"""Native plugin entry point for the resource registry."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService
+
+from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
+from liteyukibot.services import ServiceRequirement
+
+from .service import RESOURCE_SERVICE, create_resource_service
+
+
+async def setup(context: PluginContext) -> PluginHandle:
+    permissions = cast(PermissionService, context.services.require(PERMISSION_SERVICE))
+    context.services.provide(RESOURCE_SERVICE, create_resource_service(permissions))
+    return PluginHandle()
+
+
+def create_plugin(version: str) -> PluginDefinition:
+    return PluginDefinition(
+        manifest=PluginManifest(
+            id="liteyukibot.resources",
+            name="LiteyukiBot Resources",
+            version=version,
+            provides=(RESOURCE_SERVICE,),
+            requires=(ServiceRequirement(PERMISSION_SERVICE),),
+        ),
+        setup=setup,
+    )
+
+
+__all__ = ["create_plugin"]

--- a/packages/resources/src/liteyukibot_resources/service.py
+++ b/packages/resources/src/liteyukibot_resources/service.py
@@ -1,0 +1,249 @@
+"""Resource registry and principal-aware operation dispatch."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from liteyukibot_permissions import PermissionService, Principal
+
+from liteyukibot.events import EventEnvelope
+from liteyukibot.services import ServiceKey
+
+from .models import ResourceField, ResourceOperation, ResourceProvider, ResourceRegistration, ResourceSpec
+
+RESOURCE_SERVICE = ServiceKey("liteyukibot.resources", 1)
+
+
+class ResourceError(ValueError):
+    """Raised when a resource operation cannot be performed."""
+
+
+class ResourceService(Protocol):
+    def register(
+        self,
+        spec: ResourceSpec,
+        provider: ResourceProvider,
+        *,
+        owner: str,
+    ) -> ResourceRegistration: ...
+
+    def register_many(
+        self,
+        bindings: Sequence[tuple[ResourceSpec, ResourceProvider]],
+        *,
+        owner: str,
+    ) -> tuple[ResourceRegistration, ...]: ...
+
+    def unregister(self, registration: ResourceRegistration) -> bool: ...
+
+    def snapshot(self) -> tuple[ResourceRegistration, ...]: ...
+
+    def resolve(self, path: Sequence[str]) -> ResourceRegistration | None: ...
+
+    async def inspect(
+        self,
+        event: EventEnvelope,
+        path: Sequence[str],
+        *,
+        actor_id: str | None = None,
+    ) -> Mapping[str, object]: ...
+
+    async def set(
+        self,
+        event: EventEnvelope,
+        path: Sequence[str],
+        field: str,
+        value: str,
+        *,
+        actor_id: str | None = None,
+    ) -> None: ...
+
+    async def delete(
+        self,
+        event: EventEnvelope,
+        path: Sequence[str],
+        field: str,
+        *,
+        actor_id: str | None = None,
+    ) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _RegisteredResource:
+    registration: ResourceRegistration
+    provider: ResourceProvider
+
+
+class _ResourceService:
+    def __init__(self, permissions: PermissionService) -> None:
+        self._permissions = permissions
+        self._resources: dict[int, _RegisteredResource] = {}
+        self._paths: dict[tuple[str, ...], int] = {}
+        self._next_id = 0
+
+    def register(
+        self,
+        spec: ResourceSpec,
+        provider: ResourceProvider,
+        *,
+        owner: str,
+    ) -> ResourceRegistration:
+        return self.register_many(((spec, provider),), owner=owner)[0]
+
+    def register_many(
+        self,
+        bindings: Sequence[tuple[ResourceSpec, ResourceProvider]],
+        *,
+        owner: str,
+    ) -> tuple[ResourceRegistration, ...]:
+        if not owner or owner != owner.strip():
+            raise ValueError("resource owner must be a non-empty trimmed string")
+        pending = tuple(bindings)
+        claimed = set(self._paths)
+        prepared: list[tuple[ResourceSpec, ResourceProvider, tuple[str, ...]]] = []
+        for spec, provider in pending:
+            if not isinstance(spec, ResourceSpec):
+                raise TypeError("resource binding must contain ResourceSpec")
+            for operation in ("inspect", "set", "delete"):
+                if not callable(getattr(provider, operation, None)):
+                    raise TypeError(f"resource provider must define {operation}")
+            path = tuple(segment.casefold() for segment in spec.resource_path)
+            if path in claimed:
+                raise ValueError(f"resource path is already registered: {' '.join(path)}")
+            claimed.add(path)
+            prepared.append((spec, provider, path))
+        registrations: list[ResourceRegistration] = []
+        for spec, provider, path in prepared:
+            registration = ResourceRegistration(self._next_id, owner, spec)
+            self._next_id += 1
+            self._resources[registration.id] = _RegisteredResource(registration, provider)
+            self._paths[path] = registration.id
+            registrations.append(registration)
+        return tuple(registrations)
+
+    def unregister(self, registration: ResourceRegistration) -> bool:
+        registered = self._resources.get(registration.id)
+        if registered is None or registered.registration != registration:
+            return False
+        del self._resources[registration.id]
+        self._paths.pop(tuple(segment.casefold() for segment in registration.spec.resource_path), None)
+        return True
+
+    def snapshot(self) -> tuple[ResourceRegistration, ...]:
+        return tuple(
+            item.registration
+            for item in sorted(
+                self._resources.values(),
+                key=lambda item: (
+                    tuple(segment.casefold() for segment in item.registration.spec.resource_path),
+                    item.registration.id,
+                ),
+            )
+        )
+
+    def resolve(self, path: Sequence[str]) -> ResourceRegistration | None:
+        resource_id = self._paths.get(tuple(segment.casefold() for segment in path))
+        return None if resource_id is None else self._resources[resource_id].registration
+
+    async def inspect(
+        self,
+        event: EventEnvelope,
+        path: Sequence[str],
+        *,
+        actor_id: str | None = None,
+    ) -> Mapping[str, object]:
+        registered, principal = self._target(event, path, actor_id)
+        result: dict[str, object] = {}
+        for field in registered.registration.spec.fields:
+            if not field.readable:
+                continue
+            self._authorize(event, principal, field, "inspect")
+            result[field.name] = await _await_provider(registered.provider.inspect(principal, field))
+        return result
+
+    async def set(
+        self,
+        event: EventEnvelope,
+        path: Sequence[str],
+        field: str,
+        value: str,
+        *,
+        actor_id: str | None = None,
+    ) -> None:
+        registered, principal = self._target(event, path, actor_id)
+        selected = self._field(registered.registration.spec, field)
+        if not selected.settable:
+            raise ResourceError(f"resource field is not settable: {field}")
+        self._authorize(event, principal, selected, "set")
+        try:
+            converted = selected.converter(value)
+        except Exception as error:
+            raise ResourceError(f"invalid value for resource field: {field}") from error
+        await _await_provider(registered.provider.set(principal, selected, converted))
+
+    async def delete(
+        self,
+        event: EventEnvelope,
+        path: Sequence[str],
+        field: str,
+        *,
+        actor_id: str | None = None,
+    ) -> None:
+        registered, principal = self._target(event, path, actor_id)
+        selected = self._field(registered.registration.spec, field)
+        if not selected.deletable:
+            raise ResourceError(f"resource field is not deletable: {field}")
+        self._authorize(event, principal, selected, "delete")
+        await _await_provider(registered.provider.delete(principal, selected))
+
+    def _target(
+        self,
+        event: EventEnvelope,
+        path: Sequence[str],
+        actor_id: str | None,
+    ) -> tuple[_RegisteredResource, Principal]:
+        resource_id = self._paths.get(tuple(segment.casefold() for segment in path))
+        if resource_id is None:
+            raise ResourceError(f"resource not found: {' '.join(path)}")
+        if event.actor is None:
+            raise ResourceError("resource operations require an actor")
+        current = Principal(event.runtime_id, event.bot_id, event.actor.id)
+        target = current if actor_id is None else Principal(event.runtime_id, event.bot_id, actor_id)
+        return self._resources[resource_id], target
+
+    def _authorize(
+        self,
+        event: EventEnvelope,
+        target: Principal,
+        field: ResourceField,
+        operation: ResourceOperation,
+    ) -> None:
+        current = Principal(event.runtime_id, event.bot_id, event.actor.id) if event.actor is not None else None
+        if current == target:
+            return
+        capability = field.capability_for(operation)
+        if capability is None or not self._permissions.allows(event, capability):
+            raise ResourceError(f"resource {operation} is not authorized for target")
+
+    @staticmethod
+    def _field(spec: ResourceSpec, name: str) -> ResourceField:
+        for field in spec.fields:
+            if field.name.casefold() == name.casefold():
+                return field
+        raise ResourceError(f"resource field not found: {name}")
+
+
+async def _await_provider(value: object) -> object:
+    if not inspect.isawaitable(value):
+        raise TypeError("resource provider operation must return an awaitable")
+    return await value
+
+
+def create_resource_service(permissions: PermissionService) -> ResourceService:
+    return _ResourceService(permissions)
+
+
+__all__ = ["RESOURCE_SERVICE", "ResourceError", "ResourceService", "create_resource_service"]

--- a/packages/resources/tests/test_resources.py
+++ b/packages/resources/tests/test_resources.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, PermissionSnapshot, Principal
+from liteyukibot_resources import (
+    RESOURCE_SERVICE,
+    ResourceError,
+    ResourceField,
+    ResourceProvider,
+    ResourceSpec,
+    plugin,
+)
+from liteyukibot_resources.service import create_resource_service
+
+from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
+from liteyukibot.testing import PluginTestHarness
+
+
+def event(*, actor_id: str | None = "user") -> EventEnvelope:
+    return EventEnvelope(
+        runtime_id="runtime",
+        adapter="test",
+        bot_id="bot",
+        type="message",
+        conversation=ConversationRef(id="group", type="group"),
+        actor=None if actor_id is None else ActorRef(id=actor_id),
+    )
+
+
+class PermissionStub:
+    def principal(self, item: EventEnvelope) -> Principal | None:
+        if item.actor is None:
+            return None
+        return Principal(item.runtime_id, item.bot_id, item.actor.id)
+
+    def resolve(self, item: EventEnvelope) -> PermissionSnapshot:
+        principal = self.principal(item)
+        capabilities = {PUBLIC}
+        if item.actor is not None:
+            capabilities.add("profile.manage")
+        return PermissionSnapshot(principal, frozenset(), frozenset(capabilities))
+
+    def allows(self, _event: EventEnvelope, capability: str) -> bool:
+        return capability == "profile.manage"
+
+
+class DenyingPermissionStub(PermissionStub):
+    def allows(self, _event: EventEnvelope, _capability: str) -> bool:
+        return False
+
+
+class Provider(ResourceProvider):
+    def __init__(self) -> None:
+        self.values = {"user": "Alice"}
+
+    async def inspect(self, principal: Principal, field: ResourceField) -> object:
+        return self.values.get(principal.actor_id, "")
+
+    async def set(self, principal: Principal, field: ResourceField, value: object) -> None:
+        self.values[principal.actor_id] = cast(str, value)
+
+    async def delete(self, principal: Principal, field: ResourceField) -> None:
+        self.values.pop(principal.actor_id, None)
+
+
+def specification() -> ResourceSpec:
+    return ResourceSpec(
+        "profile",
+        summary="User profile",
+        fields=(
+            ResourceField(
+                "nickname",
+                str,
+                description="Display name",
+                inspect_capability="profile.manage",
+                set_capability="profile.manage",
+                delete_capability="profile.manage",
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_resource_plugin_provides_service_and_removes_it_on_stop(tmp_path: Path) -> None:
+    harness = PluginTestHarness(
+        plugin,
+        root=tmp_path,
+        dependencies={PERMISSION_SERVICE: PermissionStub()},
+    )
+    async with harness:
+        assert harness.require_service(RESOURCE_SERVICE) is not None
+
+
+@pytest.mark.asyncio
+async def test_resource_service_reads_writes_and_deletes_current_principal() -> None:
+    service = create_resource_service(PermissionStub())
+    provider = Provider()
+    service.register(specification(), provider, owner="test")
+
+    current = event()
+    assert await service.inspect(current, ("profile",)) == {"nickname": "Alice"}
+    await service.set(current, ("profile",), "nickname", "Bob")
+    assert await service.inspect(current, ("profile",)) == {"nickname": "Bob"}
+    await service.delete(current, ("profile",), "nickname")
+    assert await service.inspect(current, ("profile",)) == {"nickname": ""}
+
+
+@pytest.mark.asyncio
+async def test_resource_service_requires_capability_for_other_actor() -> None:
+    service = create_resource_service(PermissionStub())
+    provider = Provider()
+    service.register(specification(), provider, owner="test")
+
+    current = event()
+    await service.set(current, ("profile",), "nickname", "Bob", actor_id="other")
+    assert await service.inspect(current, ("profile",), actor_id="other") == {"nickname": "Bob"}
+
+
+@pytest.mark.asyncio
+async def test_resource_service_fails_closed_for_other_actor() -> None:
+    service = create_resource_service(DenyingPermissionStub())
+    service.register(specification(), Provider(), owner="test")
+
+    with pytest.raises(ResourceError, match="not authorized"):
+        await service.set(event(), ("profile",), "nickname", "Bob", actor_id="other")
+
+
+def test_resource_registration_is_atomic_and_path_stable() -> None:
+    service = create_resource_service(PermissionStub())
+    provider = Provider()
+    profile = specification()
+    duplicate = ResourceSpec("PROFILE", fields=(ResourceField("language", str),))
+
+    with pytest.raises(ValueError, match="already registered"):
+        service.register_many(((profile, provider), (duplicate, provider)), owner="test")
+
+    assert service.snapshot() == ()
+    registration = service.register(profile, provider, owner="test")
+    assert service.resolve(("PrOfIlE",)) == registration
+    assert service.unregister(registration) is True
+    assert service.resolve(("profile",)) is None
+
+
+@pytest.mark.asyncio
+async def test_resource_service_rejects_anonymous_and_invalid_operations() -> None:
+    service = create_resource_service(PermissionStub())
+    service.register(specification(), Provider(), owner="test")
+
+    with pytest.raises(ResourceError, match="resource not found"):
+        await service.inspect(event(actor_id="user"), ("missing",))
+
+    with pytest.raises(ResourceError, match="require an actor"):
+        await service.inspect(event(actor_id=None), ("profile",))

--- a/scripts/run_resources_install.py
+++ b/scripts/run_resources_install.py
@@ -1,0 +1,40 @@
+"""Run the resources verifier against wheels built from this workspace."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _one_wheel(distribution: str) -> Path:
+    directory = ROOT / "dist" / "workspace"
+    matches = tuple(directory.glob(f"{distribution}-*-py3-none-any.whl"))
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one {distribution} wheel in {directory}, found {len(matches)}")
+    return matches[0].resolve()
+
+
+def main() -> int:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv executable was not found")
+    wheels = (
+        _one_wheel("liteyukibot_v7"),
+        _one_wheel("liteyukibot_v7_permissions"),
+        _one_wheel("liteyukibot_v7_resources"),
+    )
+    command = [uv, "run", "--no-project", "--python", "3.14"]
+    for wheel in wheels:
+        command.extend(("--with", str(wheel)))
+    command.extend(("python", str(ROOT / "scripts" / "verify_resources_install.py")))
+    with tempfile.TemporaryDirectory() as directory:
+        subprocess.run(command, cwd=directory, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_resources_install.py
+++ b/scripts/verify_resources_install.py
@@ -1,0 +1,104 @@
+"""Verify the installed resource wheel without importing workspace sources."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.metadata
+import json
+import tempfile
+from pathlib import Path
+from typing import cast
+
+import liteyukibot_resources
+from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService
+from liteyukibot_resources import RESOURCE_SERVICE, ResourceField, ResourceProvider, ResourceSpec
+from liteyukibot_resources.service import ResourceService
+
+import liteyukibot
+from liteyukibot import PluginDefinition
+from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
+from liteyukibot.testing import PluginTestHarness
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _verify_import_sources() -> None:
+    imported = (
+        Path(liteyukibot.__file__).resolve(),
+        Path(liteyukibot_resources.__file__).resolve(),
+    )
+    if any(path.is_relative_to(SOURCE_ROOT) for path in imported):
+        raise RuntimeError(f"workspace source import detected: {imported}")
+
+
+def _installed_plugin() -> PluginDefinition:
+    matches = tuple(
+        item
+        for item in importlib.metadata.entry_points(group="liteyukibot.plugins")
+        if item.name == "liteyukibot.resources"
+    )
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one resources entry point, found {len(matches)}")
+    candidate = matches[0].load()
+    if not isinstance(candidate, PluginDefinition):
+        raise TypeError("resources entry point did not resolve to PluginDefinition")
+    return candidate
+
+
+class _Provider(ResourceProvider):
+    async def inspect(self, _principal: object, _field: ResourceField) -> object:
+        return "ok"
+
+    async def set(self, _principal: object, _field: ResourceField, _value: object) -> None:
+        return None
+
+    async def delete(self, _principal: object, _field: ResourceField) -> None:
+        return None
+
+
+async def verify(expected_version: str | None = None) -> None:
+    _verify_import_sources()
+    definition = _installed_plugin()
+    event = EventEnvelope(
+        runtime_id="runtime",
+        adapter="test",
+        bot_id="bot",
+        type="message",
+        conversation=ConversationRef(id="conversation"),
+        actor=ActorRef(id="user"),
+    )
+    with tempfile.TemporaryDirectory() as directory:
+        async with PluginTestHarness(
+            definition,
+            root=Path(directory),
+            dependencies={PERMISSION_SERVICE: cast(PermissionService, _PermissionStub())},
+        ) as harness:
+            service = cast(ResourceService, harness.require_service(RESOURCE_SERVICE))
+            service.register(
+                ResourceSpec("verify", fields=(ResourceField("value", str),)),
+                _Provider(),
+                owner="verify",
+            )
+            if await service.inspect(event, ("verify",)) != {"value": "ok"}:
+                raise RuntimeError("installed resources service returned an unexpected value")
+
+    observed = {
+        "liteyukibot-v7": importlib.metadata.version("liteyukibot-v7"),
+        "liteyukibot-v7-resources": importlib.metadata.version("liteyukibot-v7-resources"),
+    }
+    if expected_version is not None and observed["liteyukibot-v7-resources"] != expected_version:
+        raise RuntimeError(f"expected liteyukibot-v7-resources {expected_version}; observed {observed}")
+    print(json.dumps(observed, sort_keys=True))
+
+
+class _PermissionStub:
+    def allows(self, _event: EventEnvelope, _capability: str) -> bool:
+        return False
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-version")
+    arguments = parser.parse_args()
+    asyncio.run(verify(arguments.expected_version))

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "liteyukibot-v7-commands",
     "liteyukibot-v7-essentials",
     "liteyukibot-v7-permissions",
+    "liteyukibot-v7-resources",
 ]
 
 [[package]]
@@ -344,6 +345,21 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
+
+[[package]]
+name = "liteyukibot-v7-resources"
+version = "0.1.0a1"
+source = { editable = "packages/resources" }
+dependencies = [
+    { name = "liteyukibot-v7" },
+    { name = "liteyukibot-v7-permissions" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "liteyukibot-v7", editable = "." },
+    { name = "liteyukibot-v7-permissions", editable = "packages/permissions" },
+]
 
 [[package]]
 name = "loguru"


### PR DESCRIPTION
## Summary\n- add the optional liteyukibot-v7-resources workspace distribution and liteyukibot.resources@1 registry\n- define field-level inspect, set, and delete provider contracts with exact-principal targeting and fail-closed cross-principal capability checks\n- add ADR 0020 and isolated wheel-install verification\n- keep persistence, generated commands, profile behavior, kernel Event/Action schemas, and runtime IPC out of this PR\n\n## Validation\n- uv run ruff check src tests scripts examples packages\n- uv run mypy\n- uv run pytest -q (226 passed, 20 skipped)\n- uv build --all-packages --out-dir dist/workspace --clear\n- uv run python scripts/run_resources_install.py