### PR TITLE
fix: clean up plugin command lifecycle

### DIFF
--- a/docs/adr/0003-native-plugin-api-v1.md
+++ b/docs/adr/0003-native-plugin-api-v1.md
@@ -37,10 +37,13 @@ manifest. Services use `name@major` keys, have exactly one provider, and form a
 startup dependency graph. Missing required services, conflicting providers, and
 cycles are startup errors.
 
-Setup occurs in dependency order. Stop callbacks and managed task cleanup occur
-in reverse dependency order, including after partial startup. If setup fails,
-services already provided by that plugin are removed and its tasks are stopped.
-Task failures are reported through the plugin-bound logger.
+Setup occurs in dependency order. Plugins may register synchronous or async
+cleanup through `context.defer_cleanup()`; callbacks run in reverse registration
+order after a stop callback and before managed-task cancellation. They also run
+when setup fails, so a plugin can safely undo EventBus subscriptions or service
+registrations created before a later setup error. Services already provided by a
+failed plugin are removed and its tasks are stopped. Task failures are reported
+through the plugin-bound logger.
 
 ## Consequences
 

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -127,68 +127,15 @@ used as an automatic pass/fail threshold. The current three-run alpha reference
 and published-install matrix are documented in
 [`performance-v7.md`](../performance-v7.md).
 
-## Pre-release Delivery
+## Current Release State
 
-Phase 1 is distributed as `7.0.0a1` on PyPI. The non-root Docker image is built
-from the locked uv environment and includes all current optional integrations;
-local builds are validated, while GHCR publication is paused. The Docker
-workflow only builds images. Package publication requires an exact match among
-the `pyproject.toml` version, the release tag, and the built wheel metadata.
+The current pre-release is `liteyukibot-v7==7.0.0a3`. The kernel, bounded v6
+compatibility, NoneBot adapter boundary, and first-party plugin foundation are
+complete. Resources and profile remain optional business plugins; their storage
+and migration ownership does not belong to the kernel.
 
-Phase 2 kernel stabilization is complete. The runtime failure matrix, accepted
-v1 ADRs, three-platform kernel suite, isolated public-PyPI installation checks,
-and informational alpha performance reference form the kernel baseline.
-
-Phase 3 compatibility is complete and distributed as `7.0.0a2`. It adds
-reusable child transport, negotiated bidirectional Events and Actions, the
-bounded v6 message matcher bridge, structured NoneBot OneBot/Satori adapter
-contracts, and the plugin/runtime developer kit. Its root and example wheels,
-three-platform quality and published-install jobs, NoneBot contract job, and
-local non-root Docker smoke all passed before publication.
-
-Phase 4 builds first-party capabilities as separately distributable native
-plugins. Its first kernel addition is the versioned read-only status service;
-command routing, access policy, and user-facing rendering remain plugin-owned.
-The uv workspace holds these packages during alpha so they share locking and CI
-without becoming kernel modules. `liteyukibot-v7-permissions` is the first
-member and provides an exact-principal `public`/`operator` policy service.
-`liteyukibot-v7-commands` consumes that policy and owns prefix parsing,
-collision-free registration, and high-priority EventBus routing. It deliberately
-keeps argument parsing and user-facing commands outside the kernel.
-`liteyukibot-v7-essentials` consumes commands and the kernel status snapshot to
-provide permission-filtered help and operator-only status as plain text. Its
-small Chinese/English dictionary remains package-local rather than establishing
-a premature kernel localization contract.
-
-Phase 4 is released as `7.0.0a3`; the three plugin distributions begin at
-`0.1.0a1`. Release identities and tag prefixes are fixed per package, and the
-dependency chain is published in root, permissions, commands, essentials order.
-
-Phase 5 evolves the first-party plugin contracts without expanding the kernel.
-Its permission service resolves static roles and exact-principal grants into
-immutable capability snapshots; `liteyukibot.status.read` replaces role-name
-checks for the essential status command. ADR 0016 records the fail-closed,
-no-wildcard policy. ADR 0017 adds explicit command schemas, deterministic chat
-tokenization, options, and typed converters without handler annotation
-inspection. ADR 0018 adds hierarchical routing and ADR 0019 keeps detailed help
-and localized usage rendering in essentials. Runtime IPC stays at v3 and the
-kernel dependency set does not change.
-
-The Phase 5 plugin contract release is `0.2.0a1` for all three first-party
-distributions. It is published with new immutable plugin tags after the release
-identity and isolated wheel checks pass.
-
-Phase 6 adds optional business-plugin infrastructure without promoting storage
-or user data into the kernel. `liteyukibot-v7-resources==0.1.0a1` provides
-`liteyukibot.resources@1`, a declarative field registry that owns command
-generation, exact-principal targeting, and per-operation capability checks.
-It does not own storage, transactions, or schema migration.
-`liteyukibot-v7-profile==0.1.0a1` is the first provider: it owns a private,
-serialized SQLite database keyed by `(runtime_id, bot_id, actor_id)` and exposes
-nickname and language fields. Essentials treats profile language as optional
-and falls back to its static setting. The release chain becomes root,
-permissions, commands, resources, profile, then essentials; each package has
-an immutable tag, isolated wheel verifier, and dedicated Trusted Publishing
-environment. Essentials is released as `0.2.0a2` because its optional profile
-language integration changed after `0.2.0a1`; no new runtime IPC version or
-kernel dependency is introduced.
+Current release procedure and package identities are in
+[`development/releasing.md`](../development/releasing.md). Completed alpha
+delivery phases are retained in the
+[`documentation archive`](../archive/v7-alpha-delivery-history.md); the root
+[`CHANGELOG`](../../CHANGELOG.md) is the release history.

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,16 @@
+# Documentation Archive
+
+This directory preserves historical records that remain useful for release and
+design archaeology but no longer describe the current v7 architecture or
+development workflow.
+
+Active documentation stays in:
+
+- [`../architecture/v7.md`](../architecture/v7.md) for the current kernel and
+  runtime boundaries;
+- [`../adr/README.md`](../adr/README.md) for accepted architectural decisions;
+- [`../development/`](../development/) for contributor and maintainer guides;
+- [`../migration-v6.md`](../migration-v6.md) for the supported v6 compatibility
+  surface.
+
+Archived records are not compatibility promises or implementation guidance.

