### PR TITLE
feat: prepare CLI tool workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,26 @@ The v7 kernel distribution on PyPI is named `liteyukibot-v7` and provides the
 `liteyukibot` namespace. The separately installed v6 runtime provides the
 `liteyuki` compatibility namespace.
 
+## Tool Installation
+
+Install the v7 CLI into uv's isolated tool environment:
+
+```bash
+uv tool install --python 3.14 liteyukibot-v7
+liteyuki init
+liteyuki run
+```
+
+The commands operate on the current directory by default. Use
+`liteyuki --workspace PATH ...` to select another project. `liteyukibot` and
+`ly` are equivalent executable aliases. Upgrade only the v7 tool with:
+
+```bash
+uv tool upgrade --python 3.14 liteyukibot-v7
+```
+
+This does not replace a separately installed v6 `liteyukibot` distribution.
+
 ```bash
 uv sync --locked
 uv run liteyuki check

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,22 @@ choices.
 liteyuki init --non-interactive and a missing Docker configuration both create
 a minimal configuration with no enabled plugins, runtimes, or secrets.
 
+## Workspace Selection
+
+The current directory is the default workspace. Use `--workspace PATH` before
+the subcommand to operate on another project without changing the shell's
+current directory:
+
+~~~bash
+liteyuki --workspace /srv/liteyuki init --non-interactive
+liteyuki --workspace /srv/liteyuki run
+~~~
+
+`init` and `run` hold `.liteyuki/instance.lock` for the duration of the
+operation. A second process for the same workspace exits rather than replacing
+the active control descriptor. `liteyuki --version` is equivalent to
+`liteyuki version`.
+
 ## Precedence And Inspection
 
 The effective order is:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 dependencies = [
     "cryptography>=46,<51",
+    "filelock>=3.19,<4",
     "pydantic>=2.13,<3",
     "tomli-w>=1.2,<2",
     "yukilog>=1,<2",
@@ -26,6 +27,7 @@ http = [
 ]
 
 [project.scripts]
+liteyukibot = "liteyukibot.cli:main"
 liteyuki = "liteyukibot.cli:main"
 ly = "liteyukibot.cli:main"
 

--- a/src/liteyukibot/cli.py
+++ b/src/liteyukibot/cli.py
@@ -9,9 +9,11 @@ import json
 import os
 import signal
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from typing import Any
 
+from filelock import FileLock, Timeout
 from tomli_w import dumps as dump_toml
 
 from . import __version__
@@ -34,6 +36,8 @@ from .exceptions import LiteyukiError
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="liteyuki")
+    parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument("--workspace", default=".", metavar="PATH", help="project workspace directory")
     parser.add_argument("--config", action="append", default=[], metavar="PATH")
     parser.add_argument("--set", action="append", default=[], dest="overrides", metavar="KEY=VALUE")
     subcommands = parser.add_subparsers(dest="command", required=True)
@@ -80,18 +84,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     try:
         if args.command == "init":
-            return _init(args.non_interactive)
+            return _init(args.workspace, args.non_interactive)
         if args.command == "config" and args.config_command == "upgrade":
-            return _upgrade(args.refresh)
+            return _upgrade(args.workspace, args.refresh)
         if args.command == "config" and args.config_command == "show":
             return _config_show(args)
         if args.command == "config" and args.config_command == "explain":
             return _config_explain(args)
         if args.command == "vault":
             return _vault(args)
-        settings = _load(args.config, args.overrides)
+        workspace = ConfigWorkspace(args.workspace)
+        settings = _load(workspace, args.config, args.overrides)
         if args.command == "run":
-            return _run(settings, _runtime_secrets(settings))
+            return _run(settings, workspace)
         if args.command in {"check", "config"}:
             if args.command == "check":
                 _check(settings)
@@ -108,8 +113,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 2
 
 
-def _load(config_paths: Sequence[str], overrides: Sequence[str]) -> AppSettings:
-    primary = ConfigWorkspace().prepare()
+def _load(workspace: ConfigWorkspace, config_paths: Sequence[str], overrides: Sequence[str]) -> AppSettings:
+    primary = workspace.prepare()
     return load_settings(
         primary,
         config_paths=config_paths,
@@ -117,36 +122,37 @@ def _load(config_paths: Sequence[str], overrides: Sequence[str]) -> AppSettings:
     )
 
 
-def _init(non_interactive: bool) -> int:
-    workspace = ConfigWorkspace()
-    if non_interactive:
-        path = workspace.initialize()
-    else:
-        plan = build_initialization_plan(
-            prompt=_prompt,
-            output=lambda message: print(message, file=sys.stderr),
-            secret_prompt=_prompt_secret,
-        )
-        if plan.secrets:
-            vault = SecretVault(workspace.management_directory)
-            vault.initialize(_vault_password(workspace, create=True), plan.secrets)
-        path = workspace.initialize(
-            data_dir=plan.data_dir,
-            cache_dir=plan.cache_dir,
-            logging_level=plan.logging_level,
-            payload_mode=plan.payload_mode,
-            payload_exclude_runtimes=plan.payload_exclude_runtimes,
-            plugins=plan.plugins,
-            plugin_config=plan.plugin_config,
-            runtimes=plan.runtimes,
-            runtime_event_routes=plan.runtime_event_routes,
-        )
+def _init(directory: str, non_interactive: bool) -> int:
+    workspace = ConfigWorkspace(directory)
+    with _exclusive_workspace(workspace):
+        if non_interactive:
+            path = workspace.initialize()
+        else:
+            plan = build_initialization_plan(
+                prompt=_prompt,
+                output=lambda message: print(message, file=sys.stderr),
+                secret_prompt=_prompt_secret,
+            )
+            if plan.secrets:
+                vault = SecretVault(workspace.management_directory)
+                vault.initialize(_vault_password(workspace, create=True), plan.secrets)
+            path = workspace.initialize(
+                data_dir=plan.data_dir,
+                cache_dir=plan.cache_dir,
+                logging_level=plan.logging_level,
+                payload_mode=plan.payload_mode,
+                payload_exclude_runtimes=plan.payload_exclude_runtimes,
+                plugins=plan.plugins,
+                plugin_config=plan.plugin_config,
+                runtimes=plan.runtimes,
+                runtime_event_routes=plan.runtime_event_routes,
+            )
     print(f"created {path}")
     return 0
 
 
-def _upgrade(refresh: bool) -> int:
-    result = ConfigWorkspace().upgrade(refresh=refresh)
+def _upgrade(directory: str, refresh: bool) -> int:
+    result = ConfigWorkspace(directory).upgrade(refresh=refresh)
     if result is None:
         print("configuration is current")
     return 0
@@ -182,7 +188,7 @@ def _config_explain(args: argparse.Namespace) -> int:
 
 
 def _inspect(args: argparse.Namespace) -> ConfigInspection:
-    primary = ConfigWorkspace().prepare()
+    primary = ConfigWorkspace(args.workspace).prepare()
     return inspect_settings(
         primary,
         config_paths=args.config,
@@ -191,7 +197,7 @@ def _inspect(args: argparse.Namespace) -> ConfigInspection:
 
 
 def _vault(args: argparse.Namespace) -> int:
-    workspace = ConfigWorkspace()
+    workspace = ConfigWorkspace(args.workspace)
     workspace.prepare()
     vault = SecretVault(workspace.management_directory)
     if args.vault_command == "set":
@@ -244,7 +250,7 @@ def _vault_password(workspace: ConfigWorkspace, *, create: bool = False) -> str:
     return value
 
 
-def _runtime_secrets(settings: AppSettings) -> dict[str, str]:
+def _runtime_secrets(settings: AppSettings, workspace: ConfigWorkspace) -> dict[str, str]:
     names = {
         secret_name
         for runtime in settings.runtimes.values()
@@ -253,7 +259,6 @@ def _runtime_secrets(settings: AppSettings) -> dict[str, str]:
     }
     if not names:
         return {}
-    workspace = ConfigWorkspace()
     values = SecretVault(workspace.management_directory).read(_vault_password(workspace))
     missing = sorted(names - values.keys())
     if missing:
@@ -275,12 +280,26 @@ def _list_plugins(settings: AppSettings) -> None:
         print(f"{manifest.id}\t{manifest.version}\t{manifest.name}")
 
 
-def _run(settings: AppSettings, runtime_secrets: Mapping[str, str]) -> int:
+def _run(settings: AppSettings, workspace: ConfigWorkspace) -> int:
     try:
-        asyncio.run(_run_until_signal(settings, runtime_secrets))
+        with _exclusive_workspace(workspace):
+            asyncio.run(_run_until_signal(settings, _runtime_secrets(settings, workspace)))
     except KeyboardInterrupt:
         return 130
     return 0
+
+
+@contextmanager
+def _exclusive_workspace(workspace: ConfigWorkspace) -> Iterator[None]:
+    """Prevent init or run from replacing one workspace's live control state."""
+
+    workspace.management_directory.mkdir(parents=True, exist_ok=True)
+    lock = FileLock(workspace.management_directory / "instance.lock", timeout=0)
+    try:
+        with lock:
+            yield
+    except Timeout as error:
+        raise RuntimeError(f"another LiteyukiBot command is active for {workspace.directory}") from error
 
 
 async def _run_until_signal(settings: AppSettings, runtime_secrets: Mapping[str, str] | None = None) -> None:

--- a/tests/test_cli_v7.py
+++ b/tests/test_cli_v7.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import signal
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, ClassVar
 
 import pytest
+from filelock import Timeout
 
 import liteyukibot.cli as cli_module
 from liteyukibot.config import AppSettings
@@ -90,3 +92,27 @@ async def test_run_until_signal_uses_windows_signal_fallback(monkeypatch: pytest
         signal.SIGTERM,
     ]
     assert assignments[-2:] == [(signal.SIGINT, previous), (signal.SIGTERM, previous)]
+
+
+def test_run_rejects_an_active_workspace_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from liteyukibot.config import ConfigWorkspace
+
+    ConfigWorkspace(tmp_path).initialize()
+
+    class LockedFileLock:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> None:
+            raise Timeout("instance.lock")
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    monkeypatch.setattr(cli_module, "FileLock", LockedFileLock)
+    monkeypatch.setattr(cli_module, "_runtime_secrets", lambda *_args: (_ for _ in ()).throw(AssertionError()))
+
+    assert cli_module.main(["--workspace", str(tmp_path), "run"]) == 2
+    assert "another LiteyukiBot command is active" in capsys.readouterr().err

--- a/tests/test_config_workspace.py
+++ b/tests/test_config_workspace.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 import liteyukibot.cli as cli_module
+from liteyukibot import __version__
 from liteyukibot.config import ConfigUpgradeRequired, ConfigurationError, ConfigWorkspace, load_settings
 
 
@@ -91,3 +92,19 @@ def test_cli_init_noninteractive_writes_project_config(tmp_path: Path, monkeypat
 
     assert cli_module.main(["init", "--non-interactive"]) == 0
     assert (tmp_path / "liteyuki.toml").is_file()
+
+
+def test_cli_init_uses_explicit_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "instance"
+
+    assert cli_module.main(["--workspace", str(workspace), "init", "--non-interactive"]) == 0
+
+    assert (workspace / "liteyuki.toml").is_file()
+
+
+def test_cli_version_option_exits_successfully(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as raised:
+        cli_module.main(["--version"])
+
+    assert raised.value.code == 0
+    assert capsys.readouterr().out.strip() == __version__

--- a/uv.lock
+++ b/uv.lock
@@ -1116,6 +1116,7 @@ version = "7.0.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
+    { name = "filelock" },
     { name = "pydantic" },
     { name = "tomli-w" },
     { name = "yukilog" },
@@ -1142,6 +1143,7 @@ dev = [
 requires-dist = [
     { name = "cryptography", specifier = ">=46,<51" },
     { name = "fastapi", marker = "extra == 'http'", specifier = ">=0.141,<1" },
+    { name = "filelock", specifier = ">=3.19,<4" },
     { name = "pydantic", specifier = ">=2.13,<3" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=6,<7" },
     { name = "tomli-w", specifier = ">=1.2,<2" },


### PR DESCRIPTION
## Summary\n- add workspace-aware CLI execution and conventional version output\n- prevent concurrent initialization or runs from replacing workspace control state\n- document the v7 tool path: uv tool install liteyukibot-v7\n\n## Validation\n- uv run ruff check .\n- uv run mypy\n- uv run pytest -q\n- uv lock --check\n- uv build --all-packages --out-dir dist/cli-tooling-final --clear\n- isolated wheel tool install with liteyuki, liteyukibot, and ly entry points