### PR TITLE
fix: harden NoneBot runtime event handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,8 @@ jobs:
         working-directory: LiteyukiBot
         run: |
           uv python install 3.14
-          uv sync --locked --extra nonebot --extra onebot --extra satori
+          uv sync --locked --all-packages --extra nonebot --extra onebot --extra satori
           uv run --extra nonebot --extra onebot --extra satori pytest \
             tests/test_runtime_v7.py::test_nonebot_runtime_loads_an_existing_plugin \
-            tests/test_nonebot_adapters_v7.py
+            tests/test_nonebot_adapters_v7.py \
+            tests/test_nonebot_runtime_e2e_v7.py

--- a/docs/adr/0005-runtime-ipc-protocol-v2.md
+++ b/docs/adr/0005-runtime-ipc-protocol-v2.md
@@ -47,6 +47,14 @@ Timeout removes the pending request. Disconnect fails it with
 before another frame is sent. An unmatched or late `event_accepted` has no
 effect.
 
+Child-originated Event handling runs in tracked work outside the connection
+reader. This keeps later Action responses and heartbeats routable when an Event
+handler waits for an Action result on the same runtime connection. The
+supervisor bounds that tracked work with each runtime's `max_inbound_events`
+limit (default `100`), replying `overloaded` before creating a task when full.
+A duplicate in-flight child Event correlation ID receives `invalid`, and
+disconnect cancels unfinished Event work.
+
 ## Consequences
 
 V1 and v2 children may connect to the same supervisor concurrently. Existing v1

--- a/docs/development/custom-runtimes.md
+++ b/docs/development/custom-runtimes.md
@@ -39,6 +39,11 @@ The host must also:
 - never reconnect itself, because restart limits and backoff belong to the
   supervisor.
 
+The supervisor applies the same protection to child-to-core Events. Each
+runtime has `max_inbound_events` (default `100`); additional Events receive
+`overloaded` without creating another handler task. Set it in the runtime's
+TOML table when the adapter has a known, bounded concurrency requirement.
+
 Protocol v2/v3 Event receipt requires `runtime.events.receive`. Child-originated
 Actions require protocol v3 and `runtime.actions.send`. Capability names and
 protocol versions are negotiated exactly rather than inferred.

--- a/liteyuki.example.toml
+++ b/liteyuki.example.toml
@@ -54,6 +54,7 @@ kind = "nonebot"
 enabled = false
 heartbeat_interval_seconds = 10.0
 stale_after_seconds = 30.0
+max_inbound_events = 100
 
 [runtimes.nonebot.options]
 plugins = []

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -142,6 +142,7 @@ class LiteyukiApp:
                     ready_timeout=runtime.ready_timeout_seconds,
                     heartbeat_interval=runtime.heartbeat_interval_seconds,
                     stale_after=runtime.stale_after_seconds,
+                    max_inbound_events=runtime.max_inbound_events,
                 )
             )
             if runtime.kind == "v6":

--- a/src/liteyukibot/config/models.py
+++ b/src/liteyukibot/config/models.py
@@ -94,6 +94,7 @@ class RuntimeSettings(FrozenSettingsModel):
     ready_timeout_seconds: float = Field(default=30.0, gt=0)
     heartbeat_interval_seconds: float = Field(default=10.0, gt=0)
     stale_after_seconds: float = Field(default=30.0, gt=0)
+    max_inbound_events: int = Field(default=100, ge=1)
     max_failures: int = Field(default=5, ge=1)
     failure_window_seconds: float = Field(default=60.0, gt=0)
 

--- a/src/liteyukibot/runtime/nonebot.py
+++ b/src/liteyukibot/runtime/nonebot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import os
+import signal
 import threading
 from collections import OrderedDict
 from collections.abc import Callable, Coroutine, Mapping, Sequence
@@ -36,6 +37,14 @@ type ActionHandler = Callable[
     [Mapping[str, Any]],
     Coroutine[Any, Any, tuple[bool, Any, str | None]],
 ]
+
+
+def _stop_driver(driver: Any) -> None:
+    exit_driver = getattr(driver, "exit", None)
+    if callable(exit_driver):
+        exit_driver()
+        return
+    signal.raise_signal(signal.SIGINT)
 
 
 class SupervisorBridge:
@@ -189,7 +198,7 @@ class NoneBotHost:
             main_loop = asyncio.get_running_loop()
 
             def shutdown() -> None:
