### PR TITLE
✨ Add resource command integration

### DIFF
--- a/docs/adr/0020-resource-management-contract.md
+++ b/docs/adr/0020-resource-management-contract.md
@@ -8,8 +8,10 @@ Accepted for the alpha resource/profile chapter.
 
 The optional `liteyukibot.resources@1` plugin provides a registry for
 declarative resource fields. It owns path resolution, field capability checks,
-and the inspect/set/delete operation boundary. A resource provider owns its
-data, storage, transactions, and migrations.
+and the inspect/set/delete operation boundary. It registers canonical resource
+commands through `liteyukibot.commands@1`: `<path>`, `<path> set <field>
+<value>`, and `<path> delete <field>`. A resource provider owns its data,
+storage, transactions, and migrations.
 
 Resources target an exact `(runtime_id, bot_id, actor_id)` principal. A command
 without `--actor` targets the event actor. A different actor is rejected unless

--- a/packages/profile/tests/test_profile.py
+++ b/packages/profile/tests/test_profile.py
@@ -12,7 +12,16 @@ from liteyukibot_resources import RESOURCE_SERVICE, ResourceField, ResourceServi
 
 from liteyukibot import LiteyukiApp
 from liteyukibot.config import AppSettings, CoreSettings, PluginSettings
-from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
+from liteyukibot.events import (
+    ActionEnvelope,
+    ActionResult,
+    ActorRef,
+    ConversationRef,
+    EventEnvelope,
+    Message,
+    Segment,
+    SendMessage,
+)
 from liteyukibot.logging import get_logger
 
 
@@ -91,7 +100,12 @@ async def test_profile_plugin_uses_private_storage_and_registers_resource(tmp_pa
     settings = AppSettings(
         core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
         plugins=PluginSettings(
-            enabled=("liteyukibot.permissions", "liteyukibot.resources", "liteyukibot.profile"),
+            enabled=(
+                "liteyukibot.permissions",
+                "liteyukibot.commands",
+                "liteyukibot.resources",
+                "liteyukibot.profile",
+            ),
         ),
     )
     app = LiteyukiApp(settings, logger=get_logger(component="profile-tests"))
@@ -110,9 +124,63 @@ async def test_profile_plugin_uses_private_storage_and_registers_resource(tmp_pa
     assert plugin.manifest.storage == "private"
 
 
+@pytest.mark.asyncio
+async def test_profile_resource_commands_mutate_data_and_describe_limits(tmp_path: Path) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
+        plugins=PluginSettings(
+            enabled=(
+                "liteyukibot.permissions",
+                "liteyukibot.commands",
+                "liteyukibot.resources",
+                "liteyukibot.profile",
+                "liteyukibot.essentials",
+            ),
+        ),
+    )
+    actions: list[ActionEnvelope] = []
+
+    async def record(action: ActionEnvelope) -> ActionResult:
+        actions.append(action)
+        return ActionResult(action_id=action.action_id, success=True)
+
+    app = LiteyukiApp(settings, logger=get_logger(component="profile-command-tests"))
+    app.events._action_executor = record
+    await app.start()
+    try:
+        for text in ("/profile", "/profile set nickname Alice", "/profile", "/profile delete nickname"):
+            await app.events.publish(_message_event(text))
+        rendered = [cast(SendMessage, action.action).message.plain_text for action in actions]
+        assert rendered == [
+            "nickname: \nlanguage: zh-CN",
+            "Updated profile.nickname",
+            "nickname: Alice\nlanguage: zh-CN",
+            "Reset profile.nickname",
+        ]
+
+        await app.events.publish(_message_event("/help profile set"))
+        help_text = cast(SendMessage, actions[-1].action).message.plain_text
+        assert "nickname: Display name; 1 to 32 characters" in help_text
+    finally:
+        await app.stop()
+
+
 def _nickname_field() -> ResourceField:
     return ResourceField("nickname", nickname_value)
 
 
 def _language_field() -> ResourceField:
     return ResourceField("language", language_value)
+
+
+def _message_event(text: str) -> EventEnvelope:
+    return EventEnvelope(
+        runtime_id="runtime",
+        adapter="test",
+        bot_id="bot",
+        type="message",
+        conversation=ConversationRef(id="conversation", type="group"),
+        actor=ActorRef(id="user"),
+        message=Message(segments=(Segment(type="text", data={"text": text}),)),
+        reply_token="reply",
+    )

--- a/packages/resources/pyproject.toml
+++ b/packages/resources/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 dependencies = [
     "liteyukibot-v7>=7.0.0a3,<8",
+    "liteyukibot-v7-commands>=0.2.0a1,<0.3",
     "liteyukibot-v7-permissions>=0.2.0a1,<0.3",
 ]
 
@@ -23,6 +24,7 @@ build-backend = "uv_build"
 
 [tool.uv.sources]
 liteyukibot-v7 = { workspace = true }
+liteyukibot-v7-commands = { workspace = true }
 liteyukibot-v7-permissions = { workspace = true }
 
 [tool.uv.build-backend]

--- a/packages/resources/src/liteyukibot_resources/plugin.py
+++ b/packages/resources/src/liteyukibot_resources/plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import cast
 
+from liteyukibot_commands import COMMAND_SERVICE, CommandService
 from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService
 
 from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
@@ -14,7 +15,8 @@ from .service import RESOURCE_SERVICE, create_resource_service
 
 async def setup(context: PluginContext) -> PluginHandle:
     permissions = cast(PermissionService, context.services.require(PERMISSION_SERVICE))
-    context.services.provide(RESOURCE_SERVICE, create_resource_service(permissions))
+    commands = cast(CommandService, context.services.require(COMMAND_SERVICE))
+    context.services.provide(RESOURCE_SERVICE, create_resource_service(permissions, commands))
     return PluginHandle()
 
 
@@ -25,7 +27,10 @@ def create_plugin(version: str) -> PluginDefinition:
             name="LiteyukiBot Resources",
             version=version,
             provides=(RESOURCE_SERVICE,),
-            requires=(ServiceRequirement(PERMISSION_SERVICE),),
+            requires=(
+                ServiceRequirement(PERMISSION_SERVICE),
+                ServiceRequirement(COMMAND_SERVICE),
+            ),
         ),
         setup=setup,
     )

