### PR TITLE
✨ Add persistent profile storage

### DIFF
--- a/packages/profile/LICENSE
+++ b/packages/profile/LICENSE
@@ -1,0 +1,1 @@
+LiteyukiBot is licensed under the Liteyuki Open Source License (LSO).

--- a/packages/profile/README.md
+++ b/packages/profile/README.md
@@ -1,0 +1,8 @@
+# LiteyukiBot v7 Profile
+
+`liteyukibot-v7-profile` stores persistent per-bot user preferences and
+provides `liteyukibot.profile@1` to native plugins.
+
+Records are keyed by exact `(runtime_id, bot_id, actor_id)` principals. The
+initial fields are `nickname` and `language`; storage lives entirely in this
+plugin's private SQLite database.

--- a/packages/profile/pyproject.toml
+++ b/packages/profile/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "liteyukibot-v7-profile"
+version = "0.1.0a1"
+description = "Persistent per-bot user profiles for LiteyukiBot v7."
+readme = "README.md"
+requires-python = ">=3.14"
+license = "LicenseRef-LSO"
+license-files = ["LICENSE"]
+authors = [
+    { name = "LiteyukiStudio" },
+]
+dependencies = [
+    "liteyukibot-v7>=7.0.0a3,<8",
+    "liteyukibot-v7-resources>=0.1.0a1,<0.2",
+]
+
+[project.entry-points."liteyukibot.plugins"]
+"liteyukibot.profile" = "liteyukibot_profile:plugin"
+
+[build-system]
+requires = ["uv_build>=0.11.32,<0.12"]
+build-backend = "uv_build"
+
+[tool.uv.sources]
+liteyukibot-v7 = { workspace = true }
+liteyukibot-v7-resources = { workspace = true }
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "liteyukibot_profile"

--- a/packages/profile/src/liteyukibot_profile/__init__.py
+++ b/packages/profile/src/liteyukibot_profile/__init__.py
@@ -1,0 +1,15 @@
+"""Persistent per-bot user profiles for LiteyukiBot v7."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+from .plugin import create_plugin
+from .service import PROFILE_SERVICE, ProfileService, ProfileSnapshot
+
+try:
+    __version__ = version("liteyukibot-v7-profile")
+except PackageNotFoundError:
+    __version__ = "0.1.0a1"
+
+plugin = create_plugin(__version__)
+
+__all__ = ["PROFILE_SERVICE", "ProfileService", "ProfileSnapshot", "__version__", "plugin"]

--- a/packages/profile/src/liteyukibot_profile/plugin.py
+++ b/packages/profile/src/liteyukibot_profile/plugin.py
@@ -1,0 +1,63 @@
+"""Native plugin entry point for persistent user profiles."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from liteyukibot_resources import RESOURCE_SERVICE, ResourceField, ResourceService, ResourceSpec
+
+from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
+from liteyukibot.services import ServiceRequirement
+
+from .service import PROFILE_SERVICE, SQLiteProfileService, language_value, nickname_value
+
+
+async def setup(context: PluginContext) -> PluginHandle:
+    if context.paths is None:
+        raise RuntimeError("profile plugin requires private storage")
+    resources = cast(ResourceService, context.services.require(RESOURCE_SERVICE))
+    service = SQLiteProfileService(context.paths.data / "profile.sqlite3")
+    registration = resources.register(
+        ResourceSpec(
+            "profile",
+            summary="Manage your user profile",
+            fields=(
+                ResourceField(
+                    "nickname",
+                    nickname_value,
+                    description="Display name; 1 to 32 characters",
+                ),
+                ResourceField(
+                    "language",
+                    language_value,
+                    description="Display language: zh-CN or en",
+                ),
+            ),
+        ),
+        service,
+        owner=context.id,
+    )
+    context.services.provide(PROFILE_SERVICE, service)
+
+    async def stop() -> None:
+        resources.unregister(registration)
+        await service.close()
+
+    return PluginHandle(stop=stop)
+
+
+def create_plugin(version: str) -> PluginDefinition:
+    return PluginDefinition(
+        manifest=PluginManifest(
+            id="liteyukibot.profile",
+            name="LiteyukiBot Profile",
+            version=version,
+            provides=(PROFILE_SERVICE,),
+            requires=(ServiceRequirement(RESOURCE_SERVICE),),
+            storage="private",
+        ),
+        setup=setup,
+    )
+
+
+__all__ = ["PROFILE_SERVICE", "create_plugin"]

