### PR TITLE
🔖 Extend plugin release metadata

### DIFF
--- a/.github/workflows/publish-plugins.yaml
+++ b/.github/workflows/publish-plugins.yaml
@@ -5,6 +5,8 @@ on:
     tags:
       - "permissions-v*"
       - "commands-v*"
+      - "resources-v*"
+      - "profile-v*"
       - "essentials-v*"
   workflow_dispatch:
     inputs:
@@ -15,6 +17,8 @@ on:
         options:
           - permissions
           - commands
+          - resources
+          - profile
           - essentials
       version:
         description: Exact plugin version to publish
@@ -31,7 +35,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('{0}-v{1}', inputs.package, inputs.version) || github.ref_name }}
     environment:
-      name: ${{ github.event_name == 'workflow_dispatch' && format('pypi-{0}', inputs.package) || startsWith(github.ref_name, 'permissions-v') && 'pypi-permissions' || startsWith(github.ref_name, 'commands-v') && 'pypi-commands' || 'pypi-essentials' }}
+      name: ${{ github.event_name == 'workflow_dispatch' && format('pypi-{0}', inputs.package) || startsWith(github.ref_name, 'permissions-v') && 'pypi-permissions' || startsWith(github.ref_name, 'commands-v') && 'pypi-commands' || startsWith(github.ref_name, 'resources-v') && 'pypi-resources' || startsWith(github.ref_name, 'profile-v') && 'pypi-profile' || 'pypi-essentials' }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.3.2

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -18,6 +18,8 @@ Before the first plugin upload, create these Pending Publishers:
 | --- | --- |
 | `liteyukibot-v7-permissions` | `pypi-permissions` |
 | `liteyukibot-v7-commands` | `pypi-commands` |
+| `liteyukibot-v7-resources` | `pypi-resources` |
+| `liteyukibot-v7-profile` | `pypi-profile` |
 | `liteyukibot-v7-essentials` | `pypi-essentials` |
 
 PyPI requires different pending project names to use distinct publisher
@@ -36,6 +38,8 @@ distribution inside the workflow.
 | `liteyukibot-v7==7.0.0a3` | `pyproject.toml` | `v7.0.0a3` |
 | `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
 | `liteyukibot-v7-commands==0.2.0a1` | `packages/commands` | `commands-v0.2.0a1` |
+| `liteyukibot-v7-resources==0.1.0a1` | `packages/resources` | `resources-v0.1.0a1` |
+| `liteyukibot-v7-profile==0.1.0a1` | `packages/profile` | `profile-v0.1.0a1` |
 | `liteyukibot-v7-essentials==0.2.0a1` | `packages/essentials` | `essentials-v0.2.0a1` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
@@ -48,7 +52,9 @@ Push and wait for each release before creating the next tag:
 1. `v7.0.0a3`;
 2. `permissions-v0.2.0a1`;
 3. `commands-v0.2.0a1`;
-4. `essentials-v0.2.0a1`.
+4. `resources-v0.1.0a1`;
+5. `profile-v0.1.0a1`;
+6. `essentials-v0.2.0a1`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -57,6 +57,22 @@ RELEASE_PROJECTS: dict[str, ReleaseProject] = {
         tag_selector="commands-v",
         verifier="scripts/verify_commands_install.py",
     ),
+    "resources": ReleaseProject(
+        name="resources",
+        project_dir="packages/resources",
+        distribution="liteyukibot-v7-resources",
+        tag_prefix="resources-v",
+        tag_selector="resources-v",
+        verifier="scripts/verify_resources_install.py",
+    ),
+    "profile": ReleaseProject(
+        name="profile",
+        project_dir="packages/profile",
+        distribution="liteyukibot-v7-profile",
+        tag_prefix="profile-v",
+        tag_selector="profile-v",
+        verifier="scripts/verify_profile_install.py",
+    ),
     "essentials": ReleaseProject(
         name="essentials",
         project_dir="packages/essentials",

--- a/scripts/run_profile_install.py
+++ b/scripts/run_profile_install.py
@@ -1,0 +1,45 @@
+"""Run the profile verifier against wheels built from this workspace."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _one_wheel(distribution: str) -> Path:
+    directory = ROOT / "dist" / "workspace"
+    matches = tuple(directory.glob(f"{distribution}-*-py3-none-any.whl"))
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one {distribution} wheel in {directory}, found {len(matches)}")
+    return matches[0].resolve()
+
+
+def main() -> int:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv executable was not found")
+    wheels = tuple(
+        _one_wheel(name)
+        for name in (
+            "liteyukibot_v7",
+            "liteyukibot_v7_permissions",
+            "liteyukibot_v7_commands",
+            "liteyukibot_v7_resources",
+            "liteyukibot_v7_profile",
+        )
+    )
+    command = [uv, "run", "--no-project", "--python", "3.14"]
+    for wheel in wheels:
+        command.extend(("--with", str(wheel)))
+    command.extend(("python", str(ROOT / "scripts" / "verify_profile_install.py")))
+    with tempfile.TemporaryDirectory() as directory:
+        subprocess.run(command, cwd=directory, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_profile_install.py
+++ b/scripts/verify_profile_install.py
@@ -1,0 +1,111 @@
+"""Verify the installed profile wheel without importing workspace sources."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.metadata
+import json
+import tempfile
+from pathlib import Path
+from typing import cast
+
+import liteyukibot_profile
+import liteyukibot_resources
+from liteyukibot_commands import COMMAND_SERVICE, CommandService
+from liteyukibot_commands.service import create_command_service
+from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService, Principal
+from liteyukibot_profile import PROFILE_SERVICE, ProfileService, ProfileSnapshot
+from liteyukibot_resources import RESOURCE_SERVICE, ResourceService
+from liteyukibot_resources.service import create_resource_service
+
+import liteyukibot
+from liteyukibot import PluginDefinition
+from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
+from liteyukibot.logging import get_logger
+from liteyukibot.testing import PluginTestHarness
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _verify_import_sources() -> None:
+    imported = (
+        Path(liteyukibot.__file__).resolve(),
+        Path(liteyukibot_profile.__file__).resolve(),
+        Path(liteyukibot_resources.__file__).resolve(),
+    )
+    if any(path.is_relative_to(SOURCE_ROOT) for path in imported):
+        raise RuntimeError(f"workspace source import detected: {imported}")
+
+
+def _installed_plugin() -> PluginDefinition:
+    matches = tuple(
+        item
+        for item in importlib.metadata.entry_points(group="liteyukibot.plugins")
+        if item.name == "liteyukibot.profile"
+    )
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one profile entry point, found {len(matches)}")
+    candidate = matches[0].load()
+    if not isinstance(candidate, PluginDefinition):
+        raise TypeError("profile entry point did not resolve to PluginDefinition")
+    return candidate
+
+
+class _PermissionStub:
+    def allows(self, _event: EventEnvelope, _capability: str) -> bool:
+        return False
+
+
+def _event() -> EventEnvelope:
+    return EventEnvelope(
+        runtime_id="runtime",
+        adapter="test",
+        bot_id="bot",
+        type="message",
+        conversation=ConversationRef(id="conversation"),
+        actor=ActorRef(id="user"),
+    )
+
+
+async def verify(expected_version: str | None = None) -> None:
+    _verify_import_sources()
+    definition = _installed_plugin()
+    permissions = cast(PermissionService, _PermissionStub())
+    commands = cast(CommandService, create_command_service({}, permissions, get_logger(component="verify")))
+    resources = create_resource_service(permissions, commands)
+    with tempfile.TemporaryDirectory() as directory:
+        async with PluginTestHarness(
+            definition,
+            root=Path(directory),
+            dependencies={PERMISSION_SERVICE: permissions, COMMAND_SERVICE: commands, RESOURCE_SERVICE: resources},
+        ) as harness:
+            profile = cast(ProfileService, harness.require_service(PROFILE_SERVICE))
+            user = Principal("runtime", "bot", "user")
+            if await profile.get(user) != ProfileSnapshot(user):
+                raise RuntimeError("installed profile service did not return defaults")
+            resource_service = cast(ResourceService, harness.require_service(RESOURCE_SERVICE))
+            await resource_service.set(_event(), ("profile",), "nickname", "Alice")
+            if await profile.get(user) != ProfileSnapshot(user, nickname="Alice"):
+                raise RuntimeError("installed profile service did not persist a resource update")
+
+    observed = {
+        name: importlib.metadata.version(name)
+        for name in (
+            "liteyukibot-v7",
+            "liteyukibot-v7-permissions",
+            "liteyukibot-v7-commands",
+            "liteyukibot-v7-resources",
+            "liteyukibot-v7-profile",
+        )
+    }
+    if expected_version is not None and observed["liteyukibot-v7-profile"] != expected_version:
+        raise RuntimeError(f"expected liteyukibot-v7-profile {expected_version}; observed {observed}")
+    print(json.dumps(observed, sort_keys=True))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-version")
+    arguments = parser.parse_args()
+    asyncio.run(verify(arguments.expected_version))

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -30,6 +30,8 @@ def test_import_namespaces_use_distribution_version() -> None:
         ("root", "v7.0.0a3"),
         ("permissions", "permissions-v0.2.0a1"),
         ("commands", "commands-v0.2.0a1"),
+        ("resources", "resources-v0.1.0a1"),
+        ("profile", "profile-v0.1.0a1"),
         ("essentials", "essentials-v0.2.0a1"),
     ],
 )


### PR DESCRIPTION
## Summary
- add resources/profile package release identities and tag validation
- extend plugin Trusted Publishing workflow and release documentation
- add isolated profile wheel verification

## Validation
- uv run pytest tests/test_release_v7.py packages/profile/tests/test_profile.py -q
- uv run mypy scripts/check_release.py scripts/verify_profile_install.py scripts/run_profile_install.py
- uv run python scripts/run_resources_install.py
- uv run python scripts/run_profile_install.py
- uv build --all-packages --out-dir dist/workspace --clear