--- a/packages/resources/src/liteyukibot_resources/service.py
+++ b/packages/resources/src/liteyukibot_resources/service.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 import inspect
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, cast
 
+from liteyukibot_commands import (
+    ArgumentSpec,
+    CommandBinding,
+    CommandInvocation,
+    CommandParseError,
+    CommandRegistration,
+    CommandSchema,
+    CommandService,
+    CommandSpec,
+    OptionSpec,
+)
 from liteyukibot_permissions import PermissionService, Principal
 
-from liteyukibot.events import EventEnvelope
+from liteyukibot.events import EventEnvelope, HandlerResult
 from liteyukibot.services import ServiceKey
 
 from .models import ResourceField, ResourceOperation, ResourceProvider, ResourceRegistration, ResourceSpec
@@ -75,11 +86,13 @@ class ResourceService(Protocol):
 class _RegisteredResource:
     registration: ResourceRegistration
     provider: ResourceProvider
+    commands: tuple[CommandRegistration, ...]
 
 
 class _ResourceService:
-    def __init__(self, permissions: PermissionService) -> None:
+    def __init__(self, permissions: PermissionService, commands: CommandService) -> None:
         self._permissions = permissions
+        self._commands = commands
         self._resources: dict[int, _RegisteredResource] = {}
         self._paths: dict[tuple[str, ...], int] = {}
         self._next_id = 0
@@ -115,11 +128,19 @@ class _ResourceService:
                 raise ValueError(f"resource path is already registered: {' '.join(path)}")
             claimed.add(path)
             prepared.append((spec, provider, path))