--- a/packages/profile/src/liteyukibot_profile/service.py
+++ b/packages/profile/src/liteyukibot_profile/service.py
@@ -1,0 +1,165 @@
+"""SQLite-backed profile storage and resource provider."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Protocol
+
+from liteyukibot_permissions import Principal
+from liteyukibot_resources import ResourceField, ResourceProvider
+
+from liteyukibot.services import ServiceKey
+
+_SCHEMA_VERSION: Final = 1
+_DEFAULT_LANGUAGE: Final = "zh-CN"
+_VALID_LANGUAGES: Final = frozenset({"zh-CN", "en"})
+PROFILE_SERVICE = ServiceKey("liteyukibot.profile", 1)
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileSnapshot:
+    principal: Principal
+    nickname: str = ""
+    language: str = _DEFAULT_LANGUAGE
+
+
+class ProfileService(Protocol):
+    async def get(self, principal: Principal) -> ProfileSnapshot: ...
+
+
+def nickname_value(value: str) -> str:
+    normalized = value.strip()
+    if not normalized or len(normalized) > 32:
+        raise ValueError("nickname must contain 1 to 32 characters")
+    return normalized
+
+
+def language_value(value: str) -> str:
+    if value not in _VALID_LANGUAGES:
+        raise ValueError("language must be 'zh-CN' or 'en'")
+    return value
+
+
+class SQLiteProfileService(ProfileService, ResourceProvider):
+    def __init__(self, database: Path) -> None:
+        self._connection = sqlite3.connect(database)
+        self._lock = asyncio.Lock()
+        self._closed = False
+        self._initialize()
+
+    def _initialize(self) -> None:
+        with self._connection:
+            version = self._connection.execute("PRAGMA user_version").fetchone()
+            if version is None:
+                raise RuntimeError("profile database did not report a schema version")
+            current = int(version[0])
+            if current > _SCHEMA_VERSION:
+                raise RuntimeError(f"profile database schema {current} is newer than supported {_SCHEMA_VERSION}")
+            if current == 0:
+                self._connection.execute(
+                    """
+                    CREATE TABLE profiles (
+                        runtime_id TEXT NOT NULL,
+                        bot_id TEXT NOT NULL,
+                        actor_id TEXT NOT NULL,
+                        nickname TEXT NOT NULL DEFAULT '',
+                        language TEXT NOT NULL DEFAULT 'zh-CN',
+                        PRIMARY KEY (runtime_id, bot_id, actor_id)
+                    )
+                    """
+                )
+                self._connection.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
+
+    async def get(self, principal: Principal) -> ProfileSnapshot:
+        async with self._lock:
+            self._ensure_open()
+            row = self._connection.execute(
+                "SELECT nickname, language FROM profiles WHERE runtime_id = ? AND bot_id = ? AND actor_id = ?",
+                (principal.runtime_id, principal.bot_id, principal.actor_id),
+            ).fetchone()
+        if row is None:
+            return ProfileSnapshot(principal)
+        return ProfileSnapshot(principal, nickname=str(row[0]), language=str(row[1]))
+
+    async def inspect(self, principal: Principal, field: ResourceField) -> object:
+        profile = await self.get(principal)
+        return getattr(profile, field.name)
+
+    async def set(self, principal: Principal, field: ResourceField, value: object) -> None:
+        if field.name not in {"nickname", "language"}:
+            raise ValueError(f"unsupported profile field: {field.name}")
+        if not isinstance(value, str):
+            raise TypeError(f"profile field {field.name} must be a string")
+        async with self._lock:
+            self._ensure_open()
+            previous = self._row_locked(principal)
+            nickname = value if field.name == "nickname" else previous.nickname
+            language = value if field.name == "language" else previous.language
+            with self._connection:
+                self._connection.execute(
+                    """
+                    INSERT INTO profiles (runtime_id, bot_id, actor_id, nickname, language)
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(runtime_id, bot_id, actor_id) DO UPDATE SET
+                        nickname = excluded.nickname,
+                        language = excluded.language
+                    """,
+                    (principal.runtime_id, principal.bot_id, principal.actor_id, nickname, language),
+                )
+
+    async def delete(self, principal: Principal, field: ResourceField) -> None:
+        if field.name not in {"nickname", "language"}:
+            raise ValueError(f"unsupported profile field: {field.name}")
+        async with self._lock:
+            self._ensure_open()
+            previous = self._row_locked(principal)
+            nickname = "" if field.name == "nickname" else previous.nickname
+            language = _DEFAULT_LANGUAGE if field.name == "language" else previous.language
+            if nickname == "" and language == _DEFAULT_LANGUAGE:
+                with self._connection:
+                    self._connection.execute(
+                        "DELETE FROM profiles WHERE runtime_id = ? AND bot_id = ? AND actor_id = ?",
+                        (principal.runtime_id, principal.bot_id, principal.actor_id),
+                    )
+                return
+            with self._connection:
+                self._connection.execute(
+                    """
+                    INSERT INTO profiles (runtime_id, bot_id, actor_id, nickname, language)
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(runtime_id, bot_id, actor_id) DO UPDATE SET
+                        nickname = excluded.nickname,
+                        language = excluded.language
+                    """,
+                    (principal.runtime_id, principal.bot_id, principal.actor_id, nickname, language),
+                )
+
+    async def close(self) -> None:
+        async with self._lock:
+            if not self._closed:
+                self._connection.close()
+                self._closed = True
+
+    def _row_locked(self, principal: Principal) -> ProfileSnapshot:
+        row = self._connection.execute(
+            "SELECT nickname, language FROM profiles WHERE runtime_id = ? AND bot_id = ? AND actor_id = ?",
+            (principal.runtime_id, principal.bot_id, principal.actor_id),
+        ).fetchone()
+        return ProfileSnapshot(principal) if row is None else ProfileSnapshot(principal, str(row[0]), str(row[1]))
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise RuntimeError("profile service is closed")
+
+
+__all__ = [
+    "PROFILE_SERVICE",
+    "ProfileService",
+    "ProfileSnapshot",
+    "SQLiteProfileService",
+    "language_value",
+    "nickname_value",
+]

--- a/packages/profile/tests/test_profile.py
+++ b/packages/profile/tests/test_profile.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import cast
+
+import pytest
+from liteyukibot_permissions import Principal
+from liteyukibot_profile import PROFILE_SERVICE, ProfileService, ProfileSnapshot, plugin
+from liteyukibot_profile.service import SQLiteProfileService, language_value, nickname_value
+from liteyukibot_resources import RESOURCE_SERVICE, ResourceField, ResourceService
+
+from liteyukibot import LiteyukiApp
+from liteyukibot.config import AppSettings, CoreSettings, PluginSettings
+from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
+from liteyukibot.logging import get_logger
+
+
+def principal(*, runtime_id: str = "runtime", bot_id: str = "bot", actor_id: str = "user") -> Principal:
+    return Principal(runtime_id, bot_id, actor_id)
+
+
+def event(*, actor_id: str | None = "user", bot_id: str = "bot") -> EventEnvelope:
+    return EventEnvelope(
+        runtime_id="runtime",
+        adapter="test",
+        bot_id=bot_id,
+        type="message",
+        conversation=ConversationRef(id="conversation", type="group"),
+        actor=None if actor_id is None else ActorRef(id=actor_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_defaults_mutations_and_reopen_persistence(tmp_path: Path) -> None:
+    database = tmp_path / "profile.sqlite3"
+    service = SQLiteProfileService(database)
+    user = principal()
+    try:
+        assert await service.get(user) == ProfileSnapshot(user)
+        await service.set(user, _nickname_field(), "Alice")
+        await service.set(user, _language_field(), "en")
+        assert await service.get(user) == ProfileSnapshot(user, nickname="Alice", language="en")
+        await service.delete(user, _nickname_field())
+        assert await service.get(user) == ProfileSnapshot(user, language="en")
+    finally:
+        await service.close()
+
+    reopened = SQLiteProfileService(database)
+    try:
+        assert await reopened.get(user) == ProfileSnapshot(user, language="en")
+        await reopened.delete(user, _language_field())
+        assert await reopened.get(user) == ProfileSnapshot(user)
+    finally:
+        await reopened.close()
+
+
+def test_profile_field_converters_are_strict() -> None:
+    assert nickname_value(" Alice ") == "Alice"
+    assert nickname_value("x" * 32) == "x" * 32
+    assert language_value("zh-CN") == "zh-CN"
+    with pytest.raises(ValueError, match="1 to 32"):
+        nickname_value(" ")
+    with pytest.raises(ValueError, match="1 to 32"):
+        nickname_value("x" * 33)
+    with pytest.raises(ValueError, match="zh-CN"):
+        language_value("fr")
+
+
+@pytest.mark.asyncio
+async def test_profile_principals_are_isolated_and_serialized(tmp_path: Path) -> None:
+    service = SQLiteProfileService(tmp_path / "profile.sqlite3")
+    first = principal(actor_id="first")
+    second = principal(bot_id="other", actor_id="first")
+    try:
+        await service.set(first, _nickname_field(), "Alice")
+        await service.set(second, _nickname_field(), "Bob")
+        assert await service.get(first) == ProfileSnapshot(first, nickname="Alice")
+        assert await service.get(second) == ProfileSnapshot(second, nickname="Bob")
+        await asyncio.gather(
+            service.set(first, _language_field(), "en"),
+            service.set(first, _nickname_field(), "Carol"),
+        )
+        assert await service.get(first) == ProfileSnapshot(first, nickname="Carol", language="en")
+    finally:
+        await service.close()
+
+
+@pytest.mark.asyncio
+async def test_profile_plugin_uses_private_storage_and_registers_resource(tmp_path: Path) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
+        plugins=PluginSettings(
+            enabled=("liteyukibot.permissions", "liteyukibot.resources", "liteyukibot.profile"),
+        ),
+    )
+    app = LiteyukiApp(settings, logger=get_logger(component="profile-tests"))
+    await app.start()
+    try:
+        resources = cast(ResourceService, app.services.require(RESOURCE_SERVICE))
+        profile = cast(ProfileService, app.services.require(PROFILE_SERVICE))
+        user = principal()
+        assert await profile.get(user) == ProfileSnapshot(user)
+        await resources.set(event(), ("profile",), "nickname", "Alice")
+        assert await profile.get(user) == ProfileSnapshot(user, nickname="Alice")
+        assert (tmp_path / "data" / "plugins" / "liteyukibot.profile" / "profile.sqlite3").is_file()
+    finally:
+        await app.stop()
+
+    assert plugin.manifest.storage == "private"
+
+
+def _nickname_field() -> ResourceField:
+    return ResourceField("nickname", nickname_value)
+
+
+def _language_field() -> ResourceField:
+    return ResourceField("language", language_value)

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ members = [
     "liteyukibot-v7-commands",
     "liteyukibot-v7-essentials",
     "liteyukibot-v7-permissions",
+    "liteyukibot-v7-profile",
     "liteyukibot-v7-resources",
 ]
 
@@ -345,6 +346,21 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
+
+[[package]]
+name = "liteyukibot-v7-profile"
+version = "0.1.0a1"
+source = { editable = "packages/profile" }
+dependencies = [
+    { name = "liteyukibot-v7" },
+    { name = "liteyukibot-v7-resources" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "liteyukibot-v7", editable = "." },
+    { name = "liteyukibot-v7-resources", editable = "packages/resources" },
+]
 
 [[package]]
 name = "liteyukibot-v7-resources"


### PR DESCRIPTION
## Summary\n- add the optional liteyukibot-v7-profile workspace distribution and liteyukibot.profile@1\n- store immutable per (runtime_id, bot_id, actor_id) nickname and language snapshots in the plugin private SQLite database\n- use one plugin-lifetime SQLite connection guarded by syncio.Lock; create schema v1 idempotently and preserve data across reopen\n- register the profile resource provider while leaving generated commands, Essentials integration, publishing, kernel schemas, and runtime IPC to follow-up PRs\n\n## Validation\n- uv run ruff check src tests scripts examples packages\n- uv run mypy\n- uv run pytest -q (230 passed, 20 skipped)\n- uv build --all-packages --out-dir dist/workspace --clear