### PR TITLE
feat: add metadata-driven project initialization

### DIFF
--- a/packages/agent/src/liteyukibot_agent/__init__.py
+++ b/packages/agent/src/liteyukibot_agent/__init__.py
@@ -6,7 +6,7 @@ import sys
 from importlib.metadata import PackageNotFoundError, version
 
 from liteyukibot import PluginDefinition
-from liteyukibot.runtime import RuntimePlugin
+from liteyukibot.runtime import InitFieldKind, InitFieldSpec, RuntimeInitSpec, RuntimePlugin
 
 from .plugin import create_plugin
 
@@ -16,6 +16,33 @@ def runtime_plugin() -> RuntimePlugin:
         kind="agent",
         command=(sys.executable, "-m", "liteyukibot_agent"),
         agent_harness="native",
+        init_spec=RuntimeInitSpec(
+            default_id="agent",
+            description="Native OpenAI-compatible agent runtime.",
+            fields=(
+                InitFieldSpec(
+                    key="model",
+                    label="Model",
+                    kind=InitFieldKind.STRING,
+                    required=True,
+                    description="OpenAI-compatible model identifier.",
+                ),
+                InitFieldSpec(
+                    key="base_url",
+                    label="Base URL",
+                    kind=InitFieldKind.STRING,
+                    description="Optional OpenAI-compatible API endpoint.",
+                ),
+                InitFieldSpec(
+                    key="api_key_secret",
+                    label="API key",
+                    kind=InitFieldKind.SECRET,
+                    required=True,
+                    description="Stored by the kernel vault in the next configuration layer.",
+                    secret_environment="LITEYUKI_AGENT_API_KEY",
+                ),
+            ),
+        ),
     )
 
 

--- a/packages/agent/src/liteyukibot_agent/plugin.py
+++ b/packages/agent/src/liteyukibot_agent/plugin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from liteyukibot import PluginContext, PluginDefinition, PluginManifest
+from liteyukibot import PluginContext, PluginDefinition, PluginInitSpec, PluginManifest
 from liteyukibot.agents import AGENT_TOOL_BROKER_SERVICE
 from liteyukibot.services import ServiceKey, ServiceRequirement
 
@@ -31,4 +31,5 @@ def create_plugin(version: str) -> PluginDefinition:
             requires=(ServiceRequirement(PERMISSION_SERVICE, optional=True),),
         ),
         setup=setup,
+        init_spec=PluginInitSpec(description="Kernel-side agent tool broker."),
     )

--- a/packages/commands/src/liteyukibot_commands/plugin.py
+++ b/packages/commands/src/liteyukibot_commands/plugin.py
@@ -6,7 +6,7 @@ from typing import cast
 
 from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService
 
-from liteyukibot import PluginContext, PluginDefinition, PluginManifest
+from liteyukibot import InitFieldKind, InitFieldSpec, PluginContext, PluginDefinition, PluginInitSpec, PluginManifest
 from liteyukibot.services import ServiceRequirement
 
 from .service import COMMAND_SERVICE, create_command_service
@@ -35,6 +35,17 @@ def create_plugin(version: str) -> PluginDefinition:
             requires=(ServiceRequirement(PERMISSION_SERVICE),),
         ),
         setup=setup,
+        init_spec=PluginInitSpec(
+            description="Protocol-neutral command routing.",
+            fields=(
+                InitFieldSpec(
+                    key="prefixes",
+                    label="Command prefixes",
+                    kind=InitFieldKind.STRING_LIST,
+                    default=("/",),
+                ),
+            ),
+        ),
     )
 
 

--- a/packages/essentials/src/liteyukibot_essentials/plugin.py
+++ b/packages/essentials/src/liteyukibot_essentials/plugin.py
@@ -17,7 +17,7 @@ from liteyukibot_commands import (
 )
 from liteyukibot_permissions import Principal
 
-from liteyukibot import PluginContext, PluginDefinition, PluginManifest
+from liteyukibot import InitFieldKind, InitFieldSpec, PluginContext, PluginDefinition, PluginInitSpec, PluginManifest
 from liteyukibot.events import HandlerResult
 from liteyukibot.services import ServiceKey, ServiceRequirement
 from liteyukibot.status import KERNEL_STATUS_SERVICE, KernelStatusProvider
@@ -136,6 +136,18 @@ def create_plugin(version: str) -> PluginDefinition:
             ),
         ),
         setup=setup,
+        init_spec=PluginInitSpec(
+            description="Help and protected kernel status commands.",
+            fields=(
+                InitFieldSpec(
+                    key="language",
+                    label="Default language",
+                    kind=InitFieldKind.STRING,
+                    default="zh-CN",
+                    choices=("zh-CN", "en"),
+                ),
+            ),
+        ),
     )
 
 

--- a/packages/permissions/src/liteyukibot_permissions/plugin.py
+++ b/packages/permissions/src/liteyukibot_permissions/plugin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from liteyukibot import PluginContext, PluginDefinition, PluginManifest
+from liteyukibot import PluginContext, PluginDefinition, PluginInitSpec, PluginManifest
 
 from .service import PERMISSION_SERVICE, create_permission_service
 
@@ -21,6 +21,7 @@ def create_plugin(version: str) -> PluginDefinition:
             provides=(PERMISSION_SERVICE,),
         ),
         setup=setup,
+        init_spec=PluginInitSpec(description="Permission grants and roles can be configured after initialization."),
     )
 
 

--- a/packages/profile/src/liteyukibot_profile/plugin.py
+++ b/packages/profile/src/liteyukibot_profile/plugin.py
@@ -6,7 +6,7 @@ from typing import cast
 
 from liteyukibot_resources import RESOURCE_SERVICE, ResourceField, ResourceService, ResourceSpec
 
-from liteyukibot import PluginContext, PluginDefinition, PluginManifest
+from liteyukibot import PluginContext, PluginDefinition, PluginInitSpec, PluginManifest
 from liteyukibot.services import ServiceRequirement
 
 from .service import PROFILE_SERVICE, SQLiteProfileService, language_value, nickname_value
