### PR TITLE
chore: prepare v7.0.0a5 release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,15 +48,15 @@ jobs:
           uv build --all-packages --out-dir dist/workspace --clear
           uv build --project examples/native-plugin --out-dir dist/examples
           uv build --project examples/custom-runtime --out-dir dist/examples
-          uv run python scripts/run_developer_kit_install.py
-          uv run python scripts/run_permissions_install.py
-          uv run python scripts/run_commands_install.py
-          uv run python scripts/run_essentials_install.py
-          uv run python scripts/run_nonebot_runtime_install.py
-          uv run python scripts/run_v6_runtime_install.py
-          uv run python scripts/run_agent_install.py
-          uv run python scripts/run_astrbot_runtime_install.py
-          uv run python scripts/run_mofox_runtime_install.py
+          uv run python -m scripts.run_developer_kit_install
+          uv run python -m scripts.run_permissions_install
+          uv run python -m scripts.run_commands_install
+          uv run python -m scripts.run_essentials_install
+          uv run python -m scripts.run_nonebot_runtime_install
+          uv run python -m scripts.run_v6_runtime_install
+          uv run python -m scripts.run_agent_install
+          uv run python -m scripts.run_astrbot_runtime_install
+          uv run python -m scripts.run_mofox_runtime_install
       - name: Capture baseline
         working-directory: LiteyukiBot
         run: uv run python scripts/benchmark_v7.py --output benchmark.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 7.0.0a5 - 2026-08-11
+
+- added an installable v7 CLI workflow with `uv tool install liteyukibot-v7`;
+- added explicit workspace selection, conventional `--version`, and
+  `liteyukibot`/`ly` executable aliases;
+- serialized workspace initialization and foreground runs so a competing
+  instance cannot replace the active local control descriptor.
+
 ## 7.0.0a3 - 2026-08-10
 
 The third v7 alpha establishes the first-party native plugin foundation:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a4`. Kernel stabilization,
+The current pre-release is `liteyukibot-v7==7.0.0a5`. Kernel stabilization,
 the first bounded compatibility phase, and the first-party plugin foundation
 are complete. Runtime protocol v3 remains an alpha contract and may change
 under ADR 0011 before the first stable release.
@@ -136,13 +136,13 @@ uv build
 uv build --all-packages --out-dir dist/workspace --clear
 uv build --project examples/native-plugin --out-dir dist/examples
 uv build --project examples/custom-runtime --out-dir dist/examples
-uv run python scripts/run_developer_kit_install.py
-uv run python scripts/run_permissions_install.py
-uv run python scripts/run_commands_install.py
-uv run python scripts/run_resources_install.py
-uv run python scripts/run_profile_install.py
-uv run python scripts/run_essentials_install.py
-uv run python scripts/run_nonebot_runtime_install.py
+uv run python -m scripts.run_developer_kit_install
+uv run python -m scripts.run_permissions_install
+uv run python -m scripts.run_commands_install
+uv run python -m scripts.run_resources_install
+uv run python -m scripts.run_profile_install
+uv run python -m scripts.run_essentials_install
+uv run python -m scripts.run_nonebot_runtime_install
 ```
 
 The architecture overview is documented in `docs/architecture/v7.md`; accepted

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -138,7 +138,7 @@ and published-install matrix are documented in
 
 ## Current Release State
 
-The current pre-release is `liteyukibot-v7==7.0.0a4`. The kernel, bounded v6
+The current pre-release is `liteyukibot-v7==7.0.0a5`. The kernel, bounded v6
 compatibility, separately published NoneBot and v6 runtime boundaries, and first-party plugin foundation are
 complete. Resources and profile remain optional business plugins; their storage
 and migration ownership does not belong to the kernel.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -37,7 +37,7 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a4` | `pyproject.toml` | `v7.0.0a4` |
+| `liteyukibot-v7==7.0.0a5` | `pyproject.toml` | `v7.0.0a5` |
 | `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
 | `liteyukibot-v7-commands==0.2.0a1` | `packages/commands` | `commands-v0.2.0a1` |
 | `liteyukibot-v7-resources==0.1.0a1` | `packages/resources` | `resources-v0.1.0a1` |
