### PR TITLE
feat: add encrypted runtime secret vault

### DIFF
--- a/packages/agent/src/liteyukibot_agent/host.py
+++ b/packages/agent/src/liteyukibot_agent/host.py
@@ -151,7 +151,7 @@ async def run() -> None:
         logger.info("starting native agent runtime")
         options = await client.connect()
         state_directory = Path(os.environ["LITEYUKI_RUNTIME_STATE_DIR"])
-        api_key = _environment_secret(options, "api_key_env", "OPENAI_API_KEY")
+        api_key = _environment_secret(options, "api_key_env", "LITEYUKI_AGENT_API_KEY")
         engine = OpenAIChatEngine(
             api_key=api_key,
             base_url=_optional_string(options, "base_url"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
+    "cryptography>=46,<51",
     "pydantic>=2.13,<3",
     "tomli-w>=1.2,<2",
     "yukilog>=1,<2",

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -84,7 +84,13 @@ class _AppStatusProvider:
 class LiteyukiApp:
     """Own all v7 services and enforce deterministic startup and shutdown."""
 
-    def __init__(self, settings: AppSettings, *, logger: Logger | None = None) -> None:
+    def __init__(
+        self,
+        settings: AppSettings,
+        *,
+        logger: Logger | None = None,
+        runtime_secrets: Mapping[str, str] | None = None,
+    ) -> None:
         self.settings = settings
         self.logger = logger or get_logger(component="core")
         self.state = AppState.CREATED
@@ -93,6 +99,7 @@ class LiteyukiApp:
             logger=self.logger,
             event_sink=self._ingest_runtime_event,
             action_sink=self._execute_runtime_action,
+            secret_values=runtime_secrets,
         )
         self.runtimes.set_logging_settings(settings.logging)
         self.actions = ActionService(self.runtimes)
@@ -150,6 +157,7 @@ class LiteyukiApp:
                         **runtime.env,
                         "LITEYUKI_RUNTIME_STATE_DIR": str(state_directory),
                     },
+                    secret_env=runtime.secret_env,
                     handshake_timeout=runtime.handshake_timeout_seconds,
                     restart_limit=runtime.max_failures,
                     restart_window=runtime.failure_window_seconds,
@@ -158,9 +166,7 @@ class LiteyukiApp:
                     stale_after=runtime.stale_after_seconds,
                     max_inbound_events=runtime.max_inbound_events,
                     agent_harness=(
-                        runtime_plugins[runtime.kind].agent_harness
-                        if runtime.kind in runtime_plugins
-                        else None
+                        runtime_plugins[runtime.kind].agent_harness if runtime.kind in runtime_plugins else None
                     ),
                 )
             )
@@ -275,12 +281,8 @@ class LiteyukiApp:
             version=__version__,
             state=self.state.value,
             uptime_seconds=self._uptime_seconds(),
-            plugins={
-                plugin_id: plugin.state.value for plugin_id, plugin in self.plugins.loaded.items()
-            },
-            runtimes={
-                runtime_id: record.state.value for runtime_id, record in self.runtimes.records.items()
-            },
+            plugins={plugin_id: plugin.state.value for plugin_id, plugin in self.plugins.loaded.items()},
+            runtimes={runtime_id: record.state.value for runtime_id, record in self.runtimes.records.items()},
             events_outstanding=self.events.outstanding,
         )
 
@@ -355,9 +357,7 @@ class LiteyukiApp:
         result = await self.events.publish(event)
         return "accepted" if result.status == "processed" else result.status
 
-    async def _execute_runtime_action(
-        self, source_runtime_id: str, payload: dict[str, Any]
-    ) -> ActionSinkResult:
+    async def _execute_runtime_action(self, source_runtime_id: str, payload: dict[str, Any]) -> ActionSinkResult:
         try:
             action = ActionEnvelope.model_validate(payload)
         except ValueError as error:
@@ -381,9 +381,7 @@ class LiteyukiApp:
         routes = list(settings.runtime_event_routes)
         configured_targets = {route.target for route in routes}
         runtime_plugins = RuntimeCatalog().discover()
-        enabled_ids = tuple(
-            runtime_id for runtime_id, runtime in settings.runtimes.items() if runtime.enabled
-        )
+        enabled_ids = tuple(runtime_id for runtime_id, runtime in settings.runtimes.items() if runtime.enabled)
         for runtime_id, runtime in settings.runtimes.items():
             plugin = runtime_plugins.get(runtime.kind)
             if (
@@ -500,9 +498,7 @@ class LiteyukiApp:
         )
         if result.status != "accepted":
             detail = f": {result.detail}" if result.detail else ""