-                main_loop.call_soon_threadsafe(driver.exit)
+                main_loop.call_soon_threadsafe(_stop_driver, driver)
 
             self.bridge.set_handlers(
                 self.execute_action,

--- a/src/liteyukibot/runtime/supervisor.py
+++ b/src/liteyukibot/runtime/supervisor.py
@@ -72,6 +72,7 @@ class RuntimeSpec:
     heartbeat_interval: float = 10.0
     stale_after: float = 30.0
     shutdown_timeout: float = 10.0
+    max_inbound_events: int = 100
 
     def __post_init__(self) -> None:
         if not self.id or not self.kind:
@@ -82,6 +83,8 @@ class RuntimeSpec:
             raise ValueError("runtime lifecycle timeouts must be positive")
         if self.heartbeat_interval <= 0 or self.stale_after <= self.heartbeat_interval:
             raise ValueError("runtime stale_after must exceed its positive heartbeat interval")
+        if self.max_inbound_events < 1:
+            raise ValueError("runtime max_inbound_events must be at least 1")
         if self.command is not None and (
             not self.command or any(not part for part in self.command)
         ):
@@ -106,6 +109,7 @@ class RuntimeRecord:
     pending_actions: dict[str, asyncio.Future[ActionResponse]] = field(default_factory=dict)
     pending_events: dict[str, asyncio.Future[EventAccepted]] = field(default_factory=dict)
     inbound_actions: dict[str, asyncio.Task[None]] = field(default_factory=dict)
+    inbound_events: dict[str, asyncio.Task[None]] = field(default_factory=dict)
     protocol_version: ProtocolVersion | None = None
     capabilities: frozenset[str] = frozenset()
     send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -302,18 +306,7 @@ class RuntimeSupervisor:
         elif isinstance(message, Heartbeat):
             record.last_heartbeat = time.monotonic()
         elif isinstance(message, EventMessage):
-            status = "accepted"
-            if self.event_sink is not None:
-                status = await self.event_sink(record.spec.id, message.payload)
-            match status:
-                case "accepted" | "overloaded" | "invalid":
-                    normalized = status
-                case _:
-                    normalized = "invalid"
-            await self._send(
-                record,
-                EventAccepted(correlation_id=message.correlation_id, status=normalized),
-            )
+            await self._accept_child_event(record, message)
         elif isinstance(message, EventAccepted):
             event_future = record.pending_events.pop(message.correlation_id, None)
             if event_future is not None and not event_future.done():
@@ -328,6 +321,60 @@ class RuntimeSupervisor:
             self.logger.error("runtime {} error {}: {}", record.spec.id, message.code, message.message)
         else:
             self.logger.debug("ignored runtime {} message {}", record.spec.id, message.type)
+
+    async def _accept_child_event(self, record: RuntimeRecord, message: EventMessage) -> None:
+        if message.correlation_id in record.inbound_events:
+            await self._send(
+                record,
+                EventAccepted(
+                    correlation_id=message.correlation_id,
+                    status="invalid",
+                    detail="duplicate child event correlation id",
+                ),
+            )
+            return
+        if len(record.inbound_events) >= record.spec.max_inbound_events:
+            await self._send(
+                record,
+                EventAccepted(
+                    correlation_id=message.correlation_id,
+                    status="overloaded",
+                    detail="runtime inbound event capacity is exhausted",
+                ),
+            )
+            return
+        task = asyncio.create_task(
+            self._execute_child_event(record, message),
+            name=f"runtime-event:{record.spec.id}:{message.correlation_id}",
+        )
+        record.inbound_events[message.correlation_id] = task
+
+    async def _execute_child_event(self, record: RuntimeRecord, message: EventMessage) -> None:
+        detail: str | None = None
+        try:
+            status = "accepted" if self.event_sink is None else await self.event_sink(record.spec.id, message.payload)
+            match status:
+                case "accepted" | "overloaded" | "invalid":
+                    normalized = status
+                case _:
+                    normalized = "invalid"
+        except Exception as error:
+            self.logger.error("runtime {} child event {} failed: {}", record.spec.id, message.correlation_id, error)
+            normalized = "invalid"
+            detail = "core event sink failed"
+        try:
+            await self._send(
+                record,
+                EventAccepted(
+                    correlation_id=message.correlation_id,
+                    status=normalized,
+                    detail=detail,
+                ),
+            )
+        except (ConnectionError, RuntimeError):
+            pass
+        finally:
+            record.inbound_events.pop(message.correlation_id, None)
 
     async def _accept_child_action(
         self, record: RuntimeRecord, request: ActionRequest
@@ -562,6 +609,12 @@ class RuntimeSupervisor:
             task.cancel()
         if inbound_actions:
             await asyncio.gather(*inbound_actions, return_exceptions=True)
+        inbound_events = tuple(record.inbound_events.values())
+        record.inbound_events.clear()
+        for task in inbound_events:
+            task.cancel()
+        if inbound_events:
+            await asyncio.gather(*inbound_events, return_exceptions=True)
         if writer is not None:
             writer.close()
             await writer.wait_closed()

--- a/tests/test_config_v7.py
+++ b/tests/test_config_v7.py
@@ -75,6 +75,7 @@ nested = { primary = true }
     "nb": {
       "kind": "nonebot",
       "working_directory": "runtime",
+      "max_inbound_events": 7,
       "options": {"adapter": "onebot", "features": ["messages", "notices"]}
     }
   }
@@ -100,6 +101,7 @@ nested = { primary = true }
         "nested": {"include": True, "primary": True},
     }
     assert settings.runtimes["nb"].working_directory == additional_directory / "runtime"
