### PR TITLE
feat: add v6 resource function executor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
           uv run python scripts/check_release.py
           uv run python scripts/check_release.py --package permissions
           uv run python scripts/check_release.py --package commands
+          uv run python scripts/check_release.py --package functions
           uv run python scripts/check_release.py --package essentials
           uv run python scripts/check_release.py --package runtime-nonebot
           uv run python scripts/check_release.py --package runtime-v6
@@ -51,6 +52,7 @@ jobs:
           uv run python -m scripts.run_developer_kit_install
           uv run python -m scripts.run_permissions_install
           uv run python -m scripts.run_commands_install
+          uv run python -m scripts.run_functions_install
           uv run python -m scripts.run_essentials_install
           uv run python -m scripts.run_nonebot_runtime_install
           uv run python -m scripts.run_v6_runtime_install

--- a/.github/workflows/publish-plugins.yaml
+++ b/.github/workflows/publish-plugins.yaml
@@ -6,6 +6,7 @@ on:
       - "permissions-v*"
       - "commands-v*"
       - "resources-v*"
+      - "functions-v*"
       - "profile-v*"
       - "essentials-v*"
       - "runtime-nonebot-v*"
@@ -24,6 +25,7 @@ on:
           - permissions
           - commands
           - resources
+          - functions
           - profile
           - essentials
           - runtime-nonebot
@@ -47,7 +49,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('{0}-v{1}', inputs.package, inputs.version) || github.ref_name }}
     environment:
-      name: ${{ github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-v6' && 'pypi-v6-compat' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-astrbot' && 'pypi-astrbot-runtime' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-mofox' && 'pypi-mofox-runtime' || github.event_name == 'workflow_dispatch' && inputs.package == 'agent-resolver' && 'pypi-agent-resolver' || github.event_name == 'workflow_dispatch' && format('pypi-{0}', inputs.package) || startsWith(github.ref_name, 'permissions-v') && 'pypi-permissions' || startsWith(github.ref_name, 'commands-v') && 'pypi-commands' || startsWith(github.ref_name, 'resources-v') && 'pypi-resources' || startsWith(github.ref_name, 'profile-v') && 'pypi-profile' || startsWith(github.ref_name, 'runtime-nonebot-v') && 'pypi-runtime-nonebot' || startsWith(github.ref_name, 'runtime-v6-v') && 'pypi-v6-compat' || startsWith(github.ref_name, 'runtime-astrbot-v') && 'pypi-astrbot-runtime' || startsWith(github.ref_name, 'runtime-mofox-v') && 'pypi-mofox-runtime' || startsWith(github.ref_name, 'agent-resolver-v') && 'pypi-agent-resolver' || startsWith(github.ref_name, 'agent-v') && 'pypi-agent' || 'pypi-essentials' }}
+      name: ${{ github.event_name == 'workflow_dispatch' && inputs.package == 'functions' && 'pypi-lyfunctions' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-v6' && 'pypi-v6-compat' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-astrbot' && 'pypi-astrbot-runtime' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-mofox' && 'pypi-mofox-runtime' || github.event_name == 'workflow_dispatch' && inputs.package == 'agent-resolver' && 'pypi-agent-resolver' || github.event_name == 'workflow_dispatch' && format('pypi-{0}', inputs.package) || startsWith(github.ref_name, 'permissions-v') && 'pypi-permissions' || startsWith(github.ref_name, 'commands-v') && 'pypi-commands' || startsWith(github.ref_name, 'resources-v') && 'pypi-resources' || startsWith(github.ref_name, 'functions-v') && 'pypi-lyfunctions' || startsWith(github.ref_name, 'profile-v') && 'pypi-profile' || startsWith(github.ref_name, 'runtime-nonebot-v') && 'pypi-runtime-nonebot' || startsWith(github.ref_name, 'runtime-v6-v') && 'pypi-v6-compat' || startsWith(github.ref_name, 'runtime-astrbot-v') && 'pypi-astrbot-runtime' || startsWith(github.ref_name, 'runtime-mofox-v') && 'pypi-mofox-runtime' || startsWith(github.ref_name, 'agent-resolver-v') && 'pypi-agent-resolver' || startsWith(github.ref_name, 'agent-v') && 'pypi-agent' || 'pypi-essentials' }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 7.0.0a6 - 2026-08-11
+
+- added nested function invocation and explicit capability plumbing to the
+  resource-function dispatcher;
+- added `liteyukibot-v7-functions`, the separately published executor for the
+  LiteyukiBot v6 `.lyf`, `.lyfunction`, and `.mcfunction` language;
+- preserved v6 control flow while replacing the legacy Python `eval` and direct
+  shell execution with safe literal parsing and caller-supplied capabilities.
+
 ## 7.0.0a5 - 2026-08-11
 
 - added an installable v7 CLI workflow with `uv tool install liteyukibot-v7`;

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a5`. Kernel stabilization,
+The current pre-release is `liteyukibot-v7==7.0.0a6`. Kernel stabilization,
 the first bounded compatibility phase, and the first-party plugin foundation
 are complete. Runtime protocol v3 remains an alpha contract and may change
 under ADR 0011 before the first stable release.
@@ -85,6 +85,17 @@ Install bounded v6 compatibility when legacy plugins are required:
 uv add "liteyukibot-v7-runtime-v6"
 ```
 
+Install the v6 resource-function executor only when workspace resource packs
+contain `.lyf`, `.lyfunction`, or `.mcfunction` files:
+
+```bash
+uv add "liteyukibot-v7-functions"
+```
+
+It preserves the v6 function language but does not grant resource files shell
+or adapter API access by itself; callers must explicitly provide those
+capabilities.
+
 Install the Essentials command layer with:
 
 ```bash
@@ -144,6 +155,7 @@ uv run python -m scripts.run_developer_kit_install
 uv run python -m scripts.run_permissions_install
 uv run python -m scripts.run_commands_install
 uv run python -m scripts.run_resources_install
+uv run python -m scripts.run_functions_install
 uv run python -m scripts.run_profile_install
 uv run python -m scripts.run_essentials_install
 uv run python -m scripts.run_nonebot_runtime_install

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -138,7 +138,7 @@ and published-install matrix are documented in
 
 ## Current Release State
 
-The current pre-release is `liteyukibot-v7==7.0.0a5`. The kernel, bounded v6
+The current pre-release is `liteyukibot-v7==7.0.0a6`. The kernel, bounded v6
 compatibility, separately published NoneBot and v6 runtime boundaries, and first-party plugin foundation are
 complete. Resources and profile remain optional business plugins; their storage
 and migration ownership does not belong to the kernel.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -57,9 +57,15 @@ read the resolved catalog.
 
 `FUNCTION_DISPATCH_SERVICE` resolves read-only files under `functions/` and
 dispatches them to a separately installed executor registered through
-`liteyukibot.function_executors`. The kernel intentionally provides no function
-language or command-execution capability; an unavailable executor raises an
-explicit error.
+`liteyukibot.function_executors`. `liteyukibot-v7-functions` is the first
+executor and supports only the v6 `.lyf`, `.lyfunction`, and `.mcfunction`
+language. The kernel intentionally provides no function language or
+command-execution capability; an unavailable executor raises an explicit error.
+
+The v6 `api` and `cmd` instructions remain capability-gated. A caller must
+explicitly supply the adapter API or command runner it intends to authorize;
+resource packs never gain API access, Python evaluation, or shell execution
+merely by being discovered.
 
 ## Testing
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -19,6 +19,7 @@ Before the first plugin upload, create these Pending Publishers:
 | `liteyukibot-v7-permissions` | `pypi-permissions` |
 | `liteyukibot-v7-commands` | `pypi-commands` |
 | `liteyukibot-v7-resources` | `pypi-resources` |
+| `liteyukibot-v7-functions` | `pypi-lyfunctions` |
 | `liteyukibot-v7-profile` | `pypi-profile` |
 | `liteyukibot-v7-essentials` | `pypi-essentials` |
 | `liteyukibot-v7-runtime-nonebot` | `pypi-runtime-nonebot` |
@@ -37,10 +38,11 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a5` | `pyproject.toml` | `v7.0.0a5` |
+| `liteyukibot-v7==7.0.0a6` | `pyproject.toml` | `v7.0.0a6` |
 | `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
 | `liteyukibot-v7-commands==0.2.0a1` | `packages/commands` | `commands-v0.2.0a1` |
 | `liteyukibot-v7-resources==0.1.0a1` | `packages/resources` | `resources-v0.1.0a1` |
+| `liteyukibot-v7-functions==0.1.0a1` | `packages/functions` | `functions-v0.1.0a1` |
 | `liteyukibot-v7-profile==0.1.0a1` | `packages/profile` | `profile-v0.1.0a1` |
 | `liteyukibot-v7-essentials==0.2.0a2` | `packages/essentials` | `essentials-v0.2.0a2` |
 | `liteyukibot-v7-runtime-nonebot==0.1.0a1` | `packages/runtime-nonebot` | `runtime-nonebot-v0.1.0a1` |
@@ -53,14 +55,15 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a5`;
+1. `v7.0.0a6`;
 2. `permissions-v0.2.0a1`;
 3. `commands-v0.2.0a1`;
 4. `resources-v0.1.0a1`;
-5. `profile-v0.1.0a1`;
-6. `essentials-v0.2.0a2`;
-7. `runtime-nonebot-v0.1.0a1`.
-8. `runtime-v6-v0.1.0a1`.
+5. `functions-v0.1.0a1`;
+6. `profile-v0.1.0a1`;
+7. `essentials-v0.2.0a2`;
+8. `runtime-nonebot-v0.1.0a1`.
+9. `runtime-v6-v0.1.0a1`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/docs/migration-v6.md
+++ b/docs/migration-v6.md
@@ -16,6 +16,8 @@ new plugins should import `liteyukibot`.
   stable priority dispatch, and synchronous reply-intent collection;
 - supervised delivery of normalized message events and ordered string or
   mapping replies through protocol-neutral Actions.
+- separately installed execution of legacy resource functions with `.lyf`,
+  `.lyfunction`, and `.mcfunction` extensions.
 
 ## Unsupported
 
@@ -59,3 +61,15 @@ action_timeout_seconds = 10.0
 [runtimes.legacy.options.config]
 nickname = ["Liteyuki"]
 ```
+
+## Resource Functions
+
+Install `liteyukibot-v7-functions` only for v6 resource packs that use the
+legacy function language. It supports `var`, `api`, `function`, `sleep`,
+`nohup`, `await`, `end`, and `cmd`, including the legacy placeholder forms.
+
+The historical implementation evaluated values with Python `eval` and executed
+`cmd` through the process shell. The v7 executor parses literals safely and
+requires the caller to explicitly provide both API and command capabilities.
+No capability is installed by default, so a resource pack alone cannot invoke
+an adapter API or execute a local command.

--- a/packages/functions/LICENSE
+++ b/packages/functions/LICENSE
@@ -1,0 +1,1 @@
+LicenseRef-LSO

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -1,0 +1,14 @@
+# LiteyukiBot v7 Functions
+
+`liteyukibot-v7-functions` is the v6 Liteyuki resource-function executor for
+LiteyukiBot v7. It registers the `.lyf`, `.lyfunction`, and `.mcfunction`
+extensions through the kernel `liteyukibot.function_executors` entry-point
+group.
+
+It preserves the v6 resource language: `var`, `api`, `function`, `sleep`,
+`nohup`, `await`, `end`, and `cmd`. API and command instructions require a
+caller-supplied capability; installing this package never grants resource files
+access to adapter APIs or the local operating-system shell.
+
+The old v6 `eval` parsing is intentionally replaced by literal parsing. Values
+that are not literals remain strings, matching normal legacy variable lookup.

--- a/packages/functions/pyproject.toml
+++ b/packages/functions/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "liteyukibot-v7-functions"
+version = "0.1.0a1"
+description = "V6 Liteyuki resource-function executor for LiteyukiBot v7."
+readme = "README.md"
+requires-python = ">=3.14"
+license = "LicenseRef-LSO"
+license-files = ["LICENSE"]
+authors = [
+    { name = "LiteyukiStudio" },
+]
+dependencies = [
+    "liteyukibot-v7>=7.0.0a6,<8",
+]
+
+[project.entry-points."liteyukibot.function_executors"]
+v6 = "liteyukibot_functions:V6FunctionExecutor"
+
+[build-system]
+requires = ["uv_build>=0.11.32,<0.12"]
+build-backend = "uv_build"
+
+[tool.uv.sources]
+liteyukibot-v7 = { workspace = true }
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "liteyukibot_functions"

--- a/packages/functions/src/liteyukibot_functions/__init__.py
+++ b/packages/functions/src/liteyukibot_functions/__init__.py
@@ -1,0 +1,21 @@
+"""V6 Liteyuki resource-function execution for LiteyukiBot v7."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+from .executor import (
+    V6FunctionCapabilityError,
+    V6FunctionExecutor,
+    V6FunctionSyntaxError,
+)
+
+try:
+    __version__ = version("liteyukibot-v7-functions")
+except PackageNotFoundError:
+    __version__ = "0.1.0a1"
+
+__all__ = [
+    "V6FunctionCapabilityError",
+    "V6FunctionExecutor",
+    "V6FunctionSyntaxError",
+    "__version__",
+]

--- a/packages/functions/src/liteyukibot_functions/executor.py
+++ b/packages/functions/src/liteyukibot_functions/executor.py
@@ -1,0 +1,203 @@
+"""Interpreter for the bounded LiteyukiBot v6 resource-function language."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from liteyukibot.functions import FunctionCall, FunctionDocument, FunctionInvoker
+
+
+class V6FunctionError(RuntimeError):
+    """Base error for v6 resource-function execution."""
+
+
+class V6FunctionSyntaxError(V6FunctionError):
+    pass
+
+
+class V6FunctionCapabilityError(V6FunctionError):
+    pass
+
+
+type CapabilityMethod = Callable[..., object]
+
+_PLACEHOLDER = re.compile(r"\$\{([^{}]*)\}")
+_ESCAPED_EQUALS = "__LITEYUKI_ESCAPED_EQUALS__"
+
+
+@dataclass(frozen=True, slots=True)
+class _Statement:
+    head: str
+    args: tuple[str, ...]
+    kwargs: Mapping[str, Any]
+    tail: str
+
+
+@dataclass(slots=True)
+class _Execution:
+    call: FunctionCall
+    invoke: FunctionInvoker
+    variables: dict[str, Any] = field(init=False)
+    tasks: set[asyncio.Task[None]] = field(default_factory=set)
+
+    def __post_init__(self) -> None:
+        self.variables = dict(self.call.arguments)
+
+    async def run(self, document: FunctionDocument) -> None:
+        try:
+            for source in document.read_text().splitlines():
+                if not source or source.startswith("#"):
+                    continue
+                if await self._execute(source):
+                    return
+        except BaseException:
+            await self.cancel_tasks()
+            raise
+        finally:
+            self._retain_background_tasks()
+
+    async def _execute(self, source: str) -> bool:
+        statement = self._parse(self._render(source))
+        if statement.head == "var":
+            self.variables.update(statement.kwargs)
+        elif statement.head == "api":
+            api = self._required_argument(statement, "api")
+            await self._capability("call_api", api, statement.kwargs)
+        elif statement.head == "cmd":
+            await self._capability("run_command", statement.tail)
+        elif statement.head == "function":
+            function_id = self._required_argument(statement, "function")
+            await self.invoke(
+                FunctionCall(
+                    function_id,
+                    statement.kwargs,
+                    positional=statement.args[2:],
+                    capabilities=self.call.capabilities,
+                )
+            )
+        elif statement.head == "sleep":
+            seconds = self._required_argument(statement, "sleep")
+            try:
+                delay = float(seconds)
+            except ValueError as error:
+                raise V6FunctionSyntaxError(f"sleep requires a number, got {seconds!r}") from error
+            if delay < 0:
+                raise V6FunctionSyntaxError("sleep requires a non-negative number")
+            await asyncio.sleep(delay)
+        elif statement.head == "nohup":
+            if not statement.tail:
+                raise V6FunctionSyntaxError("nohup requires an instruction")
+            task = asyncio.create_task(self._execute_background(statement.tail), name="liteyuki-v6-function-nohup")
+            self.tasks.add(task)
+            task.add_done_callback(self.tasks.discard)
+        elif statement.head == "await":
+            await self.await_tasks()
+        elif statement.head == "end":
+            await self.cancel_tasks()
+            return True
+        else:
+            raise V6FunctionSyntaxError(f"unsupported v6 function instruction: {statement.head!r}")
+        return False
+
+    async def _execute_background(self, source: str) -> None:
+        await self._execute(source)
+
+    def _render(self, source: str) -> str:
+        if "${" in source:
+            return _PLACEHOLDER.sub(lambda match: str(self.variables.get(match.group(1), "")), source)
+        try:
+            return source.format(*self.call.positional, **self.variables)
+        except IndexError, KeyError, ValueError:
+            return source
+
+    def _parse(self, source: str) -> _Statement:
+        tokens = source.replace(r"\=", _ESCAPED_EQUALS).split(" ")
+        head = tokens[0]
+        args: list[str] = []
+        kwargs: dict[str, Any] = {}
+        for index, token in enumerate(tokens):
+            if "=" in token:
+                key, raw_value = token.split("=", 1)
+                if not key:
+                    raise V6FunctionSyntaxError("function keyword names must not be empty")
+                value = raw_value.replace(_ESCAPED_EQUALS, "=")
+                kwargs[key] = self._literal_or_variable(value)
+            else:
+                value = token.replace(_ESCAPED_EQUALS, "=")
+                if index == 0:
+                    head = value
+                args.append(value)
+        tail = source.split(" ", 1)[1] if " " in source else ""
+        return _Statement(head=head, args=tuple(args), kwargs=kwargs, tail=tail)
+
+    def _literal_or_variable(self, value: str) -> Any:
+        try:
+            return ast.literal_eval(value)
+        except SyntaxError, ValueError:
+            return self.variables.get(value, value)
+
+    @staticmethod
+    def _required_argument(statement: _Statement, instruction: str) -> str:
+        if len(statement.args) < 2 or not statement.args[1]:
+            raise V6FunctionSyntaxError(f"{instruction} requires an argument")
+        return statement.args[1]
+
+    async def _capability(self, name: str, *args: object) -> object:
+        capability = self.call.capabilities
+        method = getattr(capability, name, None)
+        if not callable(method):
+            raise V6FunctionCapabilityError(f"v6 function instruction requires the {name} capability")
+        result = cast(CapabilityMethod, method)(*args)
+        if not inspect.isawaitable(result):
+            raise V6FunctionCapabilityError(f"the {name} capability must return an awaitable")
+        return await result
+
+    async def await_tasks(self) -> None:
+        tasks = tuple(self.tasks)
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    async def cancel_tasks(self) -> None:
+        tasks = tuple(self.tasks)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _retain_background_tasks(self) -> None:
+        for task in tuple(self.tasks):
+            if task.done():
+                continue
+            _BACKGROUND_TASKS.add(task)
+            task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+
+_BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
+
+
+class V6FunctionExecutor:
+    """Execute v6 `.lyf`, `.lyfunction`, and `.mcfunction` resource files."""
+
+    extensions: tuple[str, ...] = (".lyf", ".lyfunction", ".mcfunction")
+
+    async def execute(
+        self,
+        document: FunctionDocument,
+        call: FunctionCall,
+        invoke: FunctionInvoker,
+    ) -> None:
+        await _Execution(call, invoke).run(document)
+
+
+__all__ = [
+    "V6FunctionCapabilityError",
+    "V6FunctionError",
+    "V6FunctionExecutor",
+    "V6FunctionSyntaxError",
+]

--- a/packages/functions/tests/test_functions.py
+++ b/packages/functions/tests/test_functions.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from liteyukibot_functions import V6FunctionCapabilityError, V6FunctionExecutor, V6FunctionSyntaxError
+
+from liteyukibot.functions import FunctionCall, FunctionDispatcher, FunctionRecursionError
+from liteyukibot.resource_packs import ResourceCatalog
+
+
+def _resources(tmp_path: Path, functions: Mapping[str, str]) -> ResourceCatalog:
+    pack = tmp_path / "resources" / "legacy"
+    function_directory = pack / "functions"
+    function_directory.mkdir(parents=True, exist_ok=True)
+    (pack / "metadata.yml").write_text('id: legacy\nname: Legacy\nversion: "6"\n', encoding="utf-8")
+    for name, source in functions.items():
+        path = function_directory / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+    (tmp_path / "resources" / "index.json").write_text('["legacy"]', encoding="utf-8")
+    return ResourceCatalog.load(tmp_path)
+
+
+def _dispatcher(tmp_path: Path, functions: Mapping[str, str]) -> FunctionDispatcher:
+    return FunctionDispatcher(
+        _resources(tmp_path, functions),
+        executors={extension: V6FunctionExecutor() for extension in V6FunctionExecutor.extensions},
+    )
+
+
+class Capabilities:
+    def __init__(self) -> None:
+        self.apis: list[tuple[str, Mapping[str, Any]]] = []
+        self.commands: list[str] = []
+
+    async def call_api(self, api: str, params: Mapping[str, Any]) -> None:
+        self.apis.append((api, params))
+
+    async def run_command(self, command: str) -> None:
+        self.commands.append(command)
+
+
+@pytest.mark.asyncio
+async def test_v6_executor_supports_variables_interpolation_and_api_calls(tmp_path: Path) -> None:
+    dispatcher = _dispatcher(
+        tmp_path,
+        {"hello.lyf": "var target=friend\napi poke user_id=${target}\napi send message={0}\n"},
+    )
+    capabilities = Capabilities()
+
+    await dispatcher.dispatch(FunctionCall("hello", {}, positional=("hello",), capabilities=capabilities))
+
+    assert capabilities.apis == [
+        ("poke", {"user_id": "friend"}),
+        ("send", {"message": "hello"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v6_executor_is_discovered_from_the_installed_entry_point(tmp_path: Path) -> None:
+    dispatcher = FunctionDispatcher(_resources(tmp_path, {"installed.lyf": "api verify value=1\n"}))
+    capabilities = Capabilities()
+
+    await dispatcher.dispatch(FunctionCall("installed", {}, capabilities=capabilities))
+
+    assert capabilities.apis == [("verify", {"value": 1})]
+
+
+@pytest.mark.asyncio
+async def test_v6_executor_supports_nested_nohup_and_await(tmp_path: Path) -> None:
+    dispatcher = _dispatcher(
+        tmp_path,
+        {
+            "main.lyfunction": "nohup function child value=1\nawait\n",
+            "child.mcfunction": "api record value=value\n",
+        },
+    )
+    capabilities = Capabilities()
+
+    await dispatcher.dispatch(FunctionCall("main", {}, capabilities=capabilities))
+
+    assert capabilities.apis == [("record", {"value": 1})]
+
+
+@pytest.mark.asyncio
+async def test_v6_executor_requires_explicit_capabilities(tmp_path: Path) -> None:
+    dispatcher = _dispatcher(tmp_path, {"unsafe.lyf": "api poke\n"})
+
+    with pytest.raises(V6FunctionCapabilityError, match="call_api"):
+        await dispatcher.dispatch(FunctionCall("unsafe", {}))
+
+
+@pytest.mark.asyncio
+async def test_v6_executor_delegates_command_without_spawning_a_shell(tmp_path: Path) -> None:
+    dispatcher = _dispatcher(tmp_path, {"command.lyf": "cmd echo hello\n"})
+    capabilities = Capabilities()
+
+    await dispatcher.dispatch(FunctionCall("command", {}, capabilities=capabilities))
+
+    assert capabilities.commands == ["echo hello"]
+
+
+@pytest.mark.asyncio
+async def test_v6_executor_rejects_unknown_instructions_and_recursive_functions(tmp_path: Path) -> None:
+    unknown = _dispatcher(tmp_path, {"unknown.lyf": "unknown value\n"})
+    with pytest.raises(V6FunctionSyntaxError, match="unsupported"):
+        await unknown.dispatch(FunctionCall("unknown", {}))
+
+    recursive = _dispatcher(tmp_path, {"loop.lyf": "function loop\n"})
+    with pytest.raises(FunctionRecursionError, match="loop -> loop"):
+        await recursive.dispatch(FunctionCall("loop", {}))
+
+
+@pytest.mark.asyncio
+async def test_v6_executor_end_cancels_pending_background_work(tmp_path: Path) -> None:
+    dispatcher = _dispatcher(tmp_path, {"end.lyf": "nohup sleep 60\nend\n"})
+
+    await asyncio.wait_for(dispatcher.dispatch(FunctionCall("end", {})), timeout=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a5"
+version = "7.0.0a6"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -65,6 +65,14 @@ RELEASE_PROJECTS: dict[str, ReleaseProject] = {
         tag_selector="resources-v",
         verifier="scripts/verify_resources_install.py",
     ),
+    "functions": ReleaseProject(
+        name="functions",
+        project_dir="packages/functions",
+        distribution="liteyukibot-v7-functions",
+        tag_prefix="functions-v",
+        tag_selector="functions-v",
+        verifier="scripts/verify_functions_install.py",
+    ),
     "profile": ReleaseProject(
         name="profile",
         project_dir="packages/profile",
@@ -161,9 +169,7 @@ def validate_release(
     tag: str | None = None,
 ) -> None:
     if identity.distribution != project.distribution:
-        raise RuntimeError(
-            f"expected project.name={project.distribution!r}, got {identity.distribution!r}"
-        )
+        raise RuntimeError(f"expected project.name={project.distribution!r}, got {identity.distribution!r}")
     if tag is not None:
         expected_tag = f"{project.tag_prefix}{identity.version}"
         if tag != expected_tag:

--- a/scripts/run_functions_install.py
+++ b/scripts/run_functions_install.py
@@ -1,0 +1,37 @@
+"""Run the v6 functions verifier against workspace-built wheels."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _one_wheel(distribution: str) -> Path:
+    matches = tuple((ROOT / "dist" / "workspace").glob(f"{distribution}-*-py3-none-any.whl"))
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one {distribution} wheel in dist/workspace, found {len(matches)}")
+    return matches[0].resolve()
+
+
+def main() -> int:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv executable was not found")
+    command = [uv, "run", "--no-project", "--python", "3.14"]
+    for wheel in (_one_wheel("liteyukibot_v7"), _one_wheel("liteyukibot_v7_functions")):
+        command.extend(("--with", str(wheel)))
+    command.extend(("python", str(ROOT / "scripts" / "verify_functions_install.py")))
+    with tempfile.TemporaryDirectory() as directory:
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_functions_install.py
+++ b/scripts/verify_functions_install.py
@@ -1,0 +1,68 @@
+"""Verify the installed v6 function executor wheel without workspace sources."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.metadata
+import json
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import liteyukibot_functions
+
+import liteyukibot
+from liteyukibot.functions import FunctionCall, FunctionDispatcher
+from liteyukibot.resource_packs import ResourceCatalog
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Capabilities:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Mapping[str, Any]]] = []
+
+    async def call_api(self, api: str, params: Mapping[str, Any]) -> None:
+        self.calls.append((api, params))
+
+
+def _verify_import_sources() -> None:
+    imported = (Path(liteyukibot.__file__).resolve(), Path(liteyukibot_functions.__file__).resolve())
+    if any(path.is_relative_to(SOURCE_ROOT) for path in imported):
+        raise RuntimeError(f"workspace source import detected: {imported}")
+
+
+async def verify(expected_version: str | None = None) -> None:
+    _verify_import_sources()
+    executors = FunctionDispatcher.discover_executors()
+    if set(liteyukibot_functions.V6FunctionExecutor.extensions) - set(executors):
+        raise RuntimeError("v6 function executor entry point was not discovered")
+
+    with tempfile.TemporaryDirectory() as directory:
+        workspace = Path(directory)
+        pack = workspace / "resources" / "legacy"
+        functions = pack / "functions"
+        functions.mkdir(parents=True)
+        (pack / "metadata.yml").write_text('id: legacy\nname: Legacy\nversion: "6"\n', encoding="utf-8")
+        (workspace / "resources" / "index.json").write_text('["legacy"]', encoding="utf-8")
+        (functions / "verify.lyf").write_text("api verify value=1\n", encoding="utf-8")
+        capabilities = _Capabilities()
+        await FunctionDispatcher(ResourceCatalog.load(workspace)).dispatch(
+            FunctionCall("verify", {}, capabilities=capabilities)
+        )
+        if capabilities.calls != [("verify", {"value": 1})]:
+            raise RuntimeError(f"unexpected v6 function result: {capabilities.calls!r}")
+
+    observed = {name: importlib.metadata.version(name) for name in ("liteyukibot-v7", "liteyukibot-v7-functions")}
+    if expected_version is not None and observed["liteyukibot-v7-functions"] != expected_version:
+        raise RuntimeError(f"expected liteyukibot-v7-functions {expected_version}; observed {observed}")
+    print(json.dumps(observed, sort_keys=True))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-version")
+    arguments = parser.parse_args()
+    asyncio.run(verify(arguments.expected_version))

--- a/src/liteyukibot/functions.py
+++ b/src/liteyukibot/functions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from importlib import metadata
 from pathlib import PurePosixPath
@@ -27,6 +27,10 @@ class FunctionExecutorUnavailableError(FunctionError):
     pass
 
 
+class FunctionRecursionError(FunctionError):
+    pass
+
+
 @dataclass(frozen=True, slots=True)
 class FunctionDocument:
     id: str
@@ -41,12 +45,22 @@ class FunctionDocument:
 class FunctionCall:
     id: str
     arguments: Mapping[str, Any]
+    positional: tuple[str, ...] = ()
+    capabilities: object | None = None
+
+
+type FunctionInvoker = Callable[[FunctionCall], Awaitable[object]]
 
 
 class FunctionExecutor(Protocol):
     extensions: tuple[str, ...]
 
-    def execute(self, document: FunctionDocument, call: FunctionCall) -> Awaitable[object]: ...
+    def execute(
+        self,
+        document: FunctionDocument,
+        call: FunctionCall,
+        invoke: FunctionInvoker,
+    ) -> Awaitable[object]: ...
 
 
 class FunctionCatalog:
@@ -85,7 +99,11 @@ class FunctionDispatcher:
         executors: dict[str, FunctionExecutor] = {}
         for entry in metadata.entry_points(group=cls.ENTRY_POINT_GROUP):
             candidate = entry.load()
-            executor = candidate() if callable(candidate) and not hasattr(candidate, "execute") else candidate
+            executor = (
+                candidate()
+                if inspect.isclass(candidate) or (callable(candidate) and not hasattr(candidate, "execute"))
+                else candidate
+            )
             if not hasattr(executor, "extensions") or not callable(getattr(executor, "execute", None)):
                 raise FunctionError(f"function executor {entry.name!r} has an invalid contract")
             for extension in executor.extensions:
@@ -96,13 +114,25 @@ class FunctionDispatcher:
         return executors
 
     async def dispatch(self, call: FunctionCall) -> object:
+        return await self._dispatch(call, ())
+
+    async def _dispatch(self, call: FunctionCall, stack: tuple[str, ...]) -> object:
         document = self.catalog.require(call.id)
+        if document.id in stack:
+            cycle = " -> ".join((*stack, document.id))
+            raise FunctionRecursionError(f"function recursion is not allowed: {cycle}")
+        if len(stack) >= 32:
+            raise FunctionRecursionError("function nesting exceeds the maximum depth of 32")
         executor = self._executors.get(document.extension)
         if executor is None:
             raise FunctionExecutorUnavailableError(
                 f"no executor is installed for {document.extension} functions; install a matching function package"
             )
-        result = executor.execute(document, call)
+
+        async def invoke(nested_call: FunctionCall) -> object:
+            return await self._dispatch(nested_call, (*stack, document.id))
+
+        result = executor.execute(document, call, invoke)
         if not inspect.isawaitable(result):
             raise FunctionError("function executor execute() must return an awaitable")
         return await result
@@ -118,4 +148,5 @@ __all__ = [
     "FunctionExecutor",
     "FunctionExecutorUnavailableError",
     "FunctionNotFoundError",
+    "FunctionRecursionError",
 ]

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -25,10 +25,11 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a5"),
+        ("root", "v7.0.0a6"),
         ("permissions", "permissions-v0.2.0a1"),
         ("commands", "commands-v0.2.0a1"),
         ("resources", "resources-v0.1.0a1"),
+        ("functions", "functions-v0.1.0a1"),
         ("profile", "profile-v0.1.0a1"),
         ("essentials", "essentials-v0.2.0a2"),
         ("runtime-nonebot", "runtime-nonebot-v0.1.0a1"),

--- a/tests/test_resource_packs.py
+++ b/tests/test_resource_packs.py
@@ -75,7 +75,7 @@ def test_function_dispatches_to_matching_external_executor(tmp_path: Path) -> No
     class Executor:
         extensions: tuple[str, ...] = (".lyf",)
 
-        async def execute(self, document: FunctionDocument, call: FunctionCall) -> object:
+        async def execute(self, document: FunctionDocument, call: FunctionCall, _invoke: object) -> object:
             return {"id": call.id, "source": document.read_text()}
 
     executor: FunctionExecutor = Executor()

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "liteyukibot-v7-agent-resolver",
     "liteyukibot-v7-commands",
     "liteyukibot-v7-essentials",
+    "liteyukibot-v7-functions",
     "liteyukibot-v7-permissions",
     "liteyukibot-v7-profile",
     "liteyukibot-v7-resources",
@@ -1112,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a5"
+version = "7.0.0a6"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1217,6 +1218,17 @@ requires-dist = [
     { name = "liteyukibot-v7", editable = "." },
     { name = "liteyukibot-v7-commands", editable = "packages/commands" },
 ]
+
+[[package]]
+name = "liteyukibot-v7-functions"
+version = "0.1.0a1"
+source = { editable = "packages/functions" }
+dependencies = [
+    { name = "liteyukibot-v7" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-permissions"


### PR DESCRIPTION
## Summary
- add the separately published `liteyukibot-v7-functions` executor for v6 `.lyf`, `.lyfunction`, and `.mcfunction` resources
- preserve v6 control flow while requiring explicit API/command capabilities and replacing `eval` / direct shell execution
- add root `7.0.0a6`, functions `0.1.0a1`, CI wheel verification, and Trusted Publisher routing through `pypi-lyfunctions`

## Validation
- `uv run ruff check .`
- `uv run mypy`
- `uv run pytest -q`
- root/functions release identity checks
- all-workspace wheel build and isolated functions wheel verifier