--- a/docs/archive/v7-alpha-delivery-history.md
+++ b/docs/archive/v7-alpha-delivery-history.md
@@ -1,0 +1,44 @@
+# v7 Alpha Delivery History
+
+- Status: Archived
+- Archived: 2026-08-10
+
+This record preserves completed alpha delivery phases that no longer belong in
+the current architecture overview. It is historical context only; use the
+current architecture, ADRs, release guide, and changelog for active decisions.
+
+## Phases 1-3: Kernel And Compatibility
+
+`7.0.0a1` established the Python 3.14 kernel, non-root Docker build, and
+version/tag/wheel release integrity. Kernel stabilization then added the
+runtime failure matrix, v1 ADRs, three-platform verification, isolated PyPI
+installation checks, and an informational performance reference.
+
+`7.0.0a2` completed the first bounded compatibility phase: reusable child
+transport, negotiated bidirectional Events and Actions, the v6 message matcher
+bridge, structured NoneBot OneBot/Satori adapter contracts, and the
+plugin/runtime developer kit.
+
+## Phases 4-5: First-Party Plugin Foundation
+
+`7.0.0a3` introduced separately distributed permissions, commands, and
+essentials plugins. The status service, policy, command routing, and help
+rendering stayed outside the kernel. The first package release order was root,
+permissions, commands, then essentials.
+
+The following plugin contract release advanced permissions, commands, and
+essentials to `0.2.0a1`. ADRs 0016-0019 recorded exact capabilities,
+structured schemas, hierarchical routing, and Essentials-owned help rendering;
+runtime IPC remained at v3.
+
+## Phase 6: Optional Business Plugins
+
+`liteyukibot-v7-resources==0.1.0a1` added declarative resource registration,
+command generation, exact-principal targeting, and per-operation capability
+checks without introducing kernel storage or migrations.
+
+`liteyukibot-v7-profile==0.1.0a1` became the reference provider, owning a
+private SQLite database keyed by `(runtime_id, bot_id, actor_id)` and exposing
+nickname and language fields. Essentials advanced to `0.2.0a2` for optional
+profile language integration. The release chain became root, permissions,
+commands, resources, profile, then essentials.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -10,8 +10,8 @@ entry-point name and `PluginManifest.id` must be identical.
 ```
 
 The complete minimal package is in [`examples/native-plugin`](../../examples/native-plugin).
-Its setup function subscribes an async handler and returns a stop callback that
-removes that subscription. Event handlers return protocol-neutral
+Its setup function subscribes an async handler and registers the matching
+unsubscription through `context.defer_cleanup()`. Event handlers return protocol-neutral
 `HandlerResult` values containing Actions; adapter objects do not belong in a
 native plugin.
 
@@ -32,7 +32,7 @@ Use only the ownership surfaces supplied by `PluginContext`:
   required;
 - background coroutines are started through `context.tasks.start()`;
 - private data/cache paths exist only when `storage = "private"`;
-- EventBus subscriptions are removed by the plugin's stop callback;
+- EventBus subscriptions and other registrations use `context.defer_cleanup()`;
 - replies and API calls use frozen models from `liteyukibot.events`.
 
 ## Testing

--- a/examples/native-plugin/src/liteyukibot_example_plugin/__init__.py
+++ b/examples/native-plugin/src/liteyukibot_example_plugin/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
+from liteyukibot import PluginContext, PluginDefinition, PluginManifest
 from liteyukibot.events import (
     ActionEnvelope,
     EventEnvelope,
@@ -13,7 +13,7 @@ from liteyukibot.events import (
 )
 
 
-async def setup(context: PluginContext) -> PluginHandle:
+async def setup(context: PluginContext) -> None:
     prefix = context.config.get("prefix", "echo: ")
     if not isinstance(prefix, str):
         raise TypeError("example.echo config prefix must be a string")
@@ -36,10 +36,7 @@ async def setup(context: PluginContext) -> PluginHandle:
 
     subscription = context.events.subscribe(echo, name="example.echo")
 
-    async def stop() -> None:
-        context.events.unsubscribe(subscription)
-
-    return PluginHandle(stop=stop)
+    context.defer_cleanup(lambda: context.events.unsubscribe(subscription))
 
 
 plugin = PluginDefinition(

--- a/packages/commands/src/liteyukibot_commands/plugin.py
+++ b/packages/commands/src/liteyukibot_commands/plugin.py
@@ -6,13 +6,13 @@ from typing import cast
 
 from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService
 
-from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
+from liteyukibot import PluginContext, PluginDefinition, PluginManifest
 from liteyukibot.services import ServiceRequirement
 
 from .service import COMMAND_SERVICE, create_command_service
 
 
-async def setup(context: PluginContext) -> PluginHandle:
+async def setup(context: PluginContext) -> None:
     permissions = cast(PermissionService, context.services.require(PERMISSION_SERVICE))
     service = create_command_service(context.config, permissions, context.logger)
     context.services.provide(COMMAND_SERVICE, service)
@@ -22,10 +22,7 @@ async def setup(context: PluginContext) -> PluginHandle:
         name="liteyukibot.commands",
     )
 
-    async def stop() -> None:
-        context.events.unsubscribe(subscription)
-
-    return PluginHandle(stop=stop)
+    context.defer_cleanup(lambda: context.events.unsubscribe(subscription))
 
 
 def create_plugin(version: str) -> PluginDefinition:

--- a/packages/commands/src/liteyukibot_commands/service.py
+++ b/packages/commands/src/liteyukibot_commands/service.py
@@ -49,6 +49,8 @@ class CommandService(Protocol):
 
     def unregister(self, registration: CommandRegistration) -> bool: ...
 
+    def unregister_owner(self, owner: str) -> int: ...
+
     def snapshot(self) -> tuple[CommandRegistration, ...]: ...
 
     def visible(self, event: EventEnvelope) -> tuple[CommandRegistration, ...]: ...
@@ -93,8 +95,7 @@ class _CommandService:
         *,
         owner: str,
     ) -> tuple[CommandRegistration, ...]:
-        if not owner or owner != owner.strip():
-            raise ValueError("command owner must be a non-empty trimmed string")
+        _validate_owner(owner)
         pending = tuple(bindings)
         if not pending:
             return ()
@@ -134,11 +135,22 @@ class _CommandService:
         registered = self._commands.get(registration.id)
         if registered is None or registered.registration != registration:
             return False
-        del self._commands[registration.id]
-        for path in registered.paths:
-            self._paths.pop(path, None)
-        self._max_path_length = max((len(path) for path in self._paths), default=0)
+        self._remove(registered)
+        self._refresh_max_path_length()
         return True
+
+    def unregister_owner(self, owner: str) -> int:
+        _validate_owner(owner)
+        registrations = tuple(
+            registered
+            for registered in self._commands.values()
+            if registered.registration.owner == owner
+        )
+        for registered in registrations:
+            self._remove(registered)
+        if registrations:
+            self._refresh_max_path_length()
+        return len(registrations)
 
     def snapshot(self) -> tuple[CommandRegistration, ...]:
         return tuple(
@@ -221,6 +233,14 @@ class _CommandService:
             )
             return False
 
+    def _remove(self, registered: _RegisteredCommand) -> None:
+        del self._commands[registered.registration.id]
+        for path in registered.paths:
+            self._paths.pop(path, None)
+
+    def _refresh_max_path_length(self) -> None:
+        self._max_path_length = max((len(path) for path in self._paths), default=0)
+
     def _parse(self, event: EventEnvelope) -> tuple[_RegisteredCommand, str, str, str] | None:
         if event.message is None:
             return None
@@ -256,6 +276,11 @@ def _command_tokens(value: str) -> tuple[tuple[str, int, int], ...]:
         tokens.append((value[start:end], start, end))
         start = end
     return tuple(tokens)
+
+
+def _validate_owner(owner: str) -> None:
+    if not owner or owner != owner.strip():
+        raise ValueError("command owner must be a non-empty trimmed string")
 
 
 def create_command_service(

--- a/packages/commands/tests/test_commands.py
+++ b/packages/commands/tests/test_commands.py
@@ -16,9 +16,10 @@ from liteyukibot_commands import (
     integer_value,
     plugin,
 )
+from liteyukibot_commands.service import create_command_service
 from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, PermissionSnapshot, Principal
 
-from liteyukibot import LiteyukiApp
+from liteyukibot import LiteyukiApp, PluginContext, PluginDefinition, PluginManifest
 from liteyukibot.config import AppSettings, CoreSettings, PluginSettings
 from liteyukibot.events import (
     ActorRef,
@@ -31,6 +32,7 @@ from liteyukibot.events import (
 )
 from liteyukibot.exceptions import PluginError, ServiceError
 from liteyukibot.logging import get_logger
+from liteyukibot.services import ServiceRequirement
 from liteyukibot.testing import PluginTestHarness
 
 ADMIN = "tests.admin"
@@ -224,6 +226,59 @@ async def test_command_registration_is_atomic_and_explicitly_owned(tmp_path: Pat
         assert service.unregister(first) is True
         assert service.unregister(first) is False
         assert service.snapshot() == ()
+
+
+@pytest.mark.asyncio
+async def test_command_owner_unregistration_removes_all_owned_paths(tmp_path: Path) -> None:
+    async with make_harness(tmp_path) as harness:
+        service = cast(CommandService, harness.require_service(COMMAND_SERVICE))
+
+        def handler(_invocation: CommandInvocation) -> None:
+            return None
+
+        service.register_many(
+            (
+                (CommandSpec("plugin", aliases=("plugins",)), handler),
+                (CommandSpec("list", aliases=("ls",), path=("plugin",)), handler),
+            ),
+            owner="owner.one",
+        )
+        retained = service.register(CommandSpec("ping"), handler, owner="owner.two")
+
+        assert service.unregister_owner("owner.one") == 2
+        assert service.snapshot() == (retained,)
+        assert service.unregister_owner("owner.one") == 0
+
+
+@pytest.mark.asyncio
+async def test_failed_plugin_setup_removes_its_owned_command_registrations(tmp_path: Path) -> None:
+    commands = create_command_service({}, PermissionStub(), get_logger(component="commands-cleanup"))
+
+    async def setup(context: PluginContext) -> None:
+        service = cast(CommandService, context.services.require(COMMAND_SERVICE))
+        service.register(CommandSpec("transient"), lambda _invocation: None, owner=context.id)
+        context.defer_cleanup(lambda: service.unregister_owner(context.id))
+        raise RuntimeError("setup failed")
+
+    definition = PluginDefinition(
+        PluginManifest(
+            id="commands.transient",
+            name="Commands transient",
+            version="1.0.0",
+            requires=(ServiceRequirement(COMMAND_SERVICE),),
+        ),
+        setup,
+    )
+    harness = PluginTestHarness(
+        definition,
+        root=tmp_path,
+        dependencies={COMMAND_SERVICE: commands},
+    )
+
+    with pytest.raises(PluginError, match="commands.transient setup failed"):
+        await harness.start()
+
+    assert commands.snapshot() == ()
 
 
 @pytest.mark.asyncio

--- a/packages/essentials/src/liteyukibot_essentials/plugin.py
+++ b/packages/essentials/src/liteyukibot_essentials/plugin.py
@@ -17,7 +17,7 @@ from liteyukibot_commands import (
 )
 from liteyukibot_permissions import Principal
 
-from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
+from liteyukibot import PluginContext, PluginDefinition, PluginManifest
 from liteyukibot.events import HandlerResult
 from liteyukibot.services import ServiceKey, ServiceRequirement
 from liteyukibot.status import KERNEL_STATUS_SERVICE, KernelStatusProvider
@@ -47,7 +47,7 @@ def _language(config: Mapping[str, Any]) -> Language:
     return cast(Language, value)
 
 
-async def setup(context: PluginContext) -> PluginHandle:
+async def setup(context: PluginContext) -> None:
     language = _language(context.config)
     command_service = cast(CommandService, context.services.require(COMMAND_SERVICE))
     status_provider = cast(KernelStatusProvider, context.services.require(KERNEL_STATUS_SERVICE))
@@ -119,13 +119,8 @@ async def setup(context: PluginContext) -> PluginHandle:
             status_command,
         ),
     )
-    registrations = command_service.register_many(bindings, owner=context.id)
-
-    async def stop() -> None:
-        for registration in reversed(registrations):
-            command_service.unregister(registration)
-
-    return PluginHandle(stop=stop)
+    command_service.register_many(bindings, owner=context.id)
+    context.defer_cleanup(lambda: command_service.unregister_owner(context.id))
 
 
 def create_plugin(version: str) -> PluginDefinition:

--- a/packages/profile/src/liteyukibot_profile/plugin.py
+++ b/packages/profile/src/liteyukibot_profile/plugin.py
@@ -6,13 +6,13 @@ from typing import cast
 
 from liteyukibot_resources import RESOURCE_SERVICE, ResourceField, ResourceService, ResourceSpec
 
-from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
+from liteyukibot import PluginContext, PluginDefinition, PluginManifest
 from liteyukibot.services import ServiceRequirement
 
 from .service import PROFILE_SERVICE, SQLiteProfileService, language_value, nickname_value
 
 
-async def setup(context: PluginContext) -> PluginHandle:
+async def setup(context: PluginContext) -> None:
     if context.paths is None:
         raise RuntimeError("profile plugin requires private storage")
     resources = cast(ResourceService, context.services.require(RESOURCE_SERVICE))
@@ -39,11 +39,11 @@ async def setup(context: PluginContext) -> PluginHandle:
     )
     context.services.provide(PROFILE_SERVICE, service)
 
-    async def stop() -> None:
+    async def close() -> None:
         resources.unregister(registration)
         await service.close()
 
-    return PluginHandle(stop=stop)
+    context.defer_cleanup(close)
 
 
 def create_plugin(version: str) -> PluginDefinition:

--- a/src/liteyukibot/plugins.py
+++ b/src/liteyukibot/plugins.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import AbstractContextManager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import partial
 from importlib import import_module, metadata
@@ -82,6 +82,36 @@ class PluginManifest(BaseModel):
 
 
 PluginCallback = Callable[[], Awaitable[None]]
+type CleanupCallback = Callable[[], object]
+
+
+class _PluginCleanup:
+    def __init__(self) -> None:
+        self._callbacks: list[CleanupCallback] = []
+        self._closed = False
+
+    def defer(self, callback: CleanupCallback) -> None:
+        if self._closed:
+            raise RuntimeError("plugin cleanup is already closed")
+        if not callable(callback):
+            raise TypeError("plugin cleanup callback must be callable")
+        self._callbacks.append(callback)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        errors: list[BaseException] = []
+        while self._callbacks:
+            callback = self._callbacks.pop()
+            try:
+                result = callback()
+                if inspect.isawaitable(result):
+                    await result
+            except BaseException as error:
+                errors.append(error)
+        if errors:
+            raise BaseExceptionGroup("plugin cleanup failed", errors)
 
 
 @dataclass(frozen=True, slots=True)
@@ -146,6 +176,12 @@ class PluginContext:
     events: EventBus
     actions: ActionServiceLike
     paths: PluginPaths | None
+    _cleanup: _PluginCleanup = field(repr=False, compare=False)
+
+    def defer_cleanup(self, callback: CleanupCallback) -> None:
+        """Run a synchronous or asynchronous callback during plugin cleanup."""
+
+        self._cleanup.defer(callback)
 
 
 class PluginState(StrEnum):
@@ -287,6 +323,7 @@ class PluginManager:
             )
             paths = self._create_paths(plugin_id) if manifest.storage == "private" else None
             plugin_services = PluginServices(manifest, self.services)
+            cleanup = _PluginCleanup()
             context = PluginContext(
                 id=plugin_id,
                 config=MappingProxyType(dict(configs.get(plugin_id, {}))),
@@ -296,13 +333,28 @@ class PluginManager:
                 events=self.events,
                 actions=self.actions,
                 paths=paths,
+                _cleanup=cleanup,
             )
+            handle = PluginHandle()
             try:
-                handle = await definition.setup(context) or PluginHandle()
+                handle = await definition.setup(context) or handle
                 plugin_services.validate_provided()
             except Exception as exc:
-                self.services.remove_provider(plugin_id)
-                await tasks.stop()
+                try:
+                    if handle.stop is not None:
+                        await handle.stop()
+                except BaseException:
+                    logger.exception("plugin {} stop after setup failure failed", plugin_id)
+                finally:
+                    try:
+                        await cleanup.close()
+                    except BaseException:
+                        logger.exception("plugin {} cleanup after setup failure failed", plugin_id)
+                    finally:
+                        try:
+                            await tasks.stop()
+                        finally:
+                            self.services.remove_provider(plugin_id)
                 raise PluginError(f"plugin {plugin_id} setup failed") from exc
             self.loaded[plugin_id] = LoadedPlugin(definition, context, handle)
 
@@ -321,6 +373,10 @@ class PluginManager:
             except BaseException as error:
                 errors.append(error)
             finally:
+                try:
+                    await plugin.context._cleanup.close()
+                except BaseException as error:
+                    errors.append(error)
                 try:
                     await plugin.context.tasks.stop()
                 except BaseException as error:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -147,6 +147,83 @@ async def test_plugin_setup_failure_removes_its_provided_services(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_plugin_setup_failure_runs_deferred_cleanup_in_reverse_order(tmp_path: Path) -> None:
+    manager = make_manager(tmp_path)
+    calls: list[str] = []
+
+    async def async_cleanup() -> None:
+        calls.append("async")
+
+    async def setup(context: PluginContext) -> None:
+        context.defer_cleanup(lambda: calls.append("sync"))
+        context.defer_cleanup(async_cleanup)
+        raise RuntimeError("setup failed")
+
+    definition = PluginDefinition(
+        PluginManifest(id="cleanup", name="Cleanup", version="1.0.0"),
+        setup,
+    )
+
+    with pytest.raises(PluginError, match="cleanup setup failed"):
+        await manager.setup({"cleanup": definition}, {})
+
+    assert calls == ["async", "sync"]
+
+
+@pytest.mark.asyncio
+async def test_plugin_setup_validation_failure_runs_stop_and_deferred_cleanup(tmp_path: Path) -> None:
+    manager = make_manager(tmp_path)
+    calls: list[str] = []
+
+    async def setup(context: PluginContext) -> PluginHandle:
+        context.defer_cleanup(lambda: calls.append("cleanup"))
+
+        async def stop() -> None:
+            calls.append("stop")
+
+        return PluginHandle(stop=stop)
+
+    definition = PluginDefinition(
+        PluginManifest(
+            id="cleanup-validation",
+            name="Cleanup validation",
+            version="1.0.0",
+            provides=(ServiceKey("example.required"),),
+        ),
+        setup,
+    )
+
+    with pytest.raises(PluginError, match="cleanup-validation setup failed"):
+        await manager.setup({"cleanup-validation": definition}, {})
+
+    assert calls == ["stop", "cleanup"]
+
+
+@pytest.mark.asyncio
+async def test_plugin_stop_runs_deferred_cleanup_after_stop_callback(tmp_path: Path) -> None:
+    manager = make_manager(tmp_path)
+    calls: list[str] = []
+
+    async def setup(context: PluginContext) -> PluginHandle:
+        context.defer_cleanup(lambda: calls.append("cleanup"))
+
+        async def stop() -> None:
+            calls.append("stop")
+
+        return PluginHandle(stop=stop)
+
+    definition = PluginDefinition(
+        PluginManifest(id="cleanup", name="Cleanup", version="1.0.0"),
+        setup,
+    )
+
+    await manager.setup({"cleanup": definition}, {})
+    await manager.stop()
+
+    assert calls == ["stop", "cleanup"]
+
+
+@pytest.mark.asyncio
 async def test_plugin_managed_task_failure_is_logged(tmp_path: Path) -> None:
     logger = RecordingLogger()
     manager = make_manager(tmp_path, logger=logger)


### PR DESCRIPTION
## Summary
- add transactional plugin cleanup for registrations made during setup
- remove command registrations by owner during plugin teardown
- archive superseded v7 alpha delivery history and update plugin lifecycle docs

## Validation
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv run pytest (265 passed)