+    assert settings.runtimes["nb"].max_inbound_events == 7
     assert settings.runtimes["nb"].options["features"] == ("messages", "notices")
     serialized = settings.model_dump(mode="json")
     assert serialized["runtimes"]["nb"]["options"]["features"] == ["messages", "notices"]
@@ -116,6 +118,11 @@ def test_runtime_options_reject_non_json_values(tmp_path: Path) -> None:
             command=("runtime",),
             options={"path": tmp_path},  # type: ignore[dict-item]
         )
+
+
+def test_runtime_rejects_non_positive_inbound_event_capacity() -> None:
+    with pytest.raises(ValidationError, match="max_inbound_events"):
+        RuntimeSettings(kind="nonebot", max_inbound_events=0)
 
 
 def test_nested_includes_merge_in_declared_order(tmp_path: Path) -> None:

--- a/tests/test_nonebot_adapters_v7.py
+++ b/tests/test_nonebot_adapters_v7.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.util
 import json
 import math
+import signal
 from datetime import UTC, datetime
 from typing import Any
 
@@ -17,6 +18,7 @@ from liteyukibot.events import (
     Segment,
     SendMessage,
 )
+from liteyukibot.runtime import nonebot as nonebot_runtime
 from liteyukibot.runtime.nonebot import NoneBotHost
 from liteyukibot.runtime.nonebot_contracts import (
     AdapterContractError,
@@ -76,6 +78,29 @@ class FakeNoneBot:
 
     def get_bot(self, bot_id: str) -> FakeBot:
         return self.bots[bot_id]
+
+
+def test_nonebot_shutdown_prefers_driver_exit_and_falls_back_to_sigint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ExitDriver:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def exit(self) -> None:
+            self.calls += 1
+
+    class CombinedDriver:
+        pass
+
+    exit_driver = ExitDriver()
+    nonebot_runtime._stop_driver(exit_driver)
+    assert exit_driver.calls == 1
+
+    signals: list[int] = []
+    monkeypatch.setattr(signal, "raise_signal", signals.append)
+    nonebot_runtime._stop_driver(CombinedDriver())
+    assert signals == [signal.SIGINT]
 
 
 def _onebot_v11_group_event() -> Any:

--- a/tests/test_nonebot_runtime_e2e_v7.py
+++ b/tests/test_nonebot_runtime_e2e_v7.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import socket
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from liteyukibot.app import LiteyukiApp
+from liteyukibot.config import AppSettings, CoreSettings, PluginSettings, RuntimeSettings
+
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("nonebot") is None
+    or importlib.util.find_spec("nonebot.adapters.onebot.v11") is None,
+    reason="NoneBot OneBot v11 extras are not installed",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OneBotApiRequest:
+    path: str
+    payload: Mapping[str, Any]
+
+
+class OneBotApiStub:
+    def __init__(self) -> None:
+        self.requests: asyncio.Queue[OneBotApiRequest] = asyncio.Queue()
+        self._server: asyncio.Server | None = None
+
+    @property
+    def url(self) -> str:
+        if self._server is None:
+            raise RuntimeError("OneBot API stub is not running")
+        port = int(self._server.sockets[0].getsockname()[1])
+        return f"http://127.0.0.1:{port}"
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            request_line = (await reader.readline()).decode("ascii").rstrip("\r\n")
+            method, path, version = request_line.split(" ", maxsplit=2)
+            if method != "POST" or version != "HTTP/1.1":
+                raise ValueError("expected an HTTP/1.1 POST request")
+
+            headers: dict[str, str] = {}
+            while line := await reader.readline():
+                if line == b"\r\n":
+                    break
+                name, value = line.decode("ascii").rstrip("\r\n").split(":", maxsplit=1)
+                headers[name.lower()] = value.strip()
+            content_length = int(headers["content-length"])
+            payload = json.loads(await reader.readexactly(content_length))
+            if not isinstance(payload, dict):
+                raise ValueError("OneBot API payload must be an object")
+            await self.requests.put(OneBotApiRequest(path=path, payload=payload))
+
+            response = json.dumps(
+                {"status": "ok", "retcode": 0, "data": {"message_id": 12345}}
+            ).encode("utf-8")
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                + b"Content-Type: application/json\r\n"
+                + f"Content-Length: {len(response)}\r\n".encode("ascii")
+                + b"Connection: close\r\n\r\n"
+                + response
+            )
+            await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+
+def _unused_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as socket_handle:
+        socket_handle.bind(("127.0.0.1", 0))
+        return int(socket_handle.getsockname()[1])
+
+
+async def _post_onebot_event(port: int, payload: Mapping[str, Any]) -> int:
+    body = json.dumps(payload).encode("utf-8")
+    deadline = asyncio.get_running_loop().time() + 10
+    while True:
+        try:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            break
+        except ConnectionRefusedError:
+            if asyncio.get_running_loop().time() >= deadline:
+                raise
+            await asyncio.sleep(0.01)
+    try:
+        writer.write(
+            b"POST /onebot/v11/http HTTP/1.1\r\n"
+            + b"Host: 127.0.0.1\r\n"
+            + b"Content-Type: application/json\r\n"
+            + b"X-Self-ID: 42\r\n"
+            + f"Content-Length: {len(body)}\r\n".encode("ascii")
+            + b"Connection: close\r\n\r\n"
+            + body
+        )
+        await writer.drain()
+        status_line = (await reader.readline()).decode("ascii").rstrip("\r\n")
+        return int(status_line.split(" ", maxsplit=2)[1])
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+async def _wait_for_event_bus_idle(app: LiteyukiApp) -> None:
+    await asyncio.wait_for(app.events._idle.wait(), timeout=10)
+
+
+def _group_help_event() -> dict[str, Any]:
+    return {
+        "time": 1_720_000_000,
+        "self_id": 42,
+        "post_type": "message",
+        "sub_type": "normal",
+        "user_id": 1001,
+        "message_type": "group",
+        "message_id": 7,
+        "message": [{"type": "text", "data": {"text": "/help"}}],
+        "raw_message": "/help",
+        "font": 0,
+        "sender": {"user_id": 1001, "nickname": "tester", "card": "group tester"},
+        "group_id": 2002,
+    }
+
+
+@pytest.mark.asyncio
+async def test_nonebot_onebot_v11_http_group_help_round_trip(tmp_path: Path) -> None:
+    api = OneBotApiStub()
+    await api.start()
+    runtime_port = _unused_port()
+    settings = AppSettings(
+        core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"),
+        plugins=PluginSettings(
+            enabled=(
+                "liteyukibot.permissions",
+                "liteyukibot.commands",
+                "liteyukibot.essentials",
+            ),
+            config={"liteyukibot.essentials": {"language": "en"}},
+        ),
+        runtimes={
+            "nonebot": RuntimeSettings(
+                kind="nonebot",
+                ready_timeout_seconds=10,
+                options={
+                    "adapters": ("nonebot.adapters.onebot.v11:Adapter",),
+                    "config": {
+                        "driver": "~fastapi+~httpx",
+                        "host": "127.0.0.1",
+                        "port": runtime_port,
+                        "onebot_api_roots": {"42": api.url},
+                    },
+                },
+            )
+        },
+    )
+    app = LiteyukiApp(settings)
+    try:
+        await app.start()
+        assert await _post_onebot_event(runtime_port, _group_help_event()) == 204
+
+        request = await asyncio.wait_for(api.requests.get(), timeout=10)
+        assert request.path == "/send_msg"
+        assert request.payload["group_id"] == 2002
+        assert request.payload["message_type"] == "group"
+        assert request.payload["message"] == [
+            {
+                "type": "text",
+                "data": {"text": "Available commands:\n/help (/帮助) - Show available commands"},
+            }
+        ]
+        await _wait_for_event_bus_idle(app)
+        assert api.requests.empty()
+    finally:
+        await app.stop()
+        await api.close()