+        command_bindings: list[CommandBinding] = []
+        for spec, _provider, _path in prepared:
+            command_bindings.extend(self._command_bindings(spec))
+        commands = self._commands.register_many(command_bindings, owner=owner)
+
         registrations: list[ResourceRegistration] = []
+        command_offset = 0
         for spec, provider, path in prepared:
             registration = ResourceRegistration(self._next_id, owner, spec)
             self._next_id += 1
-            self._resources[registration.id] = _RegisteredResource(registration, provider)
+            resource_commands = commands[command_offset : command_offset + 3]
+            command_offset += 3
+            self._resources[registration.id] = _RegisteredResource(registration, provider, resource_commands)
             self._paths[path] = registration.id
             registrations.append(registration)
         return tuple(registrations)
@@ -130,6 +151,8 @@ class _ResourceService:
             return False
         del self._resources[registration.id]
         self._paths.pop(tuple(segment.casefold() for segment in registration.spec.resource_path), None)
+        for command in reversed(registered.commands):
+            self._commands.unregister(command)
         return True
 
     def snapshot(self) -> tuple[ResourceRegistration, ...]:
@@ -235,6 +258,103 @@ class _ResourceService:
                 return field
         raise ResourceError(f"resource field not found: {name}")
 
+    def _command_bindings(self, spec: ResourceSpec) -> tuple[CommandBinding, ...]:
+        fields = "; ".join(f"{field.name}: {field.description}" for field in spec.fields if field.description)
+        set_summary = f"Set a {spec.name} field"
+        if fields:
+            set_summary += f". Fields: {fields}"
+
+        async def inspect_command(invocation: CommandInvocation) -> HandlerResult:
+            try:
+                parsed = invocation.parse()
+                actor_id = parsed.options["actor"]
+                if actor_id is not None and not isinstance(actor_id, str):
+                    raise RuntimeError("resource actor option must be a string")
+                values = await self.inspect(invocation.event, spec.resource_path, actor_id=actor_id)
+            except CommandParseError:
+                return invocation.reply("Invalid resource command arguments")
+            except ResourceError as error:
+                return invocation.reply(_error_text(error))
+            if not values:
+                return invocation.reply("No readable resource fields")
+            return invocation.reply("\n".join(f"{name}: {value}" for name, value in values.items()))
+
+        async def set_command(invocation: CommandInvocation) -> HandlerResult:
+            try:
+                parsed = invocation.parse()
+                field = parsed.arguments["field"]
+                value = parsed.arguments["value"]
+                actor_id = parsed.options["actor"]
+                if not all(isinstance(item, str) for item in (field, value)):
+                    raise RuntimeError("resource command arguments must be strings")
+                if actor_id is not None and not isinstance(actor_id, str):
+                    raise RuntimeError("resource actor option must be a string")
+                await self.set(
+                    invocation.event,
+                    spec.resource_path,
+                    cast(str, field),
+                    cast(str, value),
+                    actor_id=actor_id,
+                )
+            except CommandParseError:
+                return invocation.reply("Invalid resource command arguments")
+            except ResourceError as error:
+                return invocation.reply(_error_text(error))
+            return invocation.reply(f"Updated {' '.join(spec.resource_path)}.{field}")
+
+        async def delete_command(invocation: CommandInvocation) -> HandlerResult:
+            try:
+                parsed = invocation.parse()
+                field = parsed.arguments["field"]
+                actor_id = parsed.options["actor"]
+                if not isinstance(field, str):
+                    raise RuntimeError("resource command field must be a string")
+                if actor_id is not None and not isinstance(actor_id, str):
+                    raise RuntimeError("resource actor option must be a string")
+                await self.delete(invocation.event, spec.resource_path, field, actor_id=actor_id)
+            except CommandParseError:
+                return invocation.reply("Invalid resource command arguments")
+            except ResourceError as error:
+                return invocation.reply(_error_text(error))
+            return invocation.reply(f"Reset {' '.join(spec.resource_path)}.{field}")
+
+        actor_option = OptionSpec("actor", aliases=("a",), required=False, default=None)
+        return (
+            (
+                CommandSpec(
+                    spec.name,
+                    path=spec.path,
+                    summary=spec.summary,
+                    schema=CommandSchema(options=(actor_option,)),
+                ),
+                inspect_command,
+            ),
+            (
+                CommandSpec(
+                    "set",
+                    path=spec.resource_path,
+                    summary=set_summary,
+                    schema=CommandSchema(
+                        arguments=(ArgumentSpec("field"), ArgumentSpec("value")),
+                        options=(actor_option,),
+                    ),
+                ),
+                set_command,
+            ),
+            (
+                CommandSpec(
+                    "delete",
+                    path=spec.resource_path,
+                    summary=f"Reset a {spec.name} field to its default",
+                    schema=CommandSchema(
+                        arguments=(ArgumentSpec("field"),),
+                        options=(actor_option,),
+                    ),
+                ),
+                delete_command,
+            ),
+        )
+
 
 async def _await_provider(value: object) -> object:
     if not inspect.isawaitable(value):
