### PR TITLE
📝 Document resource profile topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ under ADR 0011 before the first stable release.
 - NoneBot2 plugin hosting and a deliberately bounded v6 compatibility shim;
 - local authenticated CLI control and an optional loopback-only HTTP status API.
 - read-only kernel status plus separately distributable capability, command,
-  help, and protected-status plugins.
+  resource-management, profile, help, and protected-status plugins.
 
 ## Requirements
 
@@ -51,7 +51,7 @@ uv sync --extra nonebot --extra onebot
 uv sync --extra nonebot --extra satori
 ```
 
-Install the complete first-party plugin chain with:
+Install the Essentials command layer with:
 
 ```bash
 uv add "liteyukibot-v7-essentials==0.2.0a1"
@@ -59,6 +59,12 @@ uv add "liteyukibot-v7-essentials==0.2.0a1"
 
 This resolves `liteyukibot-v7-commands` and
 `liteyukibot-v7-permissions`; enable all three plugin IDs in configuration.
+
+The optional profile layer adds persistent per-bot user nickname and language
+preferences. Install `liteyukibot-v7-profile` to resolve resources, then enable
+`liteyukibot.resources` and `liteyukibot.profile` before Essentials. Profile is
+a business plugin: its SQLite database is private to the plugin, and resources
+only supplies the declaration, command, and authorization boundary.
 
 Use `liteyuki.example.toml` as a configuration reference. CLI overrides must
 precede the subcommand, for example:
@@ -95,6 +101,8 @@ uv build --project examples/custom-runtime --out-dir dist/examples
 uv run python scripts/run_developer_kit_install.py
 uv run python scripts/run_permissions_install.py
 uv run python scripts/run_commands_install.py
+uv run python scripts/run_resources_install.py
+uv run python scripts/run_profile_install.py
 uv run python scripts/run_essentials_install.py
 ```
 

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -177,3 +177,16 @@ kernel dependency set does not change.
 The Phase 5 plugin contract release is `0.2.0a1` for all three first-party
 distributions. It is published with new immutable plugin tags after the release
 identity and isolated wheel checks pass.
+
+Phase 6 adds optional business-plugin infrastructure without promoting storage
+or user data into the kernel. `liteyukibot-v7-resources==0.1.0a1` provides
+`liteyukibot.resources@1`, a declarative field registry that owns command
+generation, exact-principal targeting, and per-operation capability checks.
+It does not own storage, transactions, or schema migration.
+`liteyukibot-v7-profile==0.1.0a1` is the first provider: it owns a private,
+serialized SQLite database keyed by `(runtime_id, bot_id, actor_id)` and exposes
+nickname and language fields. Essentials treats profile language as optional
+and falls back to its static setting. The release chain becomes root,
+permissions, commands, resources, profile, then essentials; each package has
+an immutable tag, isolated wheel verifier, and dedicated Trusted Publishing
+environment. No new runtime IPC version or kernel dependency is introduced.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -126,6 +126,29 @@ Essentials renders visible root commands and `/help <path>` details. Parse
 errors are converted to short localized usage messages without exposing
 converter exceptions.
 
+## Resources and Profiles
+
+`liteyukibot-v7-resources` provides the optional
+`liteyukibot.resources@1` declaration layer. A resource spec defines a stable
+path and named fields; a provider keeps ownership of its data, transactions,
+schema migrations, and validation. Resources generate three commands through
+the command service: `<path>`, `<path> set <field> <value>`, and
+`<path> delete <field>`. Direct command registrations remain valid when this
+convention does not fit a plugin.
+
+The event actor is the target principal by default. `--actor <id>` requests an
+operation for another actor in the same runtime and bot; it is denied unless
+that field explicitly declares the capability for the requested operation.
+Resources never permit overriding runtime or bot identity, and cross-principal
+access is fail-closed.
+
+`liteyukibot-v7-profile` is the reference business plugin. It stores nickname
+and language under the exact `(runtime_id, bot_id, actor_id)` key in its private
+SQLite database and provides `liteyukibot.profile@1`. It has no kernel database
+dependency. Consumers may declare the profile service as optional, as
+Essentials does for per-user language, and must preserve a documented fallback
+when profile is not enabled or cannot be read.
+
 ## Essentials
 
 `liteyukibot-v7-essentials` is a consumer plugin, not a kernel feature. It
@@ -136,5 +159,8 @@ deployment configuration. Help filters registrations through the command
 service for the current event; status reads the immutable kernel status
 provider.
 
-The `language` setting accepts `zh-CN` or `en`. This dictionary is intentionally
-local to the package and does not define a localization API for other plugins.
+The `language` setting accepts `zh-CN` or `en`. When the optional profile
+service is enabled and has a valid value for the event principal, Essentials
+uses it; anonymous events, missing profile, and lookup failures use the static
+setting. This dictionary is intentionally local to the package and does not
+define a localization API for other plugins.

--- a/liteyuki.example.toml
+++ b/liteyuki.example.toml
@@ -21,6 +21,16 @@ local_modules = []
 #   "liteyukibot.commands",
 #   "liteyukibot.essentials",
 # ]
+#
+# After installing liteyukibot-v7-profile as well, enable resources and profile
+# before Essentials to persist per-bot nickname and language preferences:
+# enabled = [
+#   "liteyukibot.permissions",
+#   "liteyukibot.commands",
+#   "liteyukibot.resources",
+#   "liteyukibot.profile",
+#   "liteyukibot.essentials",
+# ]
 
 [plugins.config."liteyukibot.permissions"]
 grants = []

--- a/packages/profile/tests/test_profile.py
+++ b/packages/profile/tests/test_profile.py
@@ -165,6 +165,42 @@ async def test_profile_resource_commands_mutate_data_and_describe_limits(tmp_pat
         await app.stop()
 
 
+@pytest.mark.asyncio
+async def test_profile_language_drives_essentials_and_falls_back_after_reset(tmp_path: Path) -> None:
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
+        plugins=PluginSettings(
+            enabled=(
+                "liteyukibot.permissions",
+                "liteyukibot.commands",
+                "liteyukibot.resources",
+                "liteyukibot.profile",
+                "liteyukibot.essentials",
+            ),
+            config={"liteyukibot.essentials": {"language": "zh-CN"}},
+        ),
+    )
+    actions: list[ActionEnvelope] = []
+
+    async def record(action: ActionEnvelope) -> ActionResult:
+        actions.append(action)
+        return ActionResult(action_id=action.action_id, success=True)
+
+    app = LiteyukiApp(settings, logger=get_logger(component="profile-language-tests"))
+    app.events._action_executor = record
+    await app.start()
+    try:
+        await app.events.publish(_message_event("/profile set language en"))
+        await app.events.publish(_message_event("/help"))
+        assert cast(SendMessage, actions[-1].action).message.plain_text.startswith("Available commands:")
+
+        await app.events.publish(_message_event("/profile delete language"))
+        await app.events.publish(_message_event("/help"))
+        assert cast(SendMessage, actions[-1].action).message.plain_text.startswith("可用命令：")
+    finally:
+        await app.stop()
+
+
 def _nickname_field() -> ResourceField:
     return ResourceField("nickname", nickname_value)
 


### PR DESCRIPTION
## Summary
- document the optional resources/profile business-plugin boundary and deployment topology
- extend the sample configuration and local verification instructions
- add an end-to-end profile language to Essentials fallback test

## Validation
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv run pytest -q
- uv build --all-packages --out-dir dist/workspace --clear
- uv run python scripts/run_resources_install.py
- uv run python scripts/run_profile_install.py