--- a/tests/test_runtime_v7.py
+++ b/tests/test_runtime_v7.py
@@ -274,6 +274,110 @@ async def test_v3_child_action_reaches_core_sink_with_correlation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_child_event_does_not_block_action_response_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    action_sent = asyncio.Event()
+    event_accepted = asyncio.Event()
+    outbound: list[Any] = []
+
+    async def event_sink(runtime_id: str, _payload: dict[str, Any]) -> str:
+        response = await supervisor.execute_action(runtime_id, "reply-1", {"message": "reply"})
+        assert response.ok is True
+        return "accepted"
+
+    supervisor = RuntimeSupervisor(logger=FakeLogger(), event_sink=event_sink)
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="runtime", kind="custom"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+    )
+    supervisor.records[record.spec.id] = record
+
+    async def capture(_record: RuntimeRecord, message: Any) -> None:
+        outbound.append(message)
+        if isinstance(message, ActionRequest):
+            action_sent.set()
+        if isinstance(message, EventAccepted):
+            event_accepted.set()
+
+    monkeypatch.setattr(supervisor, "_send", capture)
+    await supervisor._handle_message(
+        record,
+        EventMessage(correlation_id="event-1", payload={"message": "hello"}),
+    )
+    await asyncio.wait_for(action_sent.wait(), timeout=1)
+    await supervisor._handle_message(
+        record,
+        ActionResponse(correlation_id="reply-1", ok=True, data={"message_id": "sent"}),
+    )
+    await asyncio.wait_for(event_accepted.wait(), timeout=1)
+
+    assert outbound == [
+        ActionRequest(correlation_id="reply-1", payload={"message": "reply"}),
+        EventAccepted(correlation_id="event-1", status="accepted"),
+    ]
+    assert record.inbound_events == {}
+
+
+@pytest.mark.asyncio
+async def test_child_event_limit_rejects_duplicates_and_overload_then_cancels_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def hold(_runtime_id: str, _payload: dict[str, Any]) -> str:
+        started.set()
+        try:
+            await asyncio.Future[None]()
+            raise AssertionError("unreachable")
+        finally:
+            cancelled.set()
+
+    supervisor = RuntimeSupervisor(logger=FakeLogger(), event_sink=hold)
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="runtime", kind="custom", max_inbound_events=1),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+    )
+    responses: list[EventAccepted] = []
+
+    async def capture(_record: RuntimeRecord, message: Any) -> None:
+        assert isinstance(message, EventAccepted)
+        responses.append(message)
+
+    monkeypatch.setattr(supervisor, "_send", capture)
+    message = EventMessage(correlation_id="duplicate", payload={})
+    await supervisor._handle_message(record, message)
+    await asyncio.wait_for(started.wait(), timeout=1)
+    await supervisor._handle_message(record, message)
+    await supervisor._handle_message(
+        record,
+        EventMessage(correlation_id="overloaded", payload={}),
+    )
+
+    assert responses == [
+        EventAccepted(
+            correlation_id="duplicate",
+            status="invalid",
+            detail="duplicate child event correlation id",
+        ),
+        EventAccepted(
+            correlation_id="overloaded",
+            status="overloaded",
+            detail="runtime inbound event capacity is exhausted",
+        ),
+    ]
+    await supervisor._disconnect(record)
+
+    assert cancelled.is_set()
+    assert record.inbound_events == {}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("protocol_version", "capabilities", "with_sink", "error"),
     [


### PR DESCRIPTION
## Summary
- add a real OneBot v11 HTTP event-to-action E2E test and run it in the NoneBot CI contract
- stop combined NoneBot drivers through SIGINT when they do not expose exit()
- keep the IPC reader routable while child event handlers await actions, with bounded per-runtime inbound event tasks and overloaded backpressure

## Validation
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv run pytest (260 passed)
- uv run --extra nonebot --extra onebot --extra satori pytest tests/test_nonebot_adapters_v7.py tests/test_nonebot_runtime_e2e_v7.py (20 passed)