@@ -242,8 +362,12 @@ async def _await_provider(value: object) -> object:
     return await value
 
 
-def create_resource_service(permissions: PermissionService) -> ResourceService:
-    return _ResourceService(permissions)
+def _error_text(error: ResourceError) -> str:
+    return f"Resource request failed: {error}"
+
+
+def create_resource_service(permissions: PermissionService, commands: CommandService) -> ResourceService:
+    return _ResourceService(permissions, commands)
 
 
 __all__ = ["RESOURCE_SERVICE", "ResourceError", "ResourceService", "create_resource_service"]

--- a/packages/resources/tests/test_resources.py
+++ b/packages/resources/tests/test_resources.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import cast
 
 import pytest
+from liteyukibot_commands import COMMAND_SERVICE, CommandService
+from liteyukibot_commands.service import create_command_service
 from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, PermissionSnapshot, Principal
 from liteyukibot_resources import (
     RESOURCE_SERVICE,
@@ -16,6 +18,7 @@ from liteyukibot_resources import (
 from liteyukibot_resources.service import create_resource_service
 
 from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
+from liteyukibot.logging import get_logger
 from liteyukibot.testing import PluginTestHarness
 
 
@@ -83,12 +86,16 @@ def specification() -> ResourceSpec:
     )
 
 
+def command_service() -> CommandService:
+    return create_command_service({}, PermissionStub(), get_logger(component="resources-tests"))
+
+
 @pytest.mark.asyncio
 async def test_resource_plugin_provides_service_and_removes_it_on_stop(tmp_path: Path) -> None:
     harness = PluginTestHarness(
         plugin,
         root=tmp_path,
-        dependencies={PERMISSION_SERVICE: PermissionStub()},
+        dependencies={PERMISSION_SERVICE: PermissionStub(), COMMAND_SERVICE: command_service()},
     )
     async with harness:
         assert harness.require_service(RESOURCE_SERVICE) is not None
@@ -96,7 +103,7 @@ async def test_resource_plugin_provides_service_and_removes_it_on_stop(tmp_path:
 
 @pytest.mark.asyncio
 async def test_resource_service_reads_writes_and_deletes_current_principal() -> None:
-    service = create_resource_service(PermissionStub())
+    service = create_resource_service(PermissionStub(), command_service())
     provider = Provider()
     service.register(specification(), provider, owner="test")
 
@@ -110,7 +117,7 @@ async def test_resource_service_reads_writes_and_deletes_current_principal() -> 
 
 @pytest.mark.asyncio
 async def test_resource_service_requires_capability_for_other_actor() -> None:
-    service = create_resource_service(PermissionStub())
+    service = create_resource_service(PermissionStub(), command_service())
     provider = Provider()
     service.register(specification(), provider, owner="test")
 
@@ -121,7 +128,7 @@ async def test_resource_service_requires_capability_for_other_actor() -> None:
 
 @pytest.mark.asyncio
 async def test_resource_service_fails_closed_for_other_actor() -> None:
-    service = create_resource_service(DenyingPermissionStub())
+    service = create_resource_service(DenyingPermissionStub(), command_service())
     service.register(specification(), Provider(), owner="test")
 
     with pytest.raises(ResourceError, match="not authorized"):
@@ -129,7 +136,7 @@ async def test_resource_service_fails_closed_for_other_actor() -> None:
 
 
 def test_resource_registration_is_atomic_and_path_stable() -> None:
-    service = create_resource_service(PermissionStub())
+    service = create_resource_service(PermissionStub(), command_service())
     provider = Provider()
     profile = specification()
     duplicate = ResourceSpec("PROFILE", fields=(ResourceField("language", str),))
@@ -146,7 +153,7 @@ def test_resource_registration_is_atomic_and_path_stable() -> None:
 
 @pytest.mark.asyncio
 async def test_resource_service_rejects_anonymous_and_invalid_operations() -> None:
-    service = create_resource_service(PermissionStub())
+    service = create_resource_service(PermissionStub(), command_service())
     service.register(specification(), Provider(), owner="test")
 
     with pytest.raises(ResourceError, match="resource not found"):

--- a/scripts/verify_resources_install.py
+++ b/scripts/verify_resources_install.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import cast
 
 import liteyukibot_resources
+from liteyukibot_commands import COMMAND_SERVICE, CommandService
+from liteyukibot_commands.service import create_command_service
 from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService
 from liteyukibot_resources import RESOURCE_SERVICE, ResourceField, ResourceProvider, ResourceSpec
 from liteyukibot_resources.service import ResourceService
@@ -18,6 +20,7 @@ from liteyukibot_resources.service import ResourceService
 import liteyukibot
 from liteyukibot import PluginDefinition
 from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
+from liteyukibot.logging import get_logger
 from liteyukibot.testing import PluginTestHarness
 
 SOURCE_ROOT = Path(__file__).resolve().parents[1]
@@ -72,7 +75,17 @@ async def verify(expected_version: str | None = None) -> None:
         async with PluginTestHarness(
             definition,
             root=Path(directory),
-            dependencies={PERMISSION_SERVICE: cast(PermissionService, _PermissionStub())},
+            dependencies={
+                PERMISSION_SERVICE: cast(PermissionService, _PermissionStub()),
+                COMMAND_SERVICE: cast(
+                    CommandService,
+                    create_command_service(
+                        {},
+                        cast(PermissionService, _PermissionStub()),
+                        get_logger(component="verify"),
+                    ),
+                ),
+            },
         ) as harness:
             service = cast(ResourceService, harness.require_service(RESOURCE_SERVICE))
             service.register(

--- a/uv.lock
+++ b/uv.lock
@@ -368,12 +368,14 @@ version = "0.1.0a1"
 source = { editable = "packages/resources" }
 dependencies = [
     { name = "liteyukibot-v7" },
+    { name = "liteyukibot-v7-commands" },
     { name = "liteyukibot-v7-permissions" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "liteyukibot-v7", editable = "." },
+    { name = "liteyukibot-v7-commands", editable = "packages/commands" },
     { name = "liteyukibot-v7-permissions", editable = "packages/permissions" },
 ]
 


### PR DESCRIPTION
## Summary\n- integrate resources with liteyukibot.commands@1 without changing the command package API\n- generate canonical <resource>, <resource> set <field> <value>, and <resource> delete <field> commands on atomic resource registration\n- route optional --actor through the existing exact-principal, per-operation capability checks\n- surface resource field descriptions in command help, including profile nickname's 1-32 character constraint\n\n## Validation\n- uv run ruff check src tests scripts examples packages\n- uv run mypy\n- uv run pytest -q (231 passed, 20 skipped)\n- uv build --all-packages --out-dir dist/workspace --clear\n- uv run python scripts/run_resources_install.py