@@ -57,6 +57,7 @@ def create_plugin(version: str) -> PluginDefinition:
             storage="private",
         ),
         setup=setup,
+        init_spec=PluginInitSpec(description="Private per-user profile storage and resource fields."),
     )
 
 

--- a/packages/resources/src/liteyukibot_resources/plugin.py
+++ b/packages/resources/src/liteyukibot_resources/plugin.py
@@ -7,7 +7,7 @@ from typing import cast
 from liteyukibot_commands import COMMAND_SERVICE, CommandService
 from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService
 
-from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginManifest
+from liteyukibot import PluginContext, PluginDefinition, PluginHandle, PluginInitSpec, PluginManifest
 from liteyukibot.services import ServiceRequirement
 
 from .service import RESOURCE_SERVICE, create_resource_service
@@ -33,6 +33,7 @@ def create_plugin(version: str) -> PluginDefinition:
             ),
         ),
         setup=setup,
+        init_spec=PluginInitSpec(description="Resource registry required by persistent profile plugins."),
     )
 
 

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/__init__.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 
-from liteyukibot.runtime import RuntimePlugin
+from liteyukibot.runtime import RuntimeInitSpec, RuntimePlugin
 
 
 def runtime_plugin() -> RuntimePlugin:
@@ -12,6 +12,10 @@ def runtime_plugin() -> RuntimePlugin:
         kind="astrbot",
         command=(sys.executable, "-m", "liteyukibot_runtime_astrbot"),
         agent_harness="astrbot",
+        init_spec=RuntimeInitSpec(
+            default_id="astrbot",
+            description="Headless AstrBot agent host; AstrBot plugins remain runtime-owned.",
+        ),
     )
 
 

--- a/packages/runtime-mofox/src/liteyukibot_runtime_mofox/__init__.py
+++ b/packages/runtime-mofox/src/liteyukibot_runtime_mofox/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 
-from liteyukibot.runtime import RuntimePlugin
+from liteyukibot.runtime import RuntimeInitSpec, RuntimePlugin
 
 
 def runtime_plugin() -> RuntimePlugin:
@@ -12,6 +12,10 @@ def runtime_plugin() -> RuntimePlugin:
         kind="mofox",
         command=(sys.executable, "-m", "liteyukibot_runtime_mofox"),
         agent_harness="mofox",
+        init_spec=RuntimeInitSpec(
+            default_id="mofox",
+            description="Headless Neo-MoFox agent host; MoFox plugins remain runtime-owned.",
+        ),
     )
 
 

--- a/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/__init__.py
+++ b/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/__init__.py
@@ -4,13 +4,23 @@ from __future__ import annotations
 
 import sys
 
-from liteyukibot.runtime import RuntimePlugin
+from liteyukibot.runtime import RuntimeInitSpec, RuntimePlugin
 
 
 def runtime_plugin() -> RuntimePlugin:
     return RuntimePlugin(
         kind="nonebot",
         command=(sys.executable, "-m", "liteyukibot_runtime_nonebot"),
+        init_spec=RuntimeInitSpec(
+            default_id="nonebot",
+            description="NoneBot child host. Configure framework plugins and adapters in its runtime options.",
+            default_options={
+                "plugins": (),
+                "plugin_dirs": (),
+                "adapters": ("nonebot.adapters.onebot.v11:Adapter",),
+                "config": {"driver": "~fastapi"},
+            },
+        ),
     )
 
 

--- a/packages/runtime-v6/src/liteyukibot_runtime_v6/__init__.py
+++ b/packages/runtime-v6/src/liteyukibot_runtime_v6/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 
-from liteyukibot.runtime import RuntimePlugin
+from liteyukibot.runtime import RuntimeInitSpec, RuntimePlugin
 
 
 def runtime_plugin() -> RuntimePlugin:
@@ -12,6 +12,11 @@ def runtime_plugin() -> RuntimePlugin:
         kind="v6",
         command=(sys.executable, "-m", "liteyukibot_runtime_v6"),
         default_event_route_messages_only=True,
+        init_spec=RuntimeInitSpec(
+            default_id="legacy",
+            description="Bounded LiteyukiBot v6 compatibility host.",
+            default_options={"plugins": (), "plugin_dirs": ("plugins",), "config": {"nickname": ("Liteyuki",)}},
+        ),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 dependencies = [
     "pydantic>=2.13,<3",
+    "tomli-w>=1.2,<2",
     "yukilog>=1,<2",
 ]
 

--- a/src/liteyukibot/__init__.py
+++ b/src/liteyukibot/__init__.py
@@ -2,6 +2,7 @@
 
 from ._version import __version__
 from .app import LiteyukiApp
