### PR TITLE
✨ Add optional profile language

### DIFF
--- a/packages/essentials/src/liteyukibot_essentials/plugin.py
+++ b/packages/essentials/src/liteyukibot_essentials/plugin.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 from liteyukibot_commands import (
     COMMAND_SERVICE,
@@ -15,16 +15,26 @@ from liteyukibot_commands import (
     CommandService,
     CommandSpec,
 )
+from liteyukibot_permissions import Principal
 
 from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
 from liteyukibot.events import HandlerResult
-from liteyukibot.services import ServiceRequirement
+from liteyukibot.services import ServiceKey, ServiceRequirement
 from liteyukibot.status import KERNEL_STATUS_SERVICE, KernelStatusProvider
 
 from .render import Language, messages, render_help, render_parse_error, render_status
 
 _PUBLIC_PERMISSION = "public"
 _STATUS_READ_CAPABILITY = "liteyukibot.status.read"
+_PROFILE_SERVICE = ServiceKey("liteyukibot.profile", 1)
+
+
+class _ProfileSnapshot(Protocol):
+    language: str
+
+
+class _ProfileService(Protocol):
+    async def get(self, principal: Principal) -> _ProfileSnapshot: ...
 
 
 def _language(config: Mapping[str, Any]) -> Language:
@@ -41,13 +51,30 @@ async def setup(context: PluginContext) -> PluginHandle:
     language = _language(context.config)
     command_service = cast(CommandService, context.services.require(COMMAND_SERVICE))
     status_provider = cast(KernelStatusProvider, context.services.require(KERNEL_STATUS_SERVICE))
+    profile_service = cast(_ProfileService | None, context.services.get_optional(_PROFILE_SERVICE))
     text = messages(language)
 
-    def help_command(invocation: CommandInvocation) -> HandlerResult:
+    async def event_language(invocation: CommandInvocation) -> Language:
+        if profile_service is None or invocation.event.actor is None:
+            return language
+        try:
+            profile = await profile_service.get(
+                Principal(invocation.event.runtime_id, invocation.event.bot_id, invocation.event.actor.id)
+            )
+        except Exception:
+            context.logger.warning(
+                "profile language lookup failed; using essentials default",
+                event_id=invocation.event.id,
+            )
+            return language
+        return cast(Language, profile.language) if profile.language in {"zh-CN", "en"} else language
+
+    async def help_command(invocation: CommandInvocation) -> HandlerResult:
+        current_language = await event_language(invocation)
         try:
             parsed = invocation.parse()
         except CommandParseError as error:
-            return invocation.reply(render_parse_error(error, language=language))
+            return invocation.reply(render_parse_error(error, language=current_language))
         target = cast(tuple[str, ...], parsed.arguments["path"])
         visible = command_service.visible(invocation.event)
         if target:
@@ -61,13 +88,13 @@ async def setup(context: PluginContext) -> PluginHandle:
             render_help(
                 visible,
                 prefix=invocation.prefix,
-                language=language,
+                language=current_language,
                 target=target or None,
             )
         )
 