@@ -53,7 +53,7 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a4`;
+1. `v7.0.0a5`;
 2. `permissions-v0.2.0a1`;
 3. `commands-v0.2.0a1`;
 4. `resources-v0.1.0a1`;

--- a/packages/essentials/tests/test_essentials.py
+++ b/packages/essentials/tests/test_essentials.py
@@ -17,6 +17,7 @@ from liteyukibot_commands.service import create_command_service
 from liteyukibot_essentials import plugin, render_status
 from liteyukibot_permissions import PERMISSION_SERVICE, PUBLIC, PermissionSnapshot, Principal
 
+import liteyukibot
 from liteyukibot import KERNEL_STATUS_SERVICE, LiteyukiApp
 from liteyukibot.config import AppSettings, CoreSettings, PluginSettings
 from liteyukibot.events import (
@@ -277,7 +278,7 @@ async def test_three_plugin_topology_filters_help_and_correlates_status(tmp_path
         status_result = await app.events.publish(status_event)
         assert status_result.stopped is True
         status_action = cast(SendMessage, recorded[-1].action)
-        assert status_action.message.plain_text.startswith("LiteyukiBot 7.0.0a4\n状态: ready")
+        assert status_action.message.plain_text.startswith(f"LiteyukiBot {liteyukibot.__version__}\n状态: ready")
         assert "\n插件:\n- liteyukibot.commands: ready\n- liteyukibot.essentials: ready\n" in (
             status_action.message.plain_text
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a4"
+version = "7.0.0a5"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/run_agent_install.py
+++ b/scripts/run_agent_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -30,7 +33,7 @@ def main() -> int:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_agent_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_astrbot_runtime_install.py
+++ b/scripts/run_astrbot_runtime_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -26,7 +29,7 @@ def main() -> int:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_astrbot_runtime_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_commands_install.py
+++ b/scripts/run_commands_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -32,7 +35,7 @@ def main() -> int:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_commands_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_developer_kit_install.py
+++ b/scripts/run_developer_kit_install.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -31,7 +34,7 @@ def main() -> int:
     for wheel in wheels:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_developer_kit_install.py")))
-    subprocess.run(command, cwd=ROOT, check=True)
+    subprocess.run(command, cwd=ROOT, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_essentials_install.py
+++ b/scripts/run_essentials_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -33,7 +36,7 @@ def main() -> int:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_essentials_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_mofox_runtime_install.py
+++ b/scripts/run_mofox_runtime_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 NEO_MOFOX_REQUIREMENT = (
@@ -31,7 +34,7 @@ def main() -> int:
     command.extend(("--with", NEO_MOFOX_REQUIREMENT))
     command.extend(("python", str(ROOT / "scripts" / "verify_mofox_runtime_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_nonebot_runtime_install.py
+++ b/scripts/run_nonebot_runtime_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -26,7 +29,7 @@ def main() -> int:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_nonebot_runtime_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_permissions_install.py
+++ b/scripts/run_permissions_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -31,7 +34,7 @@ def main() -> int:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_permissions_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_profile_install.py
+++ b/scripts/run_profile_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -37,7 +40,7 @@ def main() -> int:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_profile_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_resources_install.py
+++ b/scripts/run_resources_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -32,7 +35,7 @@ def main() -> int:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_resources_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/run_v6_runtime_install.py
+++ b/scripts/run_v6_runtime_install.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -26,7 +29,7 @@ def main() -> int:
         command.extend(("--with", str(wheel)))
     command.extend(("python", str(ROOT / "scripts" / "verify_v6_runtime_install.py")))
     with tempfile.TemporaryDirectory() as directory:
-        subprocess.run(command, cwd=directory, check=True)
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
     return 0
 
 

--- a/scripts/verify_essentials_install.py
+++ b/scripts/verify_essentials_install.py
@@ -135,7 +135,7 @@ async def verify(expected_version: str | None = None) -> None:
                 raise RuntimeError("installed capability-protected status command did not reply")
             status_message = actions[-1].action
             if not isinstance(status_message, SendMessage) or not status_message.message.plain_text.startswith(
-                "LiteyukiBot 7.0.0a4\nState: ready"
+                f"LiteyukiBot {liteyukibot.__version__}\nState: ready"
             ):
                 raise RuntimeError("installed status command produced invalid text")
         finally:

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -25,7 +25,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a4"),
+        ("root", "v7.0.0a5"),
         ("permissions", "permissions-v0.2.0a1"),
         ("commands", "commands-v0.2.0a1"),
         ("resources", "resources-v0.1.0a1"),
@@ -51,8 +51,8 @@ def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> No
 @pytest.mark.parametrize(
     ("identity", "project_name", "tag", "message"),
     [
-        (ReleaseIdentity("liteyukibot", "7.0.0a4"), "root", None, "project.name"),
-        (ReleaseIdentity("liteyukibot-v7", "7.0.0a4"), "root", "v7.0.0a2", "release tag"),
+        (ReleaseIdentity("liteyukibot", "7.0.0a5"), "root", None, "project.name"),
+        (ReleaseIdentity("liteyukibot-v7", "7.0.0a5"), "root", "v7.0.0a2", "release tag"),
         (
             ReleaseIdentity("liteyukibot-v7-commands", "0.2.0a1"),
             "commands",

--- a/uv.lock
+++ b/uv.lock
@@ -1112,7 +1112,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a4"
+version = "7.0.0a5"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary\n- bump the root distribution to 7.0.0a5 and update release documentation\n- make status verification read the installed kernel version\n- isolate every workspace wheel verifier from the parent development environment\n\n## Validation\n- uv run ruff check .\n- uv run mypy\n- uv run pytest -q (329 passed)\n- uv run python scripts/check_release.py --tag v7.0.0a5\n- all root, plugin, runtime, agent, AstrBot, and MoFox isolated wheel checks