-            raise RuntimeError(
-                f"runtime {runtime_id} rejected event {event.id} as {result.status}{detail}"
-            )
+            raise RuntimeError(f"runtime {runtime_id} rejected event {event.id} as {result.status}{detail}")
 
     @staticmethod
     def _plugin_configs(config: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:

--- a/src/liteyukibot/cli.py
+++ b/src/liteyukibot/cli.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import getpass
 import json
+import os
 import signal
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from . import __version__
 from .app import LiteyukiApp
 from .config import AppSettings, ConfigurationError, ConfigWorkspace, load_settings
 from .config.initializer import build_initialization_plan
+from .config.vault import SecretVault
 from .control import ControlError, request_control
 from .exceptions import LiteyukiError
 
@@ -30,7 +33,19 @@ def build_parser() -> argparse.ArgumentParser:
     init.add_argument("--non-interactive", action="store_true")
 
     config = subcommands.add_parser("config", help="configuration operations")
-    config.add_subparsers(dest="config_command", required=True).add_parser("validate")
+    config_commands = config.add_subparsers(dest="config_command", required=True)
+    config_commands.add_parser("validate")
+    upgrade = config_commands.add_parser("upgrade")
+    upgrade.add_argument("--refresh", action="store_true")
+
+    vault = subcommands.add_parser("vault", help="encrypted secret vault operations")
+    vault_commands = vault.add_subparsers(dest="vault_command", required=True)
+    vault_set = vault_commands.add_parser("set")
+    vault_set.add_argument("name")
+    vault_delete = vault_commands.add_parser("delete")
+    vault_delete.add_argument("name")
+    vault_commands.add_parser("list")
+    vault_commands.add_parser("rotate")
 
     plugin = subcommands.add_parser("plugin", help="plugin operations")
     plugin.add_subparsers(dest="plugin_command", required=True).add_parser("list")
@@ -51,9 +66,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         if args.command == "init":
             return _init(args.non_interactive)
+        if args.command == "config" and args.config_command == "upgrade":
+            return _upgrade(args.refresh)
+        if args.command == "vault":
+            return _vault(args)
         settings = _load(args.config, args.overrides)
         if args.command == "run":
-            return _run(settings)
+            return _run(settings, _runtime_secrets(settings))
         if args.command in {"check", "config"}:
             if args.command == "check":
                 _check(settings)
@@ -87,7 +106,11 @@ def _init(non_interactive: bool) -> int:
         plan = build_initialization_plan(
             prompt=_prompt,
             output=lambda message: print(message, file=sys.stderr),
+            secret_prompt=_prompt_secret,
         )
+        if plan.secrets:
+            vault = SecretVault(workspace.management_directory)
+            vault.initialize(_vault_password(workspace, create=True), plan.secrets)
         path = workspace.initialize(
             data_dir=plan.data_dir,
             cache_dir=plan.cache_dir,
@@ -103,12 +126,82 @@ def _init(non_interactive: bool) -> int:
     return 0
 
 
+def _upgrade(refresh: bool) -> int:
+    result = ConfigWorkspace().upgrade(refresh=refresh)
+    if result is None:
+        print("configuration is current")
+    return 0
+
+
+def _vault(args: argparse.Namespace) -> int:
+    workspace = ConfigWorkspace()
+    workspace.prepare()
+    vault = SecretVault(workspace.management_directory)
+    if args.vault_command == "set":
+        password = _vault_password(workspace, create=not vault.path.exists())
+        vault.set(password, args.name, _prompt_secret(f"Secret value for {args.name}"))
+        print(f"stored secret {args.name}")
+        return 0
+    if args.vault_command == "delete":
+        deleted = vault.delete(_vault_password(workspace), args.name)
+        if not deleted:
+            raise ValueError(f"secret {args.name!r} does not exist")
+        print(f"deleted secret {args.name}")
+        return 0
+    if args.vault_command == "list":
+        for name in vault.list_names(_vault_password(workspace)):
+            print(name)
+        return 0
+    if args.vault_command == "rotate":
+        password = _vault_password(workspace)
+        vault.rotate(password, _vault_password(workspace, create=True))
+        print("vault password rotated")
+        return 0
+    raise RuntimeError(f"unknown vault command: {args.vault_command}")
+
+
 def _prompt(label: str, default: str) -> str:
     try:
         value = input(f"{label} [{default}]: ").strip()
     except EOFError:
         return default
     return value or default
+
+
+def _prompt_secret(label: str) -> str:
+    value = getpass.getpass(f"{label}: ")
+    if not value:
+        raise ValueError(f"{label} must not be empty")
+    return value
+
+
+def _vault_password(workspace: ConfigWorkspace, *, create: bool = False) -> str:
+    if workspace.is_docker():
+        value = os.environ.get("LITEYUKI_VAULT_PASSWORD", "")
+        if not value:
+            raise ValueError("LITEYUKI_VAULT_PASSWORD is required for Docker secret vault access")
+        return value
+    value = _prompt_secret("Vault password" if not create else "New vault password")
+    if create and value != _prompt_secret("Confirm vault password"):
+        raise ValueError("vault passwords do not match")
+    return value
+
+
+def _runtime_secrets(settings: AppSettings) -> dict[str, str]:
+    names = {
+        secret_name
+        for runtime in settings.runtimes.values()
+        if runtime.enabled
+        for secret_name in runtime.secret_env.values()
+    }
+    if not names:
+        return {}
+    workspace = ConfigWorkspace()
+    values = SecretVault(workspace.management_directory).read(_vault_password(workspace))
+    missing = sorted(names - values.keys())
+    if missing:
+        raise ValueError(f"secret vault is missing required secrets: {', '.join(missing)}")
+    return {name: values[name] for name in names}
 
 
 def _check(settings: AppSettings) -> None:
@@ -125,18 +218,18 @@ def _list_plugins(settings: AppSettings) -> None:
         print(f"{manifest.id}\t{manifest.version}\t{manifest.name}")
 
 
-def _run(settings: AppSettings) -> int:
+def _run(settings: AppSettings, runtime_secrets: Mapping[str, str]) -> int:
     try:
-        asyncio.run(_run_until_signal(settings))
+        asyncio.run(_run_until_signal(settings, runtime_secrets))
     except KeyboardInterrupt:
         return 130
     return 0
 
 
-async def _run_until_signal(settings: AppSettings) -> None:
+async def _run_until_signal(settings: AppSettings, runtime_secrets: Mapping[str, str] | None = None) -> None:
     """Run the app until SIGINT/SIGTERM and always perform graceful cleanup."""
 
-    app = LiteyukiApp(settings)
+    app = LiteyukiApp(settings) if runtime_secrets is None else LiteyukiApp(settings, runtime_secrets=runtime_secrets)
     stop_event = asyncio.Event()
     loop = asyncio.get_running_loop()
     async_handlers: list[signal.Signals] = []

--- a/src/liteyukibot/config/__init__.py
+++ b/src/liteyukibot/config/__init__.py
@@ -11,6 +11,7 @@ from .models import (
     RuntimeSettings,
 )
 from .template import CONFIG_VERSION, render_config_template
+from .vault import SecretVault, VaultError
 from .workspace import ConfigUpgradeRequired, ConfigWorkspace
 
 __all__ = (
@@ -27,6 +28,8 @@ __all__ = (
     "PluginSettings",
     "RuntimeEventRoute",
     "RuntimeSettings",
+    "SecretVault",
+    "VaultError",
     "load_settings",
     "render_config_template",
 )

--- a/src/liteyukibot/config/initializer.py
+++ b/src/liteyukibot/config/initializer.py
@@ -14,6 +14,7 @@ from ..status import KERNEL_STATUS_SERVICE
 
 Prompt = Callable[[str, str], str]
 Output = Callable[[str], None]
+SecretPrompt = Callable[[str], str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,10 +30,16 @@ class InitializationPlan:
     plugin_config: dict[str, dict[str, Any]]
     runtimes: dict[str, dict[str, Any]]
     runtime_event_routes: tuple[dict[str, Any], ...]
+    secrets: dict[str, str]
     diagnostics: tuple[str, ...]
 
 
-def build_initialization_plan(*, prompt: Prompt, output: Output) -> InitializationPlan:
+def build_initialization_plan(
+    *,
+    prompt: Prompt,
+    output: Output,
+    secret_prompt: SecretPrompt | None = None,
+) -> InitializationPlan:
     """Collect a safe configuration using only package-owned initialization metadata."""
 
     data_dir = prompt("Data directory", "data")
@@ -49,7 +56,12 @@ def build_initialization_plan(*, prompt: Prompt, output: Output) -> Initializati
 
     selected_plugins = _select_plugins(plugin_definitions, prompt=prompt, output=output)
     plugin_config = _collect_plugin_config(selected_plugins, plugin_definitions, prompt=prompt)
-    runtimes = _select_runtimes(runtime_plugins, prompt=prompt, output=output)
+    runtimes, secrets = _select_runtimes(
+        runtime_plugins,
+        prompt=prompt,
+        output=output,
+        secret_prompt=secret_prompt,
+    )
     routes = _collect_agent_routes(runtimes, runtime_plugins, prompt=prompt)
 
     return InitializationPlan(
@@ -62,6 +74,7 @@ def build_initialization_plan(*, prompt: Prompt, output: Output) -> Initializati
         plugin_config=plugin_config,
         runtimes=runtimes,
         runtime_event_routes=routes,
+        secrets=secrets,
         diagnostics=diagnostics,
     )
 
@@ -163,14 +176,17 @@ def _select_runtimes(
     *,
     prompt: Prompt,
     output: Output,
-) -> dict[str, dict[str, Any]]:
+    secret_prompt: SecretPrompt | None,
+) -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
     runtimes: dict[str, dict[str, Any]] = {}
+    secrets: dict[str, str] = {}
     for kind, plugin in sorted(plugins.items()):
         spec = plugin.init_spec
         if spec is None:
             output(f"warning: runtime {kind!r} has no initialization metadata and was skipped")
             continue
-        if any(field.kind is InitFieldKind.SECRET for field in spec.fields):
+        secret_fields = tuple(field for field in spec.fields if field.kind is InitFieldKind.SECRET)
+        if secret_fields and secret_prompt is None:
             output(f"runtime {kind!r} requires the secure vault and was skipped during this initialization")
             continue
         if not _confirm(prompt, f"Enable runtime {kind}", default=False):
@@ -180,6 +196,19 @@ def _select_runtimes(
             raise ValueError(f"runtime initialization id collision: {runtime_id}")
         options = dict(spec.default_options)
         options.update(_collect_fields(spec.fields, prompt=prompt, subject=f"Runtime {kind}"))
+        secret_env: dict[str, str] = {}
+        if secret_fields:
+            assert secret_prompt is not None
+            for field in secret_fields:
+                secret_name = f"runtime.{runtime_id}.{field.key}"
+                secret_value = secret_prompt(f"Runtime {kind}: {field.label}")
+                if not secret_value and field.required:
+                    raise ValueError(f"Runtime {kind}: {field.label} is required")
+                if secret_value:
+                    secrets[secret_name] = secret_value
+                    options[field.key] = secret_name
+                    assert field.secret_environment is not None
+                    secret_env[field.secret_environment] = secret_name
         runtimes[runtime_id] = {
             "kind": kind,
             "enabled": True,
@@ -187,8 +216,9 @@ def _select_runtimes(
             "stale_after_seconds": 30.0,
             "max_inbound_events": 100,
             "options": options,
+            "secret_env": secret_env,
         }
-    return runtimes
+    return runtimes, secrets
 
 
 def _collect_agent_routes(

--- a/src/liteyukibot/config/models.py
+++ b/src/liteyukibot/config/models.py
@@ -114,6 +114,7 @@ class RuntimeSettings(FrozenSettingsModel):
     command: tuple[str, ...] = ()
     working_directory: Path | None = None
     env: Mapping[str, str] = Field(default_factory=dict)
+    secret_env: Mapping[str, str] = Field(default_factory=dict)
     options: Mapping[str, JsonValue] = Field(default_factory=dict)
     handshake_timeout_seconds: float = Field(default=10.0, gt=0)
     ready_timeout_seconds: float = Field(default=30.0, gt=0)
@@ -142,6 +143,19 @@ class RuntimeSettings(FrozenSettingsModel):
     def freeze_env(cls, value: Mapping[str, str]) -> Mapping[str, str]:
         return MappingProxyType(dict(value))
 
+    @field_validator("secret_env", mode="after")
+    @classmethod
+    def freeze_secret_env(cls, value: Mapping[str, str]) -> Mapping[str, str]:
+        if any(
+            not environment_name
+            or environment_name != environment_name.strip()
+            or not secret_name
+            or secret_name != secret_name.strip()
+            for environment_name, secret_name in value.items()
+        ):
+            raise ValueError("runtime secret environment mappings must use non-empty trimmed names")
+        return MappingProxyType(dict(value))
+
     @field_validator("options", mode="after")
     @classmethod
     def freeze_options(cls, value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
@@ -149,6 +163,10 @@ class RuntimeSettings(FrozenSettingsModel):
 
     @field_serializer("env")
     def serialize_env(self, value: Mapping[str, str]) -> dict[str, str]:
+        return dict(value)
+
+    @field_serializer("secret_env")
+    def serialize_secret_env(self, value: Mapping[str, str]) -> dict[str, str]:
         return dict(value)
 
     @field_serializer("options")
@@ -243,11 +261,7 @@ class AppSettings(FrozenSettingsModel):
 
     @model_validator(mode="after")
     def validate_runtime_event_routes(self) -> AppSettings:
-        enabled = {
-            runtime_id
-            for runtime_id, runtime in self.runtimes.items()
-            if runtime.enabled
-        }
+        enabled = {runtime_id for runtime_id, runtime in self.runtimes.items() if runtime.enabled}
         routes: set[tuple[tuple[str, ...], str, bool]] = set()
         for route in self.runtime_event_routes:
             if route.target not in self.runtimes:

--- a/src/liteyukibot/config/vault.py
+++ b/src/liteyukibot/config/vault.py
@@ -1,0 +1,210 @@
+"""Authenticated local secret vaults for runtime child processes."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import secrets
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from ..exceptions import LiteyukiError
+
+_FORMAT_VERSION = 1
+_AAD = b"liteyukibot.secrets.v1"
+_KEY_LENGTH = 32
+_SALT_LENGTH = 16
+_NONCE_LENGTH = 12
+_MAX_KDF_MEMORY = 64 * 1024 * 1024
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class VaultError(LiteyukiError):
+    """Raised for a vault failure without ever including secret material."""
+
+
+class SecretVault:
+    """Encrypt named strings in the local secrets.v1.json file."""
+
+    filename = "secrets.v1.json"
+
+    def __init__(self, directory: str | os.PathLike[str]) -> None:
+        self.directory = Path(directory).resolve()
+        self.path = self.directory / self.filename
+
+    def initialize(self, password: str, values: Mapping[str, str] = {}) -> None:
+        if self.path.exists():
+            raise VaultError(f"secret vault already exists: {self.path}")
+        self._write(password, self._validate_values(values))
+
+    def read(self, password: str) -> dict[str, str]:
+        try:
+            raw = self.path.read_bytes()
+        except OSError as error:
+            raise VaultError(f"cannot read secret vault: {self.path}") from error
+        try:
+            document = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise VaultError("secret vault has an invalid JSON format") from error
+        return self._decrypt_document(document, password)
+
+    def set(self, password: str, name: str, value: str) -> None:
+        values = self.read(password) if self.path.exists() else {}
+        values[name] = value
+        self._write(password, self._validate_values(values))
+
+    def delete(self, password: str, name: str) -> bool:
+        values = self.read(password)
+        if name not in values:
+            return False
+        del values[name]
+        self._write(password, values)
+        return True
+
+    def list_names(self, password: str) -> tuple[str, ...]:
+        return tuple(sorted(self.read(password)))
+
+    def rotate(self, password: str, replacement_password: str) -> None:
+        self._write(replacement_password, self.read(password))
+
+    @classmethod
+    def _validate_values(cls, values: Mapping[str, str]) -> dict[str, str]:
+        result: dict[str, str] = {}
+        for name, value in values.items():
+            if not isinstance(name, str) or not _IDENTIFIER.fullmatch(name):
+                raise VaultError("secret name must use letters, digits, dots, underscores, or hyphens")
+            if not isinstance(value, str) or not value:
+                raise VaultError(f"secret {name!r} must be a non-empty string")
+            result[name] = value
+        return result
+
+    def _write(self, password: str, values: Mapping[str, str]) -> None:
+        encoded_password = self._password_bytes(password)
+        salt = secrets.token_bytes(_SALT_LENGTH)
+        kdf = {"name": "scrypt", "salt": _encode(salt), "n": 16384, "r": 8, "p": 1}
+        key = self._derive(encoded_password, kdf)
+        nonce = secrets.token_bytes(_NONCE_LENGTH)
+        plaintext = json.dumps(dict(values), ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ciphertext = AESGCM(key).encrypt(nonce, plaintext, _AAD)
+        document = {
+            "version": _FORMAT_VERSION,
+            "kdf": kdf,
+            "cipher": {
+                "name": "AES-256-GCM",
+                "nonce": _encode(nonce),
+                "ciphertext": _encode(ciphertext),
+            },
+        }
+        self.directory.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_name(f".{self.path.name}.{secrets.token_hex(8)}.tmp")
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(descriptor, "wb") as output:
+                descriptor = -1
+                output.write(
+                    json.dumps(document, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+                )
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temporary, self.path)
+            try:
+                os.chmod(self.path, 0o600)
+            except OSError:
+                pass
+        finally:
+            if descriptor != -1:
+                os.close(descriptor)
+            if temporary.exists():
+                temporary.unlink()
+
+    def _decrypt_document(self, document: Any, password: str) -> dict[str, str]:
+        if not isinstance(document, Mapping) or document.get("version") != _FORMAT_VERSION:
+            raise VaultError("secret vault has an unsupported format version")
+        kdf = document.get("kdf")
+        cipher = document.get("cipher")
+        if not isinstance(kdf, Mapping) or not isinstance(cipher, Mapping):
+            raise VaultError("secret vault is missing required encryption metadata")
+        if cipher.get("name") != "AES-256-GCM":
+            raise VaultError("secret vault uses an unsupported cipher")
+        nonce = _decode(cipher.get("nonce"), "cipher nonce")
+        ciphertext = _decode(cipher.get("ciphertext"), "ciphertext")
+        if len(nonce) != _NONCE_LENGTH or len(ciphertext) <= 16:
+            raise VaultError("secret vault contains invalid authenticated ciphertext")
+        key = self._derive(self._password_bytes(password), kdf)
+        try:
+            plaintext = AESGCM(key).decrypt(nonce, ciphertext, _AAD)
+        except InvalidTag as error:
+            raise VaultError("secret vault password is incorrect or vault data was modified") from error
+        try:
+            values = json.loads(plaintext.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise VaultError("secret vault plaintext is invalid") from error
+        if not isinstance(values, Mapping):
+            raise VaultError("secret vault plaintext must be an object")
+        return self._validate_values(values)
+
+    @staticmethod
+    def _password_bytes(password: str) -> bytes:
+        if not isinstance(password, str) or not password:
+            raise VaultError("vault password must not be empty")
+        return password.encode("utf-8")
+
+    @staticmethod
+    def _derive(password: bytes, kdf: Mapping[str, Any]) -> bytes:
+        if kdf.get("name") != "scrypt":
+            raise VaultError("secret vault uses an unsupported key derivation function")
+        salt = _decode(kdf.get("salt"), "KDF salt")
+        n = kdf.get("n")
+        r = kdf.get("r")
+        p = kdf.get("p")
+        if (
+            not isinstance(n, int)
+            or isinstance(n, bool)
+            or n < 2**14
+            or n > 2**18
+            or n & (n - 1)
+            or not isinstance(r, int)
+            or isinstance(r, bool)
+            or not 1 <= r <= 64
+            or not isinstance(p, int)
+            or isinstance(p, bool)
+            or not 1 <= p <= 16
+            or not _SALT_LENGTH <= len(salt) <= 64
+            or 128 * n * r > _MAX_KDF_MEMORY // 2
+        ):
+            raise VaultError("secret vault contains unsafe KDF parameters")
+        try:
+            return hashlib.scrypt(
+                password,
+                salt=salt,
+                n=n,
+                r=r,
+                p=p,
+                dklen=_KEY_LENGTH,
+                maxmem=_MAX_KDF_MEMORY,
+            )
+        except ValueError as error:
+            raise VaultError("secret vault KDF parameters are unavailable on this system") from error
+
+
+def _encode(value: bytes) -> str:
+    return base64.b64encode(value).decode("ascii")
+
+
+def _decode(value: Any, name: str) -> bytes:
+    if not isinstance(value, str):
+        raise VaultError(f"secret vault {name} must be base64 text")
+    try:
+        return base64.b64decode(value.encode("ascii"), validate=True)
+    except (UnicodeEncodeError, ValueError) as error:
+        raise VaultError(f"secret vault {name} is not valid base64") from error
+
+
+__all__ = ["SecretVault", "VaultError"]

--- a/src/liteyukibot/config/workspace.py
+++ b/src/liteyukibot/config/workspace.py
@@ -12,7 +12,7 @@ from typing import Any
 from ..exceptions import LiteyukiError
 from .errors import ConfigIssue, ConfigurationError
 from .loader import load_settings
-from .models import LoggingSettings
+from .models import AppSettings, LoggingSettings
 from .template import CONFIG_VERSION, render_config_template
 
 
@@ -50,18 +50,37 @@ class ConfigWorkspace:
         document = self._read_root_document()
         version = document.get("config_version")
         if not isinstance(version, int) or isinstance(version, bool):
-            self._validate_current_file()
-            self._write_upgrade_material(version=None)
-            raise AssertionError("unreachable")
+            self._upgrade(version=None, refresh=False)
         assert isinstance(version, int)
         if version > CONFIG_VERSION:
             raise ConfigurationError(
                 [ConfigIssue(self.path, f"config_version {version} is newer than this kernel ({CONFIG_VERSION})")]
             )
         if version < CONFIG_VERSION:
-            self._validate_current_file()
-            self._write_upgrade_material(version=version)
+            self._upgrade(version=version, refresh=False)
         return self.path
+
+    def upgrade(self, *, refresh: bool = False) -> Path | None:
+        """Generate upgrade material for an older root configuration."""
+
+        if not self.path.exists():
+            raise ConfigurationError(
+                [ConfigIssue(self.path, "project configuration is missing; run liteyuki init first")]
+            )
+        if not self.path.is_file():
+            raise ConfigurationError([ConfigIssue(self.path, "project configuration path is not a file")])
+        document = self._read_root_document()
+        version = document.get("config_version")
+        if not isinstance(version, int) or isinstance(version, bool):
+            self._upgrade(version=None, refresh=refresh)
+        assert isinstance(version, int)
+        if version > CONFIG_VERSION:
+            raise ConfigurationError(
+                [ConfigIssue(self.path, f"config_version {version} is newer than this kernel ({CONFIG_VERSION})")]
+            )
+        if version < CONFIG_VERSION:
+            self._upgrade(version=version, refresh=refresh)
+        return None
 
     def initialize(
         self,
@@ -86,20 +105,19 @@ class ConfigWorkspace:
             }
         )
         self.directory.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(
-            render_config_template(
-                data_dir=data_dir,
-                cache_dir=cache_dir,
-                logging_level=logging.level,
-                payload_mode=logging.payload_mode,
-                payload_exclude_runtimes=logging.payload_exclude_runtimes,
-                plugins=plugins,
-                plugin_config=plugin_config,
-                runtimes=runtimes,
-                runtime_event_routes=runtime_event_routes,
-            ),
-            encoding="utf-8",
+        rendered = render_config_template(
+            data_dir=data_dir,
+            cache_dir=cache_dir,
+            logging_level=logging.level,
+            payload_mode=logging.payload_mode,
+            payload_exclude_runtimes=logging.payload_exclude_runtimes,
+            plugins=plugins,
+            plugin_config=plugin_config,
+            runtimes=runtimes,
+            runtime_event_routes=runtime_event_routes,
         )
+        AppSettings.model_validate(tomllib.loads(rendered))
+        self.path.write_text(rendered, encoding="utf-8")
         return self.path
 
     def _read_root_document(self) -> dict[str, Any]:
@@ -116,13 +134,23 @@ class ConfigWorkspace:
         return value
 
     def _validate_current_file(self) -> None:
-        load_settings(self.path, environ={})
+        load_settings(self.path, environ={}, cli_overrides={"config_version": CONFIG_VERSION})
 
-    def _write_upgrade_material(self, *, version: int | None) -> None:
-        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    def _upgrade(self, *, version: int | None, refresh: bool) -> None:
+        self._validate_current_file()
+        self._write_upgrade_material(version=version, refresh=refresh)
+
+    def _write_upgrade_material(self, *, version: int | None, refresh: bool) -> None:
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
         backup = self.management_directory / "config-backups" / timestamp / self.filename
         upgrade_directory = self.management_directory / "config-upgrades"
         upgrade = upgrade_directory / f"liteyuki.v{CONFIG_VERSION}.toml"
+        if upgrade.exists() and not refresh:
+            found = "missing" if version is None else str(version)
+            raise ConfigUpgradeRequired(
+                f"configuration version {found} requires manual upgrade to {CONFIG_VERSION}; "
+                f"existing template: {upgrade}"
+            )
         backup.parent.mkdir(parents=True, exist_ok=True)
         upgrade_directory.mkdir(parents=True, exist_ok=True)
         shutil.copy2(self.path, backup)

--- a/src/liteyukibot/runtime/supervisor.py
+++ b/src/liteyukibot/runtime/supervisor.py
@@ -82,6 +82,7 @@ class RuntimeSpec:
     command: Sequence[str] | None = None
     working_directory: str | Path | None = None
     env: Mapping[str, str] = field(default_factory=dict)
+    secret_env: Mapping[str, str] = field(default_factory=dict)
     handshake_timeout: float = 10.0
     restart_limit: int = 5
     restart_window: float = 60.0
@@ -103,9 +104,7 @@ class RuntimeSpec:
             raise ValueError("runtime stale_after must exceed its positive heartbeat interval")
         if self.max_inbound_events < 1:
             raise ValueError("runtime max_inbound_events must be at least 1")
-        if self.command is not None and (
-            not self.command or any(not part for part in self.command)
-        ):
+        if self.command is not None and (not self.command or any(not part for part in self.command)):
             raise ValueError("runtime command arguments must not be empty")
         if self.agent_harness is not None and (
             not self.agent_harness or self.agent_harness != self.agent_harness.strip()
@@ -149,11 +148,13 @@ class RuntimeSupervisor:
         event_sink: EventSink | None = None,
         action_sink: ActionSink | None = None,
         agent_tool_sink: AgentToolSink | None = None,
+        secret_values: Mapping[str, str] | None = None,
     ) -> None:
         self.logger = logger
         self.event_sink = event_sink
         self.action_sink = action_sink
         self.agent_tool_sink = agent_tool_sink
+        self.secret_values = dict(secret_values or {})
         self.records: dict[str, RuntimeRecord] = {}
         self._server: asyncio.Server | None = None
         self._host = "127.0.0.1"
@@ -229,8 +230,7 @@ class RuntimeSupervisor:
             self.logger.bind(runtime=record.spec.id, component="runtime").info(
                 "starting {} runtime (attempt {})", record.spec.kind, record.launch_count + 1
             )
-            env = os.environ.copy()
-            env.update(record.spec.env)
+            env = self._child_environment(record)
             env.update(
                 {
                     "LITEYUKI_RUNTIME_HOST": self._host,
@@ -282,9 +282,7 @@ class RuntimeSupervisor:
                 return
             if not self._register_failure(record):
                 return
-            self.logger.warning(
-                "runtime {} exited with {}; restarting in {:.1f}s", record.spec.id, exit_code, delay
-            )
+            self.logger.warning("runtime {} exited with {}; restarting in {:.1f}s", record.spec.id, exit_code, delay)
             await asyncio.sleep(delay)
             delay = min(delay * 2, 30.0)
 
@@ -298,6 +296,21 @@ class RuntimeSupervisor:
             record.state = RuntimeState.FAILED
             return False
         return True
+
+    def _child_environment(self, record: RuntimeRecord) -> dict[str, str]:
+        """Construct a child-only environment without retaining vault credentials."""
+
+        env = os.environ.copy()
+        env.pop("LITEYUKI_VAULT_PASSWORD", None)
+        env.update(record.spec.env)
+        for environment_name, secret_name in record.spec.secret_env.items():
+            try:
+                env[environment_name] = self.secret_values[secret_name]
+            except KeyError as error:
+                raise RuntimeError(
+                    f"runtime {record.spec.id} requires unavailable secret {secret_name!r}"
+                ) from error
+        return env
 
     @staticmethod
     def _default_command(spec: RuntimeSpec) -> tuple[str, ...]:
@@ -333,7 +346,7 @@ class RuntimeSupervisor:
             )
             await self._send(record, ConfigMessage(options=json_mapping(record.spec.options)))
             await self._receive_loop(record)
-        except (EOFError, ConnectionError):
+        except EOFError, ConnectionError:
             pass
         except BaseException as exc:
             self.logger.error("runtime connection rejected: {}", exc)
@@ -444,14 +457,12 @@ class RuntimeSupervisor:
                     detail=detail,
                 ),
             )
-        except (ConnectionError, RuntimeError):
+        except ConnectionError, RuntimeError:
             pass
         finally:
             record.inbound_events.pop(message.correlation_id, None)
 
-    async def _accept_child_action(
-        self, record: RuntimeRecord, request: ActionRequest
-    ) -> None:
+    async def _accept_child_action(self, record: RuntimeRecord, request: ActionRequest) -> None:
         if record.protocol_version != 3:
             await self._reject_child_action(
                 record,
@@ -483,9 +494,7 @@ class RuntimeSupervisor:
         )
         record.inbound_actions[request.correlation_id] = task
 
-    async def _execute_child_action(
-        self, record: RuntimeRecord, request: ActionRequest
-    ) -> None:
+    async def _execute_child_action(self, record: RuntimeRecord, request: ActionRequest) -> None:
         try:
             assert self.action_sink is not None
             result = await self.action_sink(record.spec.id, request.payload)
@@ -509,7 +518,7 @@ class RuntimeSupervisor:
             )
         try:
             await self._send(record, response)
-        except (ConnectionError, RuntimeError):
+        except ConnectionError, RuntimeError:
             pass
         finally:
             record.inbound_actions.pop(request.correlation_id, None)
@@ -529,9 +538,7 @@ class RuntimeSupervisor:
             ),
         )
 
-    async def _accept_agent_tool_request(
-        self, record: RuntimeRecord, request: AgentToolRequest
-    ) -> None:
+    async def _accept_agent_tool_request(self, record: RuntimeRecord, request: AgentToolRequest) -> None:
         self._clear_expired_delivery_contexts(record)
         if record.protocol_version != 3:
             await self._reject_agent_tool_request(record, request, "agent tools require runtime protocol v3")
@@ -540,9 +547,7 @@ class RuntimeSupervisor:
             await self._reject_agent_tool_request(record, request, "runtime is not an agent harness")
             return
         if "agent.tools.execute" not in record.capabilities:
-            await self._reject_agent_tool_request(
-                record, request, "child runtime did not declare agent.tools.execute"
-            )
+            await self._reject_agent_tool_request(record, request, "child runtime did not declare agent.tools.execute")
             return
         delivery_context = record.active_delivery_contexts.get(request.delivery_correlation_id)
         if delivery_context is None:
@@ -564,9 +569,7 @@ class RuntimeSupervisor:
         )
         record.inbound_agent_tools[request.correlation_id] = task
 
-    async def _execute_agent_tool_request(
-        self, record: RuntimeRecord, request: AgentToolRequest
-    ) -> None:
+    async def _execute_agent_tool_request(self, record: RuntimeRecord, request: AgentToolRequest) -> None:
         try:
             assert self.agent_tool_sink is not None
             _deadline, payload = record.active_delivery_contexts[request.delivery_correlation_id]
@@ -584,9 +587,7 @@ class RuntimeSupervisor:
                 error=result.error,
             )
         except Exception as error:
-            self.logger.error(
-                "runtime {} agent tool {} failed: {}", record.spec.id, request.tool_id, error
-            )
+            self.logger.error("runtime {} agent tool {} failed: {}", record.spec.id, request.tool_id, error)
             response = AgentToolResponse(
                 correlation_id=request.correlation_id,
                 ok=False,
@@ -594,7 +595,7 @@ class RuntimeSupervisor:
             )
         try:
             await self._send(record, response)
-        except (ConnectionError, RuntimeError):
+        except ConnectionError, RuntimeError:
             pass
         finally:
             record.inbound_agent_tools.pop(request.correlation_id, None)
@@ -739,7 +740,7 @@ class RuntimeSupervisor:
         if record.writer is not None:
             try:
                 await self._send(record, Shutdown(reason=reason))
-            except (ConnectionError, RuntimeError):
+            except ConnectionError, RuntimeError:
                 pass
         process = record.process
         if process is None:
@@ -777,15 +778,11 @@ class RuntimeSupervisor:
         record.active_delivery_contexts.clear()
         for action_future in record.pending_actions.values():
             if not action_future.done():
-                action_future.set_exception(
-                    ConnectionError(f"runtime {record.spec.id} disconnected")
-                )
+                action_future.set_exception(ConnectionError(f"runtime {record.spec.id} disconnected"))
         record.pending_actions.clear()
         for event_future in record.pending_events.values():
             if not event_future.done():
-                event_future.set_exception(
-                    ConnectionError(f"runtime {record.spec.id} disconnected")
-                )
+                event_future.set_exception(ConnectionError(f"runtime {record.spec.id} disconnected"))
         record.pending_events.clear()
         record.pending_event_payloads.clear()
         inbound_actions = tuple(record.inbound_actions.values())
@@ -810,9 +807,7 @@ class RuntimeSupervisor:
             writer.close()
             await writer.wait_closed()
 
-    async def _capture_output(
-        self, record: RuntimeRecord, stream: asyncio.StreamReader, channel: str
-    ) -> None:
+    async def _capture_output(self, record: RuntimeRecord, stream: asyncio.StreamReader, channel: str) -> None:
         logger = self.logger.bind(
             runtime=record.spec.id,
             component="runtime",

--- a/tests/test_config_initializer.py
+++ b/tests/test_config_initializer.py
@@ -138,3 +138,38 @@ def test_initializer_rejects_unavailable_required_provider(monkeypatch: pytest.M
 
     with pytest.raises(ValueError, match="unavailable service"):
         build_initialization_plan(prompt=prompt, output=lambda _message: None)
+
+
+def test_initializer_collects_runtime_secrets_without_storing_plaintext(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = RuntimePlugin(
+        kind="agent",
+        command=("agent",),
+        init_spec=RuntimeInitSpec(
+            default_id="agent",
+            fields=(
+                InitFieldSpec(
+                    key="api_key_secret",
+                    label="API key",
+                    kind=InitFieldKind.SECRET,
+                    required=True,
+                    secret_environment="LITEYUKI_AGENT_API_KEY",
+                ),
+            ),
+        ),
+    )
+    monkeypatch.setattr(PluginManager, "discover_installed", classmethod(lambda _cls: ({}, ())))
+    monkeypatch.setattr(RuntimeCatalog, "discover_installed", lambda _self: ({"agent": runtime}, ()))
+
+    plan = build_initialization_plan(
+        prompt=lambda label, default: "y" if label.startswith("Enable runtime") else default,
+        output=lambda _message: None,
+        secret_prompt=lambda _label: "api-value",
+    )
+
+    assert plan.secrets == {"runtime.agent.api_key_secret": "api-value"}
+    assert plan.runtimes["agent"]["options"]["api_key_secret"] == "runtime.agent.api_key_secret"
+    assert plan.runtimes["agent"]["secret_env"] == {
+        "LITEYUKI_AGENT_API_KEY": "runtime.agent.api_key_secret"
+    }

--- a/tests/test_config_v7.py
+++ b/tests/test_config_v7.py
@@ -109,6 +109,7 @@ nested = { primary = true }
     }
     assert settings.runtimes["nb"].working_directory == additional_directory / "runtime"
     assert settings.runtimes["nb"].max_inbound_events == 7
+    assert settings.runtimes["nb"].secret_env == {}
     assert settings.runtimes["nb"].options["features"] == ("messages", "notices")
     assert settings.runtime_event_routes[0].sources == ("nb",)
     assert settings.runtime_event_routes[0].target == "compat"
@@ -122,6 +123,19 @@ nested = { primary = true }
         settings.plugins.config["demo"]["new"] = True
     with pytest.raises(TypeError):
         settings.runtimes["nb"].options["new"] = True  # type: ignore[index]
+
+
+def test_runtime_secret_environment_is_immutable_and_serialized() -> None:
+    settings = RuntimeSettings(
+        kind="agent",
+        secret_env={"LITEYUKI_AGENT_API_KEY": "runtime.agent.api_key_secret"},
+    )
+
+    assert settings.model_dump(mode="json")["secret_env"] == {
+        "LITEYUKI_AGENT_API_KEY": "runtime.agent.api_key_secret"
+    }
+    with pytest.raises(TypeError):
+        settings.secret_env["OTHER"] = "secret"  # type: ignore[index]
 
 
 def test_runtime_options_reject_non_json_values(tmp_path: Path) -> None:

--- a/tests/test_config_vault.py
+++ b/tests/test_config_vault.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import getpass
+import json
+from pathlib import Path
+
+import pytest
+
+import liteyukibot.cli as cli_module
+from liteyukibot.config.vault import SecretVault, VaultError
+
+
+def test_vault_round_trip_rotation_and_secret_free_errors(tmp_path: Path) -> None:
+    vault = SecretVault(tmp_path / ".liteyuki")
+    vault.initialize("correct horse", {"runtime.agent.api_key_secret": "api-value"})
+
+    raw = vault.path.read_text(encoding="utf-8")
+    assert "api-value" not in raw
+    assert vault.list_names("correct horse") == ("runtime.agent.api_key_secret",)
+
+    with pytest.raises(VaultError) as captured:
+        vault.read("wrong password")
+    assert "api-value" not in str(captured.value)
+
+    vault.rotate("correct horse", "new password")
+    assert vault.read("new password") == {"runtime.agent.api_key_secret": "api-value"}
+
+
+def test_vault_rejects_tampered_kdf_before_decryption(tmp_path: Path) -> None:
+    vault = SecretVault(tmp_path / ".liteyuki")
+    vault.initialize("password", {"runtime.agent.api_key_secret": "api-value"})
+    document = json.loads(vault.path.read_text(encoding="utf-8"))
+    document["kdf"]["n"] = 3
+    vault.path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(VaultError, match="unsafe KDF"):
+        vault.read("password")
+
+
+def test_vault_rejects_invalid_secret_names_and_values(tmp_path: Path) -> None:
+    vault = SecretVault(tmp_path / ".liteyuki")
+
+    with pytest.raises(VaultError, match="secret name"):
+        vault.initialize("password", {"bad name": "value"})
+    with pytest.raises(VaultError, match="non-empty"):
+        vault.initialize("password", {"valid.name": ""})
+
+
+def test_cli_vault_commands_never_print_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert cli_module.main(["init", "--non-interactive"]) == 0
+    responses = iter(("password", "password", "api-value", "password"))
+    monkeypatch.setattr(getpass, "getpass", lambda _prompt: next(responses))
+
+    assert cli_module.main(["vault", "set", "runtime.agent.api_key_secret"]) == 0
+    capsys.readouterr()
+    assert cli_module.main(["vault", "list"]) == 0
+    output = capsys.readouterr().out
+
+    assert "runtime.agent.api_key_secret" in output
+    assert "api-value" not in output

--- a/tests/test_config_workspace.py
+++ b/tests/test_config_workspace.py
@@ -39,6 +39,31 @@ def test_outdated_workspace_config_is_backed_up_and_blocks_start(tmp_path: Path)
     assert "config_version = 1" in template.read_text(encoding="utf-8")
 
 
+def test_workspace_upgrade_is_idempotent_until_explicit_refresh(tmp_path: Path) -> None:
+    config = tmp_path / "liteyuki.toml"
+    config.write_text("config_version = 0\n[core]\nqueue_capacity = 1\n", encoding="utf-8")
+    workspace = ConfigWorkspace(tmp_path)
+
+    with pytest.raises(ConfigUpgradeRequired):
+        workspace.prepare()
+    with pytest.raises(ConfigUpgradeRequired, match="existing template"):
+        workspace.prepare()
+    assert len(list((tmp_path / ".liteyuki" / "config-backups").glob("*/liteyuki.toml"))) == 1
+
+    with pytest.raises(ConfigUpgradeRequired):
+        workspace.upgrade(refresh=True)
+    assert len(list((tmp_path / ".liteyuki" / "config-backups").glob("*/liteyuki.toml"))) == 2
+
+
+def test_future_workspace_config_is_not_backed_up(tmp_path: Path) -> None:
+    config = tmp_path / "liteyuki.toml"
+    config.write_text("config_version = 2\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="newer than this kernel"):
+        ConfigWorkspace(tmp_path).prepare()
+    assert not (tmp_path / ".liteyuki").exists()
+
+
 def test_regular_workspace_without_config_requires_initialization(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_runtime_v7.py
+++ b/tests/test_runtime_v7.py
@@ -135,6 +135,27 @@ def test_runtime_payload_logs_default_to_metadata_and_can_be_enabled() -> None:
     assert logger.records[-1]["payload"] == {"message": "secret"}
 
 
+def test_runtime_secret_environment_is_child_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LITEYUKI_VAULT_PASSWORD", "master-password")
+    supervisor = RuntimeSupervisor(logger=FakeLogger(), secret_values={"agent.api_key": "child-secret"})
+    supervisor.add(
+        RuntimeSpec(
+            id="agent",
+            kind="custom",
+            env={"PUBLIC_VALUE": "configured"},
+            secret_env={"LITEYUKI_AGENT_API_KEY": "agent.api_key"},
+        )
+    )
+
+    environment = supervisor._child_environment(supervisor.records["agent"])
+
+    assert environment["PUBLIC_VALUE"] == "configured"
+    assert environment["LITEYUKI_AGENT_API_KEY"] == "child-secret"
+    assert "LITEYUKI_VAULT_PASSWORD" not in environment
+    with pytest.raises(RuntimeError, match="unavailable secret"):
+        RuntimeSupervisor(logger=FakeLogger())._child_environment(supervisor.records["agent"])
+
+
 @pytest.mark.asyncio
 async def test_runtime_spawn_failure_is_reported_without_waiting_for_ready_timeout() -> None:
     supervisor = RuntimeSupervisor(logger=FakeLogger())

--- a/uv.lock
+++ b/uv.lock
@@ -1115,6 +1115,7 @@ name = "liteyukibot-v7"
 version = "7.0.0a4"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "pydantic" },
     { name = "tomli-w" },
     { name = "yukilog" },
@@ -1139,6 +1140,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = ">=46,<51" },
     { name = "fastapi", marker = "extra == 'http'", specifier = ">=0.141,<1" },
     { name = "pydantic", specifier = ">=2.13,<3" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6,<7" },


### PR DESCRIPTION
## Summary
- add an scrypt and AES-GCM encrypted project secret vault
- inject only declared secret IDs into their owning runtime child environment
- add vault CLI operations and idempotent upgrade material generation

## Verification
- uv sync --locked --all-packages --extra onebot --extra satori
- uv run ruff check .
- uv run mypy
- uv run pytest -q
- uv build --all-packages