### PR TITLE
feat: add configuration provenance inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ the subcommand, for example:
 uv run liteyuki --config local.toml --set logging.level=DEBUG check
 ```
 
+Initialization, encrypted runtime secrets, upgrade recovery, and configuration
+provenance are documented in [docs/configuration.md](docs/configuration.md).
+
 ## Docker
 
 The v7 image can be built locally with the optional YAML, HTTP, NoneBot,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,89 @@
+# Configuration Operations
+
+## Project Configuration
+
+Outside Docker, every configuration-consuming command requires a project-root
+liteyuki.toml. Create it with:
+
+~~~bash
+uv run liteyuki init
+~~~
+
+The interactive initializer discovers installed native plugins and runtime
+packages without importing framework internals. It prompts for selected
+packages, resolves required native service providers, writes only package-owned
+safe options, and can add message routes to an agent runtime. A broken,
+unrelated entry point is reported as a diagnostic instead of preventing other
+choices.
+
+liteyuki init --non-interactive and a missing Docker configuration both create
+a minimal configuration with no enabled plugins, runtimes, or secrets.
+
+## Precedence And Inspection
+
+The effective order is:
+
+1. Kernel defaults.
+2. Included files, in declared order.
+3. The including or primary file.
+4. Repeated --config files, in command-line order.
+5. LITEYUKI__SECTION__FIELD environment variables.
+6. Repeated --set section.field=JSON_VALUE options.
+
+Use global CLI options before the subcommand:
+
+~~~bash
+uv run liteyuki --config local.toml --set logging.level=DEBUG config show
+uv run liteyuki config show --format toml
+uv run liteyuki config explain /plugins/config/example.plugin/value
+~~~
+
+config show emits redacted JSON by default. It recursively replaces values
+whose keys indicate credentials, API keys, secrets, passwords, or tokens.
+config explain uses RFC 6901 JSON Pointer paths and returns the final value
+plus every source that overwrote it. JSON Pointer keeps dotted plugin IDs
+unambiguous.
+
+TOML has no null literal. config show --format toml omits optional null object
+fields, which reload as their model defaults, and rejects null array values
+instead of changing their meaning.
+
+## Secret Vault
+
+Runtime secret bindings use normalized IDs in liteyuki.toml; plaintext is
+stored only in .liteyuki/secrets.v1.json. The vault derives its encryption key
+with scrypt and encrypts the complete mapping with AES-256-GCM.
+
+~~~bash
+uv run liteyuki vault set runtime.agent.api_key_secret
+uv run liteyuki vault list
+uv run liteyuki vault delete runtime.agent.api_key_secret
+uv run liteyuki vault rotate
+~~~
+
+Local commands use hidden password prompts. Docker requires
+LITEYUKI_VAULT_PASSWORD; it is removed from every child runtime environment.
+The kernel decrypts only the IDs required by enabled runtimes and injects each
+value only into the environment variable declared by that runtime's InitSpec.
+Secrets never enter runtime IPC, control APIs, or configuration diagnostics.
+
+The native agent runtime uses LITEYUKI_AGENT_API_KEY by default. Existing
+api_key_env configuration remains an explicit compatibility override.
+
+## Upgrade Material
+
+config_version = 1 is the current v7 alpha schema. A root configuration with a
+missing or older version is preserved and blocks startup after generating:
+
+- a backup under .liteyuki/config-backups/;
+- a current template under .liteyuki/config-upgrades/;
+- recovery instructions in that upgrade directory.
+
+Generation is idempotent. After reviewing and merging the template manually,
+use this command only when a fresh backup/template is required:
+
+~~~bash
+uv run liteyuki config upgrade --refresh
+~~~
+
+Configurations from a newer schema are rejected without creating backups.

--- a/src/liteyukibot/cli.py
+++ b/src/liteyukibot/cli.py
@@ -12,9 +12,20 @@ import sys
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from tomli_w import dumps as dump_toml
+
 from . import __version__
 from .app import LiteyukiApp
-from .config import AppSettings, ConfigurationError, ConfigWorkspace, load_settings
+from .config import (
+    AppSettings,
+    ConfigInspection,
+    ConfigurationError,
+    ConfigWorkspace,
+    inspect_settings,
+    load_settings,
+    redact_config,
+    toml_compatible_config,
+)
 from .config.initializer import build_initialization_plan
 from .config.vault import SecretVault
 from .control import ControlError, request_control
@@ -37,6 +48,10 @@ def build_parser() -> argparse.ArgumentParser:
     config_commands.add_parser("validate")
     upgrade = config_commands.add_parser("upgrade")
     upgrade.add_argument("--refresh", action="store_true")
+    show = config_commands.add_parser("show")
+    show.add_argument("--format", choices=("json", "toml"), default="json")
+    explain = config_commands.add_parser("explain")
+    explain.add_argument("pointer")
 
     vault = subcommands.add_parser("vault", help="encrypted secret vault operations")
     vault_commands = vault.add_subparsers(dest="vault_command", required=True)
@@ -68,6 +83,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             return _init(args.non_interactive)
         if args.command == "config" and args.config_command == "upgrade":
             return _upgrade(args.refresh)
+        if args.command == "config" and args.config_command == "show":
+            return _config_show(args)
+        if args.command == "config" and args.config_command == "explain":
+            return _config_explain(args)
         if args.command == "vault":
             return _vault(args)
         settings = _load(args.config, args.overrides)
@@ -131,6 +150,44 @@ def _upgrade(refresh: bool) -> int:
     if result is None:
         print("configuration is current")
     return 0
+
+
+def _config_show(args: argparse.Namespace) -> int:
+    inspection = _inspect(args)
+    document = redact_config(inspection.settings.model_dump(mode="json"))
+    if args.format == "toml":
+        print(dump_toml(toml_compatible_config(document)), end="")
+    else:
+        print(json.dumps(document, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+def _config_explain(args: argparse.Namespace) -> int:
+    explanation = _inspect(args).explain(args.pointer)
+    print(
+        json.dumps(
+            {
+                "pointer": explanation.pointer,
+                "value": redact_config(explanation.value),
+                "sources": [
+                    {"kind": source.kind, "source": source.source}
+                    for source in explanation.sources
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def _inspect(args: argparse.Namespace) -> ConfigInspection:
+    primary = ConfigWorkspace().prepare()
+    return inspect_settings(
+        primary,
+        config_paths=args.config,
+        cli_overrides=args.overrides,
+    )
 
 
 def _vault(args: argparse.Namespace) -> int:

--- a/src/liteyukibot/config/__init__.py
+++ b/src/liteyukibot/config/__init__.py
@@ -1,5 +1,5 @@
 from .errors import ConfigIssue, ConfigurationError
-from .loader import load_settings
+from .loader import ConfigExplanation, ConfigInspection, ConfigProvenance, ConfigSource, inspect_settings, load_settings
 from .models import (
     AgentSettings,
     AppSettings,
@@ -10,6 +10,7 @@ from .models import (
     RuntimeEventRoute,
     RuntimeSettings,
 )
+from .redaction import redact_config, toml_compatible_config
 from .template import CONFIG_VERSION, render_config_template
 from .vault import SecretVault, VaultError
 from .workspace import ConfigUpgradeRequired, ConfigWorkspace
@@ -18,6 +19,10 @@ __all__ = (
     "AgentSettings",
     "AppSettings",
     "ConfigIssue",
+    "ConfigExplanation",
+    "ConfigInspection",
+    "ConfigProvenance",
+    "ConfigSource",
     "ConfigurationError",
     "ConfigUpgradeRequired",
     "ConfigWorkspace",
@@ -31,5 +36,8 @@ __all__ = (
     "SecretVault",
     "VaultError",
     "load_settings",
+    "inspect_settings",
+    "redact_config",
+    "toml_compatible_config",
     "render_config_template",
 )

--- a/src/liteyukibot/config/loader.py
+++ b/src/liteyukibot/config/loader.py
@@ -5,6 +5,7 @@ import json
 import os
 import tomllib
 from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,81 @@ from .models import AppSettings
 
 type ConfigMap = dict[str, Any]
 type CliOverrides = Mapping[str, Any] | Iterable[str]
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigSource:
+    """One configuration layer that supplied a value."""
+
+    kind: str
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigProvenance:
+    """Immutable source chains indexed by JSON Pointer paths."""
+
+    chains: Mapping[tuple[str, ...], tuple[ConfigSource, ...]]
+
+    def explain(self, pointer: str) -> tuple[ConfigSource, ...]:
+        path = _parse_pointer(pointer)
+        exact = self.chains.get(path)
+        if exact is not None:
+            return exact
+        descendants = [
+            source
+            for candidate, chain in self.chains.items()
+            if candidate[: len(path)] == path
+            for source in chain
+        ]
+        if not descendants:
+            raise ValueError(f"configuration pointer does not exist: {pointer}")
+        return tuple(dict.fromkeys(descendants))
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigInspection:
+    """Validated settings plus their complete source provenance."""
+
+    settings: AppSettings
+    provenance: ConfigProvenance
+
+    def explain(self, pointer: str) -> ConfigExplanation:
+        return ConfigExplanation(
+            pointer=pointer,
+            value=_value_at_pointer(self.settings.model_dump(mode="json"), _parse_pointer(pointer)),
+            sources=self.provenance.explain(pointer),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigExplanation:
+    """One final value and the ordered layers that supplied it."""
+
+    pointer: str
+    value: Any
+    sources: tuple[ConfigSource, ...]
+
+
+class _ProvenanceTracker:
+    def __init__(self) -> None:
+        self.chains: dict[tuple[str, ...], list[ConfigSource]] = {}
+
+    def apply(self, value: Mapping[str, Any], source: ConfigSource) -> None:
+        self._apply(value, source, ())
+
+    def freeze(self) -> ConfigProvenance:
+        return ConfigProvenance({path: tuple(chain) for path, chain in self.chains.items()})
+
+    def _apply(self, value: Any, source: ConfigSource, path: tuple[str, ...]) -> None:
+        if isinstance(value, Mapping):
+            if not value:
+                self.chains.setdefault(path, []).append(source)
+                return
+            for key, child in value.items():
+                self._apply(child, source, (*path, str(key)))
+            return
+        self.chains.setdefault(path, []).append(source)
 
 
 def _deep_merge(base: Mapping[str, Any], overlay: Mapping[str, Any]) -> ConfigMap:
@@ -143,8 +219,9 @@ def _resolve_declared_paths(data: ConfigMap, base_directory: Path) -> ConfigMap:
 
 
 class _FileLoader:
-    def __init__(self, issues: list[ConfigIssue]) -> None:
+    def __init__(self, issues: list[ConfigIssue], tracker: _ProvenanceTracker | None = None) -> None:
         self.issues = issues
+        self.tracker = tracker
         self._active: list[Path] = []
         self._loaded: dict[str, Path] = {}
 
@@ -185,6 +262,8 @@ class _FileLoader:
             include_value = parsed.pop("include", [])
             included = self._load_includes(include_value, path)
             own_values = _resolve_declared_paths(parsed, path.parent)
+            if self.tracker is not None:
+                self.tracker.apply(own_values, ConfigSource("file", str(path)))
             return _deep_merge(included, own_values)
         finally:
             self._active.pop()
@@ -281,8 +360,47 @@ def load_settings(
     mappings may contain either nested values or dotted keys.
     """
 
+    return _load_settings(
+        primary_path,
+        config_paths=config_paths,
+        environ=environ,
+        cli_overrides=cli_overrides,
+        tracker=None,
+    )[0]
+
+
+def inspect_settings(
+    primary_path: str | os.PathLike[str] | None = None,
+    *,
+    config_paths: Iterable[str | os.PathLike[str]] = (),
+    environ: Mapping[str, str] | None = None,
+    cli_overrides: CliOverrides = (),
+) -> ConfigInspection:
+    """Load settings and preserve the full source chain for every value."""
+
+    tracker = _ProvenanceTracker()
+    tracker.apply(AppSettings().model_dump(mode="json"), ConfigSource("default", "kernel defaults"))
+    settings, provenance = _load_settings(
+        primary_path,
+        config_paths=config_paths,
+        environ=environ,
+        cli_overrides=cli_overrides,
+        tracker=tracker,
+    )
+    assert provenance is not None
+    return ConfigInspection(settings, provenance)
+
+
+def _load_settings(
+    primary_path: str | os.PathLike[str] | None,
+    *,
+    config_paths: Iterable[str | os.PathLike[str]],
+    environ: Mapping[str, str] | None,
+    cli_overrides: CliOverrides,
+    tracker: _ProvenanceTracker | None,
+) -> tuple[AppSettings, ConfigProvenance | None]:
     issues: list[ConfigIssue] = []
-    loader = _FileLoader(issues)
+    loader = _FileLoader(issues, tracker)
     merged: ConfigMap = {}
 
     if primary_path is not None:
@@ -291,8 +409,12 @@ def load_settings(
         merged = _deep_merge(merged, loader.load_root(config_path))
 
     environment_values = _environment_layer(os.environ if environ is None else environ, issues)
+    if tracker is not None:
+        tracker.apply(environment_values, ConfigSource("environment", "LITEYUKI__"))
     merged = _deep_merge(merged, _resolve_declared_paths(environment_values, Path.cwd()))
     command_line_values = _cli_layer(cli_overrides, issues)
+    if tracker is not None:
+        tracker.apply(command_line_values, ConfigSource("command_line", "--set"))
     merged = _deep_merge(merged, _resolve_declared_paths(command_line_values, Path.cwd()))
 
     try:
@@ -312,4 +434,47 @@ def load_settings(
         raise ConfigurationError(issues)
     if settings is None:  # Kept explicit for type checkers; validation errors are handled above.
         raise RuntimeError("configuration validation failed without an issue")
-    return settings
+    return settings, None if tracker is None else tracker.freeze()
+
+
+def _parse_pointer(pointer: str) -> tuple[str, ...]:
+    if pointer == "":
+        return ()
+    if not pointer.startswith("/"):
+        raise ValueError("configuration pointer must be an RFC 6901 JSON Pointer")
+    parts: list[str] = []
+    for part in pointer[1:].split("/"):
+        decoded: list[str] = []
+        index = 0
+        while index < len(part):
+            character = part[index]
+            if character != "~":
+                decoded.append(character)
+                index += 1
+                continue
+            if index + 1 >= len(part) or part[index + 1] not in {"0", "1"}:
+                raise ValueError("configuration pointer contains an invalid escape")
+            decoded.append("~" if part[index + 1] == "0" else "/")
+            index += 2
+        parts.append("".join(decoded))
+    return tuple(parts)
+
+
+def _value_at_pointer(value: Any, path: tuple[str, ...]) -> Any:
+    current = value
+    for part in path:
+        if isinstance(current, Mapping):
+            try:
+                current = current[part]
+            except KeyError as error:
+                raise ValueError(f"configuration pointer does not exist: /{'/'.join(path)}") from error
+            continue
+        if isinstance(current, (list, tuple)) and part.isdigit():
+            index = int(part)
+            try:
+                current = current[index]
+            except IndexError as error:
+                raise ValueError(f"configuration pointer does not exist: /{'/'.join(path)}") from error
+            continue
+        raise ValueError(f"configuration pointer does not exist: /{'/'.join(path)}")
+    return current

--- a/src/liteyukibot/config/redaction.py
+++ b/src/liteyukibot/config/redaction.py
@@ -1,0 +1,53 @@
+"""Secret-safe rendering helpers for configuration diagnostics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_SENSITIVE_MARKERS = (
+    "password",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "credential",
+)
+
+
+def redact_config(value: Any) -> Any:
+    """Copy JSON-compatible configuration while replacing sensitive values."""
+
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        for key, child in value.items():
+            rendered_key = str(key)
+            result[rendered_key] = "<redacted>" if _is_sensitive(rendered_key) else redact_config(child)
+        return result
+    if isinstance(value, (tuple, list)):
+        return [redact_config(item) for item in value]
+    return value
+
+
+def toml_compatible_config(value: Any) -> Any:
+    """Drop optional null object fields before rendering TOML diagnostics."""
+
+    if isinstance(value, Mapping):
+        return {
+            str(key): toml_compatible_config(child)
+            for key, child in value.items()
+            if child is not None
+        }
+    if isinstance(value, (tuple, list)):
+        if any(item is None for item in value):
+            raise ValueError("TOML output cannot represent null array values")
+        return [toml_compatible_config(item) for item in value]
+    return value
+
+
+def _is_sensitive(key: str) -> bool:
+    normalized = key.lower().replace("-", "_")
+    return any(marker in normalized for marker in _SENSITIVE_MARKERS)
+
+
+__all__ = ["redact_config", "toml_compatible_config"]

--- a/tests/test_config_inspection.py
+++ b/tests/test_config_inspection.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+import pytest
+
+import liteyukibot.cli as cli_module
+from liteyukibot.config import inspect_settings, redact_config, toml_compatible_config
+
+
+def test_inspection_tracks_all_precedence_layers_with_json_pointer(tmp_path: Path) -> None:
+    included = tmp_path / "included.toml"
+    included.write_text("[core]\nqueue_capacity = 10\n", encoding="utf-8")
+    primary = tmp_path / "liteyuki.toml"
+    primary.write_text(
+        'config_version = 1\ninclude = ["included.toml"]\n[core]\nqueue_capacity = 20\n',
+        encoding="utf-8",
+    )
+    additional = tmp_path / "extra.toml"
+    additional.write_text("[core]\nqueue_capacity = 30\n", encoding="utf-8")
+
+    inspection = inspect_settings(
+        primary,
+        config_paths=(additional,),
+        environ={"LITEYUKI__CORE__QUEUE_CAPACITY": "40"},
+        cli_overrides=("core.queue_capacity=50",),
+    )
+    explanation = inspection.explain("/core/queue_capacity")
+
+    assert explanation.value == 50
+    assert [source.kind for source in explanation.sources] == [
+        "default",
+        "file",
+        "file",
+        "file",
+        "environment",
+        "command_line",
+    ]
+
+
+def test_inspection_json_pointer_keeps_dotted_plugin_ids_unambiguous(tmp_path: Path) -> None:
+    config = tmp_path / "liteyuki.toml"
+    config.write_text(
+        'config_version = 1\n[plugins.config."example.plugin"]\nvalue = "configured"\n',
+        encoding="utf-8",
+    )
+
+    inspection = inspect_settings(config, environ={})
+
+    assert inspection.explain("/plugins/config/example.plugin/value").value == "configured"
+    with pytest.raises(ValueError, match="RFC 6901"):
+        inspection.explain("plugins.config.example.plugin.value")
+
+
+def test_config_show_and_explain_redact_sensitive_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = tmp_path / "liteyuki.toml"
+    config.write_text(
+        'config_version = 1\n[plugins.config.demo]\napi_key = "live-value"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert cli_module.main(["config", "show"]) == 0
+    shown = capsys.readouterr().out
+    assert "live-value" not in shown
+    assert json.loads(shown)["plugins"]["config"]["demo"]["api_key"] == "<redacted>"
+
+    assert cli_module.main(["config", "show", "--format", "toml"]) == 0
+    rendered_toml = capsys.readouterr().out
+    assert "live-value" not in rendered_toml
+    assert tomllib.loads(rendered_toml)["plugins"]["config"]["demo"]["api_key"] == "<redacted>"
+
+    assert cli_module.main(["--set", "core.queue_capacity=11", "config", "explain", "/core/queue_capacity"]) == 0
+    explanation = json.loads(capsys.readouterr().out)
+    assert explanation["value"] == 11
+    assert explanation["sources"][-1]["kind"] == "command_line"
+
+
+def test_redaction_descends_into_nested_collections() -> None:
+    document = {
+        "credentials": {"access_token": "token-value"},
+        "safe": [{"value": "visible"}],
+    }
+
+    assert redact_config(document) == {
+        "credentials": "<redacted>",
+        "safe": [{"value": "visible"}],
+    }
+
+
+def test_toml_output_omits_optional_nulls_but_rejects_null_arrays() -> None:
+    assert toml_compatible_config({"optional": None, "nested": {"value": 1}}) == {
+        "nested": {"value": 1}
+    }
+    with pytest.raises(ValueError, match="null array"):
+        toml_compatible_config({"items": [None]})


### PR DESCRIPTION
## Summary
- add full configuration provenance chains across defaults, files, environment, and CLI overrides
- add secret-safe configuration show and JSON Pointer explain commands
- preserve loader API behavior while making TOML diagnostics null-safe

## Verification
- uv run ruff check .
- uv run mypy
- uv run pytest -q
- uv build --all-packages