### PR TITLE
🔖 Bump Essentials alpha version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ uv sync --extra nonebot --extra satori
 Install the Essentials command layer with:
 
 ```bash
-uv add "liteyukibot-v7-essentials==0.2.0a1"
+uv add "liteyukibot-v7-essentials==0.2.0a2"
 ```
 
 This resolves `liteyukibot-v7-commands` and

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -189,4 +189,6 @@ nickname and language fields. Essentials treats profile language as optional
 and falls back to its static setting. The release chain becomes root,
 permissions, commands, resources, profile, then essentials; each package has
 an immutable tag, isolated wheel verifier, and dedicated Trusted Publishing
-environment. No new runtime IPC version or kernel dependency is introduced.
+environment. Essentials is released as `0.2.0a2` because its optional profile
+language integration changed after `0.2.0a1`; no new runtime IPC version or
+kernel dependency is introduced.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -40,7 +40,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-commands==0.2.0a1` | `packages/commands` | `commands-v0.2.0a1` |
 | `liteyukibot-v7-resources==0.1.0a1` | `packages/resources` | `resources-v0.1.0a1` |
 | `liteyukibot-v7-profile==0.1.0a1` | `packages/profile` | `profile-v0.1.0a1` |
-| `liteyukibot-v7-essentials==0.2.0a1` | `packages/essentials` | `essentials-v0.2.0a1` |
+| `liteyukibot-v7-essentials==0.2.0a2` | `packages/essentials` | `essentials-v0.2.0a2` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
 tag that does not exactly match the selected source version and distribution.
@@ -54,7 +54,7 @@ Push and wait for each release before creating the next tag:
 3. `commands-v0.2.0a1`;
 4. `resources-v0.1.0a1`;
 5. `profile-v0.1.0a1`;
-6. `essentials-v0.2.0a1`.
+6. `essentials-v0.2.0a2`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its
@@ -65,7 +65,7 @@ After the final upload, verify the public dependency chain without a checkout:
 
 ```bash
 uv run --no-project --python 3.14 \
-  --with "liteyukibot-v7-essentials==0.2.0a1" \
+  --with "liteyukibot-v7-essentials==0.2.0a2" \
   python -c "import importlib.metadata as m; print(m.version('liteyukibot-v7'))"
 ```
 

--- a/packages/essentials/pyproject.toml
+++ b/packages/essentials/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-essentials"
-version = "0.2.0a1"
+version = "0.2.0a2"
 description = "Essential help and status commands for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/essentials/src/liteyukibot_essentials/__init__.py
+++ b/packages/essentials/src/liteyukibot_essentials/__init__.py
@@ -8,7 +8,7 @@ from .render import Language, render_help, render_status
 try:
     __version__ = version("liteyukibot-v7-essentials")
 except PackageNotFoundError:
-    __version__ = "0.2.0a1"
+    __version__ = "0.2.0a2"
 
 plugin = create_plugin(__version__)
 

--- a/packages/essentials/tests/test_essentials.py
+++ b/packages/essentials/tests/test_essentials.py
@@ -375,7 +375,7 @@ async def test_help_resolves_visible_hierarchical_aliases_and_renders_schema(tmp
 
 def test_essentials_manifest_declares_optional_profile_service() -> None:
     assert plugin.manifest.id == "liteyukibot.essentials"
-    assert plugin.manifest.version == "0.2.0a1"
+    assert plugin.manifest.version == "0.2.0a2"
     assert plugin.manifest.provides == ()
     assert tuple(item.key for item in plugin.manifest.requires) == (
         COMMAND_SERVICE,

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -32,7 +32,7 @@ def test_import_namespaces_use_distribution_version() -> None:
         ("commands", "commands-v0.2.0a1"),
         ("resources", "resources-v0.1.0a1"),
         ("profile", "profile-v0.1.0a1"),
-        ("essentials", "essentials-v0.2.0a1"),
+        ("essentials", "essentials-v0.2.0a2"),
     ],
 )
 def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-essentials"
-version = "0.2.0a1"
+version = "0.2.0a2"
 source = { editable = "packages/essentials" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Summary
- bump Essentials to 0.2.0a2 after profile language integration
- update release identity tests and documentation
- keep the already-published 0.2.0a1 immutable

## Validation
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv run pytest -q
- uv build --all-packages --out-dir dist/workspace --clear
- uv run python scripts/run_essentials_install.py