+from .init_specs import InitFieldKind, InitFieldSpec, PluginInitSpec, RuntimeInitSpec
 from .plugins import (
     PluginContext,
     PluginDefinition,
@@ -18,14 +19,18 @@ __all__ = [
     "KERNEL_STATUS_SERVICE",
     "KernelStatusProvider",
     "KernelStatusSnapshot",
+    "InitFieldKind",
+    "InitFieldSpec",
     "PluginContext",
     "PluginDefinition",
     "PluginHandle",
     "PluginManifest",
+    "PluginInitSpec",
     "PluginPaths",
     "PluginServices",
     "ServiceKey",
     "ServiceRegistry",
     "ServiceRequirement",
+    "RuntimeInitSpec",
     "__version__",
 ]

--- a/src/liteyukibot/cli.py
+++ b/src/liteyukibot/cli.py
@@ -13,6 +13,7 @@ from typing import Any
 from . import __version__
 from .app import LiteyukiApp
 from .config import AppSettings, ConfigurationError, ConfigWorkspace, load_settings
+from .config.initializer import build_initialization_plan
 from .control import ControlError, request_control
 from .exceptions import LiteyukiError
 
@@ -83,16 +84,20 @@ def _init(non_interactive: bool) -> int:
     if non_interactive:
         path = workspace.initialize()
     else:
+        plan = build_initialization_plan(
+            prompt=_prompt,
+            output=lambda message: print(message, file=sys.stderr),
+        )
         path = workspace.initialize(
-            data_dir=_prompt("Data directory", "data"),
-            cache_dir=_prompt("Cache directory", "cache"),
-            logging_level=_prompt("Logging level", "INFO").upper(),
-            payload_mode=_prompt("Payload logging mode (metadata/full)", "metadata").lower(),
-            payload_exclude_runtimes=tuple(
-                item.strip()
-                for item in _prompt("Payload exclusion runtime IDs (comma-separated)", "").split(",")
-                if item.strip()
-            ),
+            data_dir=plan.data_dir,
+            cache_dir=plan.cache_dir,
+            logging_level=plan.logging_level,
+            payload_mode=plan.payload_mode,
+            payload_exclude_runtimes=plan.payload_exclude_runtimes,
+            plugins=plan.plugins,
+            plugin_config=plan.plugin_config,
+            runtimes=plan.runtimes,
+            runtime_event_routes=plan.runtime_event_routes,
         )
     print(f"created {path}")
     return 0
@@ -143,11 +148,11 @@ async def _run_until_signal(settings: AppSettings) -> None:
     for signum in (signal.SIGINT, signal.SIGTERM):
         try:
             loop.add_signal_handler(signum, request_stop)
-        except (NotImplementedError, RuntimeError, ValueError):
+        except NotImplementedError, RuntimeError, ValueError:
             try:
                 previous = signal.getsignal(signum)
                 signal.signal(signum, lambda _signum, _frame: request_stop())
-            except (OSError, RuntimeError, ValueError):
+            except OSError, RuntimeError, ValueError:
                 continue
             fallback_handlers[signum] = previous
         else:

--- a/src/liteyukibot/config/initializer.py
+++ b/src/liteyukibot/config/initializer.py
@@ -1,0 +1,278 @@
+"""Interactive project initialization from installed package metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ..init_specs import InitFieldKind, InitFieldSpec
+from ..plugins import PluginDefinition, PluginManager
+from ..runtime import RuntimeCatalog, RuntimePlugin
+from ..services import ServiceKey
+from ..status import KERNEL_STATUS_SERVICE
+
+Prompt = Callable[[str, str], str]
+Output = Callable[[str], None]
+
+
+@dataclass(frozen=True, slots=True)
+class InitializationPlan:
+    """A validated set of ordinary TOML values ready for ConfigWorkspace."""
+
+    data_dir: str
+    cache_dir: str
+    logging_level: str
+    payload_mode: str
+    payload_exclude_runtimes: tuple[str, ...]
+    plugins: tuple[str, ...]
+    plugin_config: dict[str, dict[str, Any]]
+    runtimes: dict[str, dict[str, Any]]
+    runtime_event_routes: tuple[dict[str, Any], ...]
+    diagnostics: tuple[str, ...]
+
+
+def build_initialization_plan(*, prompt: Prompt, output: Output) -> InitializationPlan:
+    """Collect a safe configuration using only package-owned initialization metadata."""
+
+    data_dir = prompt("Data directory", "data")
+    cache_dir = prompt("Cache directory", "cache")
+    logging_level = prompt("Logging level", "INFO").upper()
+    payload_mode = prompt("Payload logging mode (metadata/full)", "metadata").lower()
+    payload_exclude_runtimes = _split_values(prompt("Payload exclusion runtime IDs (comma-separated)", ""))
+
+    plugin_definitions, plugin_diagnostics = PluginManager.discover_installed()
+    runtime_plugins, runtime_diagnostics = RuntimeCatalog().discover_installed()
+    diagnostics = plugin_diagnostics + runtime_diagnostics
+    for diagnostic in diagnostics:
+        output(f"warning: {diagnostic}")
+
+    selected_plugins = _select_plugins(plugin_definitions, prompt=prompt, output=output)
+    plugin_config = _collect_plugin_config(selected_plugins, plugin_definitions, prompt=prompt)
+    runtimes = _select_runtimes(runtime_plugins, prompt=prompt, output=output)
+    routes = _collect_agent_routes(runtimes, runtime_plugins, prompt=prompt)
+
+    return InitializationPlan(
+        data_dir=data_dir,
+        cache_dir=cache_dir,
+        logging_level=logging_level,
+        payload_mode=payload_mode,
+        payload_exclude_runtimes=payload_exclude_runtimes,
+        plugins=selected_plugins,
+        plugin_config=plugin_config,
+        runtimes=runtimes,
+        runtime_event_routes=routes,
+        diagnostics=diagnostics,
+    )
+
+
+def _select_plugins(
+    definitions: Mapping[str, PluginDefinition],
+    *,
+    prompt: Prompt,
+    output: Output,
+) -> tuple[str, ...]:
+    selected: set[str] = set()
+    providers: dict[ServiceKey, tuple[str, ...]] = {}
+    for plugin_id, definition in definitions.items():
+        for service in definition.manifest.provides:
+            providers[service] = (*providers.get(service, ()), plugin_id)
+
+    def select(plugin_id: str) -> None:
+        if plugin_id in selected:
+            return
+        definition = definitions[plugin_id]
+        selected.add(plugin_id)
+        for requirement in definition.manifest.requires:
+            if requirement.optional or requirement.key == KERNEL_STATUS_SERVICE:
+                continue
+            candidates = tuple(sorted(providers.get(requirement.key, ())))
+            if not candidates:
+                raise ValueError(f"plugin {plugin_id} requires unavailable service {requirement.key}")
+            provider = _choose_provider(
+                plugin_id,
+                requirement.key,
+                candidates,
+                prompt=prompt,
+                output=output,
+            )
+            if provider is None:
+                raise ValueError(f"plugin {plugin_id} requires service {requirement.key}; setup was cancelled")
+            select(provider)
+
+    for plugin_id, definition in sorted(definitions.items()):
+        if plugin_id in selected:
+            continue
+        label = definition.manifest.name
+        if _confirm(prompt, f"Enable plugin {label} ({plugin_id})", default=False):
+            select(plugin_id)
+
+    selected_definitions = {plugin_id: definitions[plugin_id] for plugin_id in selected}
+    return PluginManager.resolve_definitions(
+        selected_definitions,
+        {KERNEL_STATUS_SERVICE: "liteyukibot.kernel"},
+    )
+
+
+def _choose_provider(
+    consumer: str,
+    service: ServiceKey,
+    candidates: tuple[str, ...],
+    *,
+    prompt: Prompt,
+    output: Output,
+) -> str | None:
+    if len(candidates) == 1:
+        provider = candidates[0]
+        if _confirm(
+            prompt,
+            f"Enable required provider {provider} for {consumer} ({service})",
+            default=True,
+        ):
+            return provider
+        return None
+
+    output(f"{consumer} requires {service}; available providers: {', '.join(candidates)}")
+    value = prompt(f"Provider for {service} (or 'skip')", candidates[0])
+    if value == "skip":
+        return None
+    if value not in candidates:
+        raise ValueError(f"unknown provider {value!r} for service {service}")
+    return value
+
+
+def _collect_plugin_config(
+    selected: tuple[str, ...],
+    definitions: Mapping[str, PluginDefinition],
+    *,
+    prompt: Prompt,
+) -> dict[str, dict[str, Any]]:
+    config: dict[str, dict[str, Any]] = {}
+    for plugin_id in selected:
+        spec = definitions[plugin_id].init_spec
+        if spec is None or not spec.fields:
+            continue
+        values = _collect_fields(spec.fields, prompt=prompt, subject=f"Plugin {plugin_id}")
+        if values:
+            config[plugin_id] = values
+    return config
+
+
+def _select_runtimes(
+    plugins: Mapping[str, RuntimePlugin],
+    *,
+    prompt: Prompt,
+    output: Output,
+) -> dict[str, dict[str, Any]]:
+    runtimes: dict[str, dict[str, Any]] = {}
+    for kind, plugin in sorted(plugins.items()):
+        spec = plugin.init_spec
+        if spec is None:
+            output(f"warning: runtime {kind!r} has no initialization metadata and was skipped")
+            continue
+        if any(field.kind is InitFieldKind.SECRET for field in spec.fields):
+            output(f"runtime {kind!r} requires the secure vault and was skipped during this initialization")
+            continue
+        if not _confirm(prompt, f"Enable runtime {kind}", default=False):
+            continue
+        runtime_id = spec.default_id
+        if runtime_id in runtimes:
+            raise ValueError(f"runtime initialization id collision: {runtime_id}")
+        options = dict(spec.default_options)
+        options.update(_collect_fields(spec.fields, prompt=prompt, subject=f"Runtime {kind}"))
+        runtimes[runtime_id] = {
+            "kind": kind,
+            "enabled": True,
+            "heartbeat_interval_seconds": 10.0,
+            "stale_after_seconds": 30.0,
+            "max_inbound_events": 100,
+            "options": options,
+        }
+    return runtimes
+
+
+def _collect_agent_routes(
+    runtimes: Mapping[str, Mapping[str, Any]],
+    plugins: Mapping[str, RuntimePlugin],
+    *,
+    prompt: Prompt,
+) -> tuple[dict[str, Any], ...]:
+    routes: list[dict[str, Any]] = []
+    sources = tuple(
+        runtime_id for runtime_id, config in runtimes.items() if plugins[str(config["kind"])].agent_harness is None
+    )
+    for runtime_id, config in runtimes.items():
+        plugin = plugins[str(config["kind"])]
+        if plugin.agent_harness is None:
+            continue
+        for source in sources:
+            if _confirm(
+                prompt,
+                f"Route messages from {source} to agent runtime {runtime_id}",
+                default=False,
+            ):
+                routes.append({"sources": [source], "target": runtime_id, "messages_only": True})
+    return tuple(routes)
+
+
+def _collect_fields(
+    fields: tuple[InitFieldSpec, ...],
+    *,
+    prompt: Prompt,
+    subject: str,
+) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for field in fields:
+        if field.kind is InitFieldKind.SECRET:
+            continue
+        values[field.key] = _read_field(field, prompt=prompt, subject=subject)
+    return values
+
+
+def _read_field(field: InitFieldSpec, *, prompt: Prompt, subject: str) -> Any:
+    default = _format_default(field.default)
+    label = f"{subject}: {field.label}"
+    value = prompt(label, default)
+    if not value and field.required:
+        raise ValueError(f"{subject}: {field.label} is required")
+    if field.choices and value not in field.choices:
+        raise ValueError(f"{subject}: {field.label} must be one of {', '.join(field.choices)}")
+    if field.kind is InitFieldKind.INTEGER:
+        try:
+            return int(value)
+        except ValueError as error:
+            raise ValueError(f"{subject}: {field.label} must be an integer") from error
+    if field.kind is InitFieldKind.BOOLEAN:
+        if value.lower() in {"1", "true", "yes", "y"}:
+            return True
+        if value.lower() in {"0", "false", "no", "n"}:
+            return False
+        raise ValueError(f"{subject}: {field.label} must be true or false")
+    if field.kind is InitFieldKind.STRING_LIST:
+        return list(_split_values(value))
+    return value
+
+
+def _confirm(prompt: Prompt, label: str, *, default: bool) -> bool:
+    value = prompt(f"{label} [y/N]" if not default else f"{label} [Y/n]", "y" if default else "n")
+    normalized = value.lower()
+    if normalized in {"y", "yes", "1", "true"}:
+        return True
+    if normalized in {"n", "no", "0", "false"}:
+        return False
+    raise ValueError(f"{label}: expected yes or no")
+
+
+def _split_values(value: str) -> tuple[str, ...]:
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def _format_default(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, tuple):
+        return ", ".join(str(item) for item in value)
+    return str(value)
+
+
+__all__ = ["InitializationPlan", "build_initialization_plan"]

--- a/src/liteyukibot/config/template.py
+++ b/src/liteyukibot/config/template.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable
+from typing import Any
+
+from tomli_w import dumps
 
 CONFIG_VERSION = 1
-
-
-def _toml_string(value: str) -> str:
-    return json.dumps(value, ensure_ascii=True)
 
 
 def render_config_template(
@@ -19,73 +17,35 @@ def render_config_template(
     logging_level: str = "INFO",
     payload_mode: str = "metadata",
     payload_exclude_runtimes: Iterable[str] = (),
+    plugins: Iterable[str] = (),
+    plugin_config: dict[str, dict[str, Any]] | None = None,
+    runtimes: dict[str, dict[str, Any]] | None = None,
+    runtime_event_routes: Iterable[dict[str, Any]] = (),
 ) -> str:
-    excluded = ", ".join(_toml_string(item) for item in payload_exclude_runtimes)
-    return f'''# LiteyukiBot configuration schema. Do not edit config_version manually.
-config_version = {CONFIG_VERSION}
-
-[core]
-data_dir = {_toml_string(data_dir)}
-cache_dir = {_toml_string(cache_dir)}
-queue_capacity = 1024
-enqueue_timeout_seconds = 1.0
-handler_timeout_seconds = 30.0
-max_concurrent_events = 100
-
-[logging]
-level = {_toml_string(logging_level)}
-console = true
-json_lines = false
-# Full payload logs can contain message content and identifiers. Keep metadata unless debugging.
-payload_mode = {_toml_string(payload_mode)}
-payload_exclude_runtimes = [{excluded}]
-
-[plugins]
-enabled = []
-local_modules = []
-
-[plugins.config."liteyukibot.permissions"]
-grants = []
-
-[plugins.config."liteyukibot.permissions".roles]
-operator = ["liteyukibot.status.read"]
-
-[plugins.config."liteyukibot.commands"]
-prefixes = ["/"]
-
-[plugins.config."liteyukibot.essentials"]
-language = "zh-CN"
-
-[http]
-enabled = false
-host = "127.0.0.1"
-port = 20216
-
-[runtimes.nonebot]
-# Install with: uv add "liteyukibot-v7-runtime-nonebot[onebot]"
-kind = "nonebot"
-enabled = false
-heartbeat_interval_seconds = 10.0
-stale_after_seconds = 30.0
-max_inbound_events = 100
-
-[runtimes.nonebot.options]
-plugins = []
-plugin_dirs = []
-adapters = ["nonebot.adapters.onebot.v11:Adapter"]
-
-[runtimes.nonebot.options.config]
-driver = "~fastapi"
-
-[runtimes.legacy]
-# Install with: uv add "liteyukibot-v7-runtime-v6"
-kind = "v6"
-enabled = false
-
-[runtimes.legacy.options]
-plugins = []
-plugin_dirs = ["plugins"]
-
-[runtimes.legacy.options.config]
-nickname = ["Liteyuki"]
-'''
+    document = {
+        "config_version": CONFIG_VERSION,
+        "core": {
+            "data_dir": data_dir,
+            "cache_dir": cache_dir,
+            "queue_capacity": 1024,
+            "enqueue_timeout_seconds": 1.0,
+            "handler_timeout_seconds": 30.0,
+            "max_concurrent_events": 100,
+        },
+        "logging": {
+            "level": logging_level,
+            "console": True,
+            "json_lines": False,
+            "payload_mode": payload_mode,
+            "payload_exclude_runtimes": list(payload_exclude_runtimes),
+        },
+        "plugins": {
+            "enabled": list(plugins),
+            "local_modules": [],
+            "config": plugin_config or {},
+        },
+        "http": {"enabled": False, "host": "127.0.0.1", "port": 20216},
+        "runtimes": runtimes or {},
+        "runtime_event_routes": list(runtime_event_routes),
+    }
+    return "# LiteyukiBot configuration schema. Do not edit config_version manually.\n" + dumps(document)

--- a/src/liteyukibot/config/workspace.py
+++ b/src/liteyukibot/config/workspace.py
@@ -34,14 +34,16 @@ class ConfigWorkspace:
     def is_docker() -> bool:
         return Path("/.dockerenv").is_file() or os.environ.get("container") == "docker"
 
-    def prepare(self) -> Path | None:
+    def prepare(self) -> Path:
         """Return the primary path after applying Docker/bootstrap upgrade policy."""
 
         if not self.path.exists():
             if self.is_docker():
                 self.initialize()
                 return self.path
-            return None
+            raise ConfigurationError(
+                [ConfigIssue(self.path, "project configuration is missing; run `liteyuki init` first")]
+            )
         if not self.path.is_file():
             raise ConfigurationError([ConfigIssue(self.path, "project configuration path is not a file")])
 
@@ -69,6 +71,10 @@ class ConfigWorkspace:
         logging_level: str = "INFO",
         payload_mode: str = "metadata",
         payload_exclude_runtimes: tuple[str, ...] = (),
+        plugins: tuple[str, ...] = (),
+        plugin_config: dict[str, dict[str, Any]] | None = None,
+        runtimes: dict[str, dict[str, Any]] | None = None,
+        runtime_event_routes: tuple[dict[str, Any], ...] = (),
     ) -> Path:
         if self.path.exists():
             raise ConfigurationError([ConfigIssue(self.path, "project configuration already exists")])
@@ -87,6 +93,10 @@ class ConfigWorkspace:
                 logging_level=logging.level,
                 payload_mode=logging.payload_mode,
                 payload_exclude_runtimes=logging.payload_exclude_runtimes,
+                plugins=plugins,
+                plugin_config=plugin_config,
+                runtimes=runtimes,
+                runtime_event_routes=runtime_event_routes,
             ),
             encoding="utf-8",
         )

--- a/src/liteyukibot/init_specs.py
+++ b/src/liteyukibot/init_specs.py
@@ -1,0 +1,86 @@
+"""Package-owned initialization metadata for CLI and future configuration UIs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+
+class InitFieldKind(StrEnum):
+    STRING = "string"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
+    STRING_LIST = "string_list"
+    SECRET = "secret"
+
+
+@dataclass(frozen=True, slots=True)
+class InitFieldSpec:
+    """One package-owned configuration field safe for generic setup clients."""
+
+    key: str
+    label: str
+    kind: InitFieldKind
+    default: Any = None
+    required: bool = False
+    description: str = ""
+    choices: tuple[str, ...] = ()
+    secret_environment: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.key or self.key != self.key.strip() or "." in self.key:
+            raise ValueError("initialization field key must be a non-empty simple identifier")
+        if not self.label.strip():
+            raise ValueError("initialization field label must not be blank")
+        if self.kind is InitFieldKind.SECRET:
+            if not self.secret_environment or self.secret_environment != self.secret_environment.strip():
+                raise ValueError("secret initialization fields require a target environment variable")
+        elif self.secret_environment is not None:
+            raise ValueError("only secret initialization fields may declare a target environment variable")
+        if len(set(self.choices)) != len(self.choices) or any(not item for item in self.choices):
+            raise ValueError("initialization field choices must be unique non-empty strings")
+
+
+@dataclass(frozen=True, slots=True)
+class PluginInitSpec:
+    description: str = ""
+    fields: tuple[InitFieldSpec, ...] = ()
+
+    def __post_init__(self) -> None:
+        _validate_fields(self.fields)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeInitSpec:
+    default_id: str
+    description: str = ""
+    default_options: Mapping[str, Any] = field(default_factory=dict)
+    fields: tuple[InitFieldSpec, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.default_id or self.default_id != self.default_id.strip():
+            raise ValueError("runtime initialization default_id must be a non-empty trimmed string")
+        _validate_fields(self.fields)
+        object.__setattr__(self, "default_options", MappingProxyType(dict(self.default_options)))
+
+
+def _validate_fields(fields: tuple[InitFieldSpec, ...]) -> None:
+    if len({field.key for field in fields}) != len(fields):
+        raise ValueError("initialization field keys must be unique")
+
+
+type InitValue = str | int | bool | tuple[str, ...] | None
+type InitValues = Mapping[str, InitValue]
+
+
+__all__ = [
+    "InitFieldKind",
+    "InitFieldSpec",
+    "InitValue",
+    "InitValues",
+    "PluginInitSpec",
+    "RuntimeInitSpec",
+]

--- a/src/liteyukibot/plugins.py
+++ b/src/liteyukibot/plugins.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 from .events import ActionEnvelope, ActionResult, EventBus
 from .exceptions import PluginError, ServiceError
+from .init_specs import PluginInitSpec
 from .services import ServiceKey, ServiceRegistry, ServiceRequirement
 from .tasks import ManagedTasks
 
@@ -127,6 +128,7 @@ PluginSetup = Callable[["PluginContext"], Awaitable[PluginHandle | None]]
 class PluginDefinition:
     manifest: PluginManifest
     setup: PluginSetup
+    init_spec: PluginInitSpec | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -221,9 +223,7 @@ class PluginManager:
         self.cache_dir = cache_dir
         self.loaded: dict[str, LoadedPlugin] = {}
 
-    def discover(
-        self, enabled: Sequence[str], local_modules: Sequence[str] = ()
-    ) -> dict[str, PluginDefinition]:
+    def discover(self, enabled: Sequence[str], local_modules: Sequence[str] = ()) -> dict[str, PluginDefinition]:
         wanted = set(enabled)
         definitions: dict[str, PluginDefinition] = {}
         entry_points = {item.name: item for item in metadata.entry_points(group=self.ENTRY_POINT_GROUP)}
@@ -246,14 +246,27 @@ class PluginManager:
                 raise PluginError(f"local plugin module {module_name} could not be imported") from error
             definition = self._coerce_definition(candidate)
             if definition.manifest.id not in wanted:
-                raise PluginError(
-                    f"local plugin {definition.manifest.id} is not present in the enabled plugin list"
-                )
+                raise PluginError(f"local plugin {definition.manifest.id} is not present in the enabled plugin list")
             self._insert_definition(definitions, definition, definition.manifest.id)
         missing = wanted - definitions.keys()
         if missing:
             raise PluginError(f"enabled plugins were not found: {', '.join(sorted(missing))}")
         return definitions
+
+    @classmethod
+    def discover_installed(cls) -> tuple[dict[str, PluginDefinition], tuple[str, ...]]:
+        """Discover entry-point plugins for setup clients without failing on unrelated packages."""
+
+        definitions: dict[str, PluginDefinition] = {}
+        diagnostics: list[str] = []
+        for entry_point in sorted(metadata.entry_points(group=cls.ENTRY_POINT_GROUP), key=lambda item: item.name):
+            try:
+                candidate = entry_point.load()
+                definition = cls._coerce_definition(candidate)
+                cls._insert_definition(definitions, definition, entry_point.name)
+            except Exception as error:
+                diagnostics.append(f"plugin {entry_point.name!r} is unavailable: {type(error).__name__}: {error}")
+        return definitions, tuple(diagnostics)
 
     @staticmethod
     def _coerce_definition(candidate: Any) -> PluginDefinition:
@@ -275,10 +288,21 @@ class PluginManager:
         definitions[plugin_id] = definition
 
     def resolve_order(self, definitions: Mapping[str, PluginDefinition]) -> tuple[str, ...]:
+        provided_services = {registration.key: registration.provider for registration in self.services.snapshot()}
+        return self.resolve_definitions(definitions, provided_services)
+
+    @staticmethod
+    def resolve_definitions(
+        definitions: Mapping[str, PluginDefinition],
+        provided_services: Mapping[ServiceKey, str] | None = None,
+    ) -> tuple[str, ...]:
+        """Resolve a plugin topology from package metadata without loading plugins."""
+
+        existing_providers = provided_services or {}
         providers: dict[ServiceKey, str] = {}
         for plugin_id, definition in definitions.items():
             for key in definition.manifest.provides:
-                existing = providers.get(key) or self.services.provider_for(key)
+                existing = providers.get(key) or existing_providers.get(key)
                 if existing is not None:
                     raise PluginError(f"service {key} has multiple providers: {existing}, {plugin_id}")
                 providers[key] = plugin_id
@@ -286,7 +310,7 @@ class PluginManager:
         dependencies: dict[str, set[str]] = {plugin_id: set() for plugin_id in definitions}
         for plugin_id, definition in definitions.items():
             for requirement in definition.manifest.requires:
-                provider = providers.get(requirement.key) or self.services.provider_for(requirement.key)
+                provider = providers.get(requirement.key) or existing_providers.get(requirement.key)
                 if provider is None:
                     if requirement.optional:
                         continue

--- a/src/liteyukibot/runtime/__init__.py
+++ b/src/liteyukibot/runtime/__init__.py
@@ -1,5 +1,6 @@
 """Child runtime protocol and supervision."""
 
+from ..init_specs import InitFieldKind, InitFieldSpec, RuntimeInitSpec
 from .catalog import RuntimeCatalog, RuntimePlugin
 from .client import RuntimeClient
 from .protocol import (
@@ -55,6 +56,8 @@ __all__ = [
     "EventMessage",
     "EventSink",
     "Heartbeat",
+    "InitFieldKind",
+    "InitFieldSpec",
     "Hello",
     "JsonValue",
     "ProtocolVersion",
@@ -62,6 +65,7 @@ __all__ = [
     "RuntimeClient",
     "RuntimeCatalog",
     "RuntimePlugin",
+    "RuntimeInitSpec",
     "RuntimeSpec",
     "RuntimeState",
     "RuntimeSupervisor",

--- a/src/liteyukibot/runtime/catalog.py
+++ b/src/liteyukibot/runtime/catalog.py
@@ -6,6 +6,8 @@ import sys
 from dataclasses import dataclass
 from importlib import metadata
 
+from ..init_specs import RuntimeInitSpec
+
 
 @dataclass(frozen=True, slots=True)
 class RuntimePlugin:
@@ -15,6 +17,7 @@ class RuntimePlugin:
     command: tuple[str, ...]
     default_event_route_messages_only: bool = False
     agent_harness: str | None = None
+    init_spec: RuntimeInitSpec | None = None
 
     def __post_init__(self) -> None:
         if not self.kind or self.kind != self.kind.strip():
@@ -43,22 +46,32 @@ class RuntimeCatalog:
         return plugin.command
 
     def discover(self) -> dict[str, RuntimePlugin]:
-        plugins: dict[str, RuntimePlugin] = {}
-        for entry in metadata.entry_points(group=self.ENTRY_POINT_GROUP):
-            loaded = entry.load()
-            if not callable(loaded):
-                raise RuntimeError(f"runtime entry point {entry.name!r} is not callable")
-            plugin = loaded()
-            if not isinstance(plugin, RuntimePlugin):
-                raise RuntimeError(f"runtime entry point {entry.name!r} did not return RuntimePlugin")
-            if plugin.kind != entry.name:
-                raise RuntimeError(
-                    f"runtime entry point {entry.name!r} returned mismatched kind {plugin.kind!r}"
-                )
-            if plugin.kind in plugins:
-                raise RuntimeError(f"duplicate runtime plugin kind {plugin.kind!r}")
-            plugins[plugin.kind] = plugin
+        plugins, diagnostics = self.discover_installed()
+        if diagnostics:
+            raise RuntimeError("; ".join(diagnostics))
         return plugins
+
+    def discover_installed(self) -> tuple[dict[str, RuntimePlugin], tuple[str, ...]]:
+        """Return valid runtime packages plus diagnostics for broken entry points."""
+
+        plugins: dict[str, RuntimePlugin] = {}
+        diagnostics: list[str] = []
+        for entry in metadata.entry_points(group=self.ENTRY_POINT_GROUP):
+            try:
+                loaded = entry.load()
+                if not callable(loaded):
+                    raise TypeError("entry point is not callable")
+                plugin = loaded()
+                if not isinstance(plugin, RuntimePlugin):
+                    raise TypeError("entry point did not return RuntimePlugin")
+                if plugin.kind != entry.name:
+                    raise ValueError(f"returned mismatched kind {plugin.kind!r}")
+                if plugin.kind in plugins:
+                    raise ValueError("duplicates an installed runtime kind")
+                plugins[plugin.kind] = plugin
+            except Exception as error:
+                diagnostics.append(f"runtime {entry.name!r} is unavailable: {type(error).__name__}: {error}")
+        return plugins, tuple(diagnostics)
 
 
 __all__ = ["RuntimeCatalog", "RuntimePlugin"]

--- a/tests/test_config_initializer.py
+++ b/tests/test_config_initializer.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from liteyukibot.config import ConfigWorkspace, load_settings
+from liteyukibot.config.initializer import build_initialization_plan
+from liteyukibot.init_specs import InitFieldKind, InitFieldSpec, PluginInitSpec, RuntimeInitSpec
+from liteyukibot.plugins import PluginContext, PluginDefinition, PluginManager, PluginManifest
+from liteyukibot.runtime import RuntimeCatalog, RuntimePlugin
+from liteyukibot.services import ServiceKey, ServiceRequirement
+
+_SERVICE = ServiceKey("test.service", 1)
+
+
+async def _setup(_context: PluginContext) -> None:
+    return None
+
+
+def _plugin(
+    plugin_id: str,
+    *,
+    provides: tuple[ServiceKey, ...] = (),
+    requires: tuple[ServiceRequirement, ...] = (),
+    fields: tuple[InitFieldSpec, ...] = (),
+) -> PluginDefinition:
+    return PluginDefinition(
+        manifest=PluginManifest(
+            id=plugin_id,
+            name=plugin_id,
+            version="1.0.0",
+            provides=provides,
+            requires=requires,
+        ),
+        setup=_setup,
+        init_spec=PluginInitSpec(fields=fields),
+    )
+
+
+def test_initializer_selects_dependencies_and_runtime_routes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    definitions = {
+        "provider": _plugin("provider", provides=(_SERVICE,)),
+        "consumer": _plugin(
+            "consumer",
+            requires=(ServiceRequirement(_SERVICE),),
+            fields=(
+                InitFieldSpec(
+                    key="language",
+                    label="Language",
+                    kind=InitFieldKind.STRING,
+                    default="en",
+                ),
+            ),
+        ),
+    }
+    runtimes = {
+        "source": RuntimePlugin(
+            kind="source",
+            command=("source",),
+            init_spec=RuntimeInitSpec(default_id="source"),
+        ),
+        "agent": RuntimePlugin(
+            kind="agent",
+            command=("agent",),
+            agent_harness="native",
+            init_spec=RuntimeInitSpec(default_id="agent"),
+        ),
+        "secure": RuntimePlugin(
+            kind="secure",
+            command=("secure",),
+            init_spec=RuntimeInitSpec(
+                default_id="secure",
+                fields=(
+                    InitFieldSpec(
+                        key="token",
+                        label="Token",
+                        kind=InitFieldKind.SECRET,
+                        secret_environment="TEST_TOKEN",
+                    ),
+                ),
+            ),
+        ),
+    }
+    monkeypatch.setattr(
+        PluginManager,
+        "discover_installed",
+        classmethod(lambda _cls: (definitions, ("plugin 'broken' is unavailable",))),
+    )
+    monkeypatch.setattr(
+        RuntimeCatalog,
+        "discover_installed",
+        lambda _self: (runtimes, ("runtime 'broken' is unavailable",)),
+    )
+
+    def prompt(label: str, default: str) -> str:
+        if label.startswith("Enable plugin consumer"):
+            return "y"
+        if label.startswith("Enable runtime source"):
+            return "y"
+        if label.startswith("Enable runtime agent"):
+            return "y"
+        if label.startswith("Route messages from source"):
+            return "y"
+        return default
+
+    output: list[str] = []
+    plan = build_initialization_plan(prompt=prompt, output=output.append)
+    path = ConfigWorkspace(tmp_path).initialize(
+        data_dir=plan.data_dir,
+        cache_dir=plan.cache_dir,
+        logging_level=plan.logging_level,
+        payload_mode=plan.payload_mode,
+        payload_exclude_runtimes=plan.payload_exclude_runtimes,
+        plugins=plan.plugins,
+        plugin_config=plan.plugin_config,
+        runtimes=plan.runtimes,
+        runtime_event_routes=plan.runtime_event_routes,
+    )
+
+    settings = load_settings(path, environ={})
+    assert plan.plugins == ("provider", "consumer")
+    assert settings.plugins.config["consumer"]["language"] == "en"
+    assert set(settings.runtimes) == {"source", "agent"}
+    assert settings.runtime_event_routes[0].target == "agent"
+    assert any("secure vault" in item for item in output)
+
+
+def test_initializer_rejects_unavailable_required_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    definitions = {
+        "consumer": _plugin("consumer", requires=(ServiceRequirement(_SERVICE),)),
+    }
+    monkeypatch.setattr(PluginManager, "discover_installed", classmethod(lambda _cls: (definitions, ())))
+    monkeypatch.setattr(RuntimeCatalog, "discover_installed", lambda _self: ({}, ()))
+
+    def prompt(label: str, default: str) -> str:
+        return "y" if label.startswith("Enable plugin") else default
+
+    with pytest.raises(ValueError, match="unavailable service"):
+        build_initialization_plan(prompt=prompt, output=lambda _message: None)

--- a/tests/test_config_workspace.py
+++ b/tests/test_config_workspace.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 import liteyukibot.cli as cli_module
-from liteyukibot.config import ConfigUpgradeRequired, ConfigWorkspace, load_settings
+from liteyukibot.config import ConfigUpgradeRequired, ConfigurationError, ConfigWorkspace, load_settings
 
 
 def test_workspace_init_creates_current_valid_template(tmp_path: Path) -> None:
@@ -39,10 +39,13 @@ def test_outdated_workspace_config_is_backed_up_and_blocks_start(tmp_path: Path)
     assert "config_version = 1" in template.read_text(encoding="utf-8")
 
 
-def test_regular_workspace_without_config_does_not_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_regular_workspace_without_config_requires_initialization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(ConfigWorkspace, "is_docker", staticmethod(lambda: False))
 
-    assert ConfigWorkspace(tmp_path).prepare() is None
+    with pytest.raises(ConfigurationError, match="liteyuki init"):
+        ConfigWorkspace(tmp_path).prepare()
     assert not (tmp_path / "liteyuki.toml").exists()
 
 
@@ -53,6 +56,9 @@ def test_docker_workspace_without_config_initializes_once(tmp_path: Path, monkey
 
     assert path == tmp_path / "liteyuki.toml"
     assert path.is_file()
+    settings = load_settings(path, environ={})
+    assert settings.plugins.enabled == ()
+    assert settings.runtimes == {}
 
 
 def test_cli_init_noninteractive_writes_project_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1116,6 +1116,7 @@ version = "7.0.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
+    { name = "tomli-w" },
     { name = "yukilog" },
 ]
 
@@ -1141,6 +1142,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'http'", specifier = ">=0.141,<1" },
     { name = "pydantic", specifier = ">=2.13,<3" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6,<7" },
+    { name = "tomli-w", specifier = ">=1.2,<2" },
     { name = "uvicorn", marker = "extra == 'http'", specifier = ">=0.52,<1" },
     { name = "yukilog", specifier = ">=1,<2" },
 ]
@@ -2763,6 +2765,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add package-owned initialization metadata for native plugins and runtime packages
- generate project configuration from selected packages and validated dependency topology
- require explicit initialization outside Docker while preserving Docker's minimal bootstrap

## Verification
- uv run pytest -q
- uv run ruff check .
- uv run mypy
- uv build --all-packages