-    def status_command(invocation: CommandInvocation) -> HandlerResult:
-        return invocation.reply(render_status(status_provider.snapshot(), language=language))
+    async def status_command(invocation: CommandInvocation) -> HandlerResult:
+        return invocation.reply(render_status(status_provider.snapshot(), language=await event_language(invocation)))
 
     bindings: tuple[CommandBinding, ...] = (
         (
@@ -110,6 +137,7 @@ def create_plugin(version: str) -> PluginDefinition:
             requires=(
                 ServiceRequirement(COMMAND_SERVICE),
                 ServiceRequirement(KERNEL_STATUS_SERVICE),
+                ServiceRequirement(_PROFILE_SERVICE, optional=True),
             ),
         ),
         setup=setup,

--- a/packages/essentials/tests/test_essentials.py
+++ b/packages/essentials/tests/test_essentials.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from liteyukibot_commands import (
@@ -31,10 +31,12 @@ from liteyukibot.events import (
 )
 from liteyukibot.exceptions import PluginError
 from liteyukibot.logging import get_logger
+from liteyukibot.services import ServiceKey
 from liteyukibot.status import KernelStatusSnapshot
 from liteyukibot.testing import PluginTestHarness
 
 STATUS_READ = "liteyukibot.status.read"
+PROFILE_SERVICE = ServiceKey("liteyukibot.profile", 1)
 
 
 class PermissionStub:
@@ -64,6 +66,17 @@ class StatusStub:
             runtimes={"runtime-b": "ready", "runtime-a": "failed"},
             events_outstanding=3,
         )
+
+
+class ProfileStub:
+    def __init__(self, language: str = "en", *, fail: bool = False) -> None:
+        self.language = language
+        self.fail = fail
+
+    async def get(self, _principal: Principal) -> object:
+        if self.fail:
+            raise RuntimeError("profile unavailable")
+        return self
 
 
 def message_event(text: str, *, actor_id: str = "user") -> EventEnvelope:
@@ -133,6 +146,50 @@ async def test_essentials_rejects_unknown_configuration(tmp_path: Path) -> None:
     assert "unknown essentials config keys" in str(raised.value.__cause__)
 
 
+@pytest.mark.asyncio
+async def test_essentials_uses_optional_profile_language_and_falls_back(tmp_path: Path) -> None:
+    commands = command_service()
+    harness = PluginTestHarness(
+        plugin,
+        root=tmp_path,
+        dependencies={
+            COMMAND_SERVICE: commands,
+            KERNEL_STATUS_SERVICE: StatusStub(),
+            PROFILE_SERVICE: ProfileStub("en"),
+        },
+    )
+    async with harness:
+        subscription = harness._events.subscribe(cast(Any, commands).dispatch, order=-100, name="commands-test")
+        result = await harness.publish(message_event("/help"))
+        assert result.stopped is True
+        assert harness.recorded_actions[-1].action.type == "send_message"
+        action = harness.recorded_actions[-1].action
+        assert isinstance(action, SendMessage)
+        assert action.message.plain_text.startswith("Available commands:")
+        harness._events.unsubscribe(subscription)
+
+    failing = PluginTestHarness(
+        plugin,
+        root=tmp_path / "fallback",
+        dependencies={
+            COMMAND_SERVICE: command_service(),
+            KERNEL_STATUS_SERVICE: StatusStub(),
+            PROFILE_SERVICE: ProfileStub(fail=True),
+        },
+    )
+    async with failing:
+        subscription = failing._events.subscribe(
+            cast(Any, failing.require_service(COMMAND_SERVICE)).dispatch,
+            order=-100,
+            name="commands-test",
+        )
+        await failing.publish(message_event("/help"))
+        fallback_action = failing.recorded_actions[-1].action
+        assert isinstance(fallback_action, SendMessage)
+        assert fallback_action.message.plain_text.startswith("可用命令：")
+        failing._events.unsubscribe(subscription)
+
+
 def test_english_status_is_stable_and_sorted() -> None:
     rendered = render_status(StatusStub().snapshot(), language="en")
 
@@ -172,7 +229,7 @@ async def test_three_plugin_topology_filters_help_and_correlates_status(tmp_path
                             "actor_id": "operator",
                             "roles": ["operator"],
                         }
-                    ]
+                    ],
                 },
                 "liteyukibot.commands": {"prefixes": ["/", "//"]},
             },
@@ -316,12 +373,13 @@ async def test_help_resolves_visible_hierarchical_aliases_and_renders_schema(tmp
         await app.stop()
 
 
-def test_essentials_manifest_declares_only_required_services() -> None:
+def test_essentials_manifest_declares_optional_profile_service() -> None:
     assert plugin.manifest.id == "liteyukibot.essentials"
     assert plugin.manifest.version == "0.2.0a1"
     assert plugin.manifest.provides == ()
     assert tuple(item.key for item in plugin.manifest.requires) == (
         COMMAND_SERVICE,
         KERNEL_STATUS_SERVICE,
+        PROFILE_SERVICE,
     )
     assert PERMISSION_SERVICE not in tuple(item.key for item in plugin.manifest.requires)


### PR DESCRIPTION
## Summary\n- declare liteyukibot.profile@1 as an optional Essentials service\n- resolve language per event principal for help/status rendering\n- fall back to configured Essentials language for missing, anonymous, invalid, or failing profile lookups\n- keep profile out of Essentials hard dependencies and preserve existing permissions and command behavior\n\n## Validation\n- uv run ruff check src tests scripts examples packages\n- uv run mypy\n- uv run pytest -q (232 passed, 20 skipped)\n- uv build --all-packages --out-dir dist/workspace --clear