### PR TITLE
perf: optimize v6 function execution lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 7.0.0a7 - 2026-08-11
+
+- cached v6 function source for each read-only dispatcher lifetime, reducing
+  repeated resource reads without introducing a resource-pack hot-reload path;
+- moved v6 `nohup` tasks into the kernel's managed task lifecycle, so shutdown
+  cancels them deterministically and Yukilog records background failures;
+- added a configurable function benchmark alongside the kernel event benchmark.
+
 ## 7.0.0a6 - 2026-08-11
 
 - added nested function invocation and explicit capability plumbing to the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a6`. Kernel stabilization,
+The current pre-release is `liteyukibot-v7==7.0.0a7`. Kernel stabilization,
 the first bounded compatibility phase, and the first-party plugin foundation
 are complete. Runtime protocol v3 remains an alpha contract and may change
 under ADR 0011 before the first stable release.

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -138,7 +138,7 @@ and published-install matrix are documented in
 
 ## Current Release State
 
-The current pre-release is `liteyukibot-v7==7.0.0a6`. The kernel, bounded v6
+The current pre-release is `liteyukibot-v7==7.0.0a7`. The kernel, bounded v6
 compatibility, separately published NoneBot and v6 runtime boundaries, and first-party plugin foundation are
 complete. Resources and profile remain optional business plugins; their storage
 and migration ownership does not belong to the kernel.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -67,6 +67,10 @@ explicitly supply the adapter API or command runner it intends to authorize;
 resource packs never gain API access, Python evaluation, or shell execution
 merely by being discovered.
 
+Function source is cached for the lifetime of its dispatcher, matching the
+read-only resource-pack contract. Restart the application or construct a new
+dispatcher after changing a workspace function file.
+
 ## Testing
 
 `PluginTestHarness` uses the production lifecycle and EventBus without importing

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -38,11 +38,11 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a6` | `pyproject.toml` | `v7.0.0a6` |
+| `liteyukibot-v7==7.0.0a7` | `pyproject.toml` | `v7.0.0a7` |
 | `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
 | `liteyukibot-v7-commands==0.2.0a1` | `packages/commands` | `commands-v0.2.0a1` |
 | `liteyukibot-v7-resources==0.1.0a1` | `packages/resources` | `resources-v0.1.0a1` |
-| `liteyukibot-v7-functions==0.1.0a1` | `packages/functions` | `functions-v0.1.0a1` |
+| `liteyukibot-v7-functions==0.1.0a2` | `packages/functions` | `functions-v0.1.0a2` |
 | `liteyukibot-v7-profile==0.1.0a1` | `packages/profile` | `profile-v0.1.0a1` |
 | `liteyukibot-v7-essentials==0.2.0a2` | `packages/essentials` | `essentials-v0.2.0a2` |
 | `liteyukibot-v7-runtime-nonebot==0.1.0a1` | `packages/runtime-nonebot` | `runtime-nonebot-v0.1.0a1` |
@@ -55,11 +55,11 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a6`;
+1. `v7.0.0a7`;
 2. `permissions-v0.2.0a1`;
 3. `commands-v0.2.0a1`;
 4. `resources-v0.1.0a1`;
-5. `functions-v0.1.0a1`;
+5. `functions-v0.1.0a2`;
 6. `profile-v0.1.0a1`;
 7. `essentials-v0.2.0a2`;
 8. `runtime-nonebot-v0.1.0a1`.

--- a/packages/functions/pyproject.toml
+++ b/packages/functions/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-functions"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "V6 Liteyuki resource-function executor for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a6,<8",
+    "liteyukibot-v7>=7.0.0a7,<8",
 ]
 
 [project.entry-points."liteyukibot.function_executors"]

--- a/packages/functions/src/liteyukibot_functions/__init__.py
+++ b/packages/functions/src/liteyukibot_functions/__init__.py
@@ -5,17 +5,19 @@ from importlib.metadata import PackageNotFoundError, version
 from .executor import (
     V6FunctionCapabilityError,
     V6FunctionExecutor,
+    V6FunctionRuntimeError,
     V6FunctionSyntaxError,
 )
 
 try:
     __version__ = version("liteyukibot-v7-functions")
 except PackageNotFoundError:
-    __version__ = "0.1.0a1"
+    __version__ = "0.1.0a2"
 
 __all__ = [
     "V6FunctionCapabilityError",
     "V6FunctionExecutor",
+    "V6FunctionRuntimeError",
     "V6FunctionSyntaxError",
     "__version__",
 ]

--- a/packages/functions/src/liteyukibot_functions/executor.py
+++ b/packages/functions/src/liteyukibot_functions/executor.py
@@ -25,6 +25,10 @@ class V6FunctionCapabilityError(V6FunctionError):
     pass
 
 
+class V6FunctionRuntimeError(V6FunctionError):
+    pass
+
+
 type CapabilityMethod = Callable[..., object]
 
 _PLACEHOLDER = re.compile(r"\$\{([^{}]*)\}")
@@ -39,28 +43,29 @@ class _Statement:
     tail: str
 
 
+@dataclass(frozen=True, slots=True)
+class _Program:
+    lines: tuple[str, ...]
+
+
 @dataclass(slots=True)
 class _Execution:
     call: FunctionCall
     invoke: FunctionInvoker
     variables: dict[str, Any] = field(init=False)
-    tasks: set[asyncio.Task[None]] = field(default_factory=set)
+    tasks: set[asyncio.Task[Any]] = field(default_factory=set)
 
     def __post_init__(self) -> None:
         self.variables = dict(self.call.arguments)
 
-    async def run(self, document: FunctionDocument) -> None:
+    async def run(self, program: _Program) -> None:
         try:
-            for source in document.read_text().splitlines():
-                if not source or source.startswith("#"):
-                    continue
+            for source in program.lines:
                 if await self._execute(source):
                     return
         except BaseException:
             await self.cancel_tasks()
             raise
-        finally:
-            self._retain_background_tasks()
 
     async def _execute(self, source: str) -> bool:
         statement = self._parse(self._render(source))
@@ -93,9 +98,10 @@ class _Execution:
         elif statement.head == "nohup":
             if not statement.tail:
                 raise V6FunctionSyntaxError("nohup requires an instruction")
-            task = asyncio.create_task(self._execute_background(statement.tail), name="liteyuki-v6-function-nohup")
+            if self.call.task_owner is None:
+                raise V6FunctionRuntimeError("v6 function nohup requires a dispatcher task owner")
+            task = self.call.task_owner.start(self._execute_background(statement.tail), name="v6-nohup")
             self.tasks.add(task)
-            task.add_done_callback(self.tasks.discard)
         elif statement.head == "await":
             await self.await_tasks()
         elif statement.head == "end":
@@ -160,8 +166,11 @@ class _Execution:
 
     async def await_tasks(self) -> None:
         tasks = tuple(self.tasks)
-        if tasks:
-            await asyncio.gather(*tasks)
+        try:
+            if tasks:
+                await asyncio.gather(*tasks)
+        finally:
+            self.tasks.difference_update(tasks)
 
     async def cancel_tasks(self) -> None:
         tasks = tuple(self.tasks)
@@ -169,16 +178,7 @@ class _Execution:
             task.cancel()
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-
-    def _retain_background_tasks(self) -> None:
-        for task in tuple(self.tasks):
-            if task.done():
-                continue
-            _BACKGROUND_TASKS.add(task)
-            task.add_done_callback(_BACKGROUND_TASKS.discard)
-
-
-_BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
+        self.tasks.difference_update(tasks)
 
 
 class V6FunctionExecutor:
@@ -186,18 +186,33 @@ class V6FunctionExecutor:
 
     extensions: tuple[str, ...] = (".lyf", ".lyfunction", ".mcfunction")
 
+    def __init__(self) -> None:
+        self._programs: dict[int, _Program] = {}
+
     async def execute(
         self,
         document: FunctionDocument,
         call: FunctionCall,
         invoke: FunctionInvoker,
     ) -> None:
-        await _Execution(call, invoke).run(document)
+        await _Execution(call, invoke).run(self._program(document))
+
+    def _program(self, document: FunctionDocument) -> _Program:
+        key = id(document.resource)
+        program = self._programs.get(key)
+        if program is None:
+            source = document.read_text()
+            program = _Program(
+                lines=tuple(line for line in source.splitlines() if line and not line.startswith("#")),
+            )
+            self._programs[key] = program
+        return program
 
 
 __all__ = [
     "V6FunctionCapabilityError",
     "V6FunctionError",
     "V6FunctionExecutor",
+    "V6FunctionRuntimeError",
     "V6FunctionSyntaxError",
 ]

--- a/packages/functions/tests/test_functions.py
+++ b/packages/functions/tests/test_functions.py
@@ -8,7 +8,7 @@ from typing import Any
 import pytest
 from liteyukibot_functions import V6FunctionCapabilityError, V6FunctionExecutor, V6FunctionSyntaxError
 
-from liteyukibot.functions import FunctionCall, FunctionDispatcher, FunctionRecursionError
+from liteyukibot.functions import FunctionCall, FunctionDispatcher, FunctionError, FunctionRecursionError
 from liteyukibot.resource_packs import ResourceCatalog
 
 
@@ -75,8 +75,8 @@ async def test_v6_executor_supports_nested_nohup_and_await(tmp_path: Path) -> No
     dispatcher = _dispatcher(
         tmp_path,
         {
-            "main.lyfunction": "nohup function child value=1\nawait\n",
-            "child.mcfunction": "api record value=value\n",
+            "main.lyfunction": "function child value=1\n",
+            "child.mcfunction": "nohup api record value=value\nawait\n",
         },
     )
     capabilities = Capabilities()
@@ -120,3 +120,38 @@ async def test_v6_executor_end_cancels_pending_background_work(tmp_path: Path) -
     dispatcher = _dispatcher(tmp_path, {"end.lyf": "nohup sleep 60\nend\n"})
 
     await asyncio.wait_for(dispatcher.dispatch(FunctionCall("end", {})), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_v6_executor_reloads_function_source_with_a_new_dispatcher(tmp_path: Path) -> None:
+    dispatcher = _dispatcher(tmp_path, {"cached.lyf": "api record value=1\n"})
+    capabilities = Capabilities()
+
+    await dispatcher.dispatch(FunctionCall("cached", {}, capabilities=capabilities))
+    (tmp_path / "resources" / "legacy" / "functions" / "cached.lyf").write_text(
+        "api record value=2\n",
+        encoding="utf-8",
+    )
+    await dispatcher.dispatch(FunctionCall("cached", {}, capabilities=capabilities))
+    reloaded = _dispatcher(tmp_path, {"cached.lyf": "api record value=2\n"})
+    await reloaded.dispatch(FunctionCall("cached", {}, capabilities=capabilities))
+
+    assert capabilities.apis == [
+        ("record", {"value": 1}),
+        ("record", {"value": 1}),
+        ("record", {"value": 2}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v6_executor_shutdown_cancels_unawaited_background_work(tmp_path: Path) -> None:
+    dispatcher = _dispatcher(tmp_path, {"background.lyf": "nohup sleep 60\n"})
+
+    await dispatcher.dispatch(FunctionCall("background", {}))
+    await asyncio.sleep(0)
+
+    assert dispatcher.background_task_count == 1
+    await dispatcher.aclose()
+    assert dispatcher.background_task_count == 0
+    with pytest.raises(FunctionError, match="closed"):
+        await dispatcher.dispatch(FunctionCall("background", {}))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a6"
+version = "7.0.0a7"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/benchmark_v7.py
+++ b/scripts/benchmark_v7.py
@@ -12,15 +12,25 @@ import platform
 import statistics
 import tempfile
 import time
+import tracemalloc
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, cast
 
 from liteyukibot.app import LiteyukiApp
 from liteyukibot.config import AppSettings, CoreSettings, LoggingSettings
 from liteyukibot.events import ConversationRef, EventBus, EventEnvelope
+from liteyukibot.functions import FunctionCall, FunctionDispatcher
+from liteyukibot.resource_packs import ResourceCatalog
 
 
-async def benchmark(event_count: int) -> dict[str, Any]:
+async def benchmark(
+    event_count: int,
+    *,
+    function_packs: int,
+    functions_per_pack: int,
+    function_calls: int,
+) -> dict[str, Any]:
     started = time.perf_counter()
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
@@ -72,7 +82,7 @@ async def benchmark(event_count: int) -> dict[str, Any]:
         await app.stop()
 
     sorted_latencies = sorted(latencies)
-    return {
+    result: dict[str, Any] = {
         "schema": 1,
         "platform": platform.platform(),
         "python": platform.python_version(),
@@ -85,6 +95,103 @@ async def benchmark(event_count: int) -> dict[str, Any]:
         },
         "peak_rss_bytes": _peak_rss_bytes(),
     }
+    result["functions"] = await _benchmark_functions(
+        packs=function_packs,
+        functions_per_pack=functions_per_pack,
+        calls=function_calls,
+    )
+    return result
+
+
+async def _benchmark_functions(*, packs: int, functions_per_pack: int, calls: int) -> dict[str, Any]:
+    if calls == 0:
+        return {"available": False, "reason": "disabled"}
+    if not FunctionDispatcher.discover_executors():
+        return {"available": False, "reason": "no function executor is installed"}
+
+    with tempfile.TemporaryDirectory() as directory:
+        workspace = Path(directory)
+        _write_function_resources(workspace, packs, functions_per_pack)
+        started = time.perf_counter()
+        catalog = ResourceCatalog.load(workspace)
+        dispatcher = FunctionDispatcher(catalog)
+        cold_setup_ms = (time.perf_counter() - started) * 1000
+
+        call = FunctionCall("benchmark-0-0", {})
+        started = time.perf_counter()
+        await dispatcher.dispatch(call)
+        first_call_ms = (time.perf_counter() - started) * 1000
+
+        hot_latencies: list[float] = []
+        for _ in range(calls):
+            started = time.perf_counter()
+            await dispatcher.dispatch(call)
+            hot_latencies.append((time.perf_counter() - started) * 1000)
+
+        cold_setup_peak = await _tracemalloc_peak(lambda: _create_dispatcher(workspace))
+        first_call_peak = await _tracemalloc_peak(lambda: _dispatch_once(workspace, call))
+        hot_peak = await _tracemalloc_peak(lambda: _dispatch_many(workspace, call, calls))
+
+    sorted_hot = sorted(hot_latencies)
+    return {
+        "available": True,
+        "packs": packs,
+        "functions_per_pack": functions_per_pack,
+        "calls": calls,
+        "catalog_setup_ms": cold_setup_ms,
+        "catalog_setup_tracemalloc_peak_bytes": cold_setup_peak,
+        "first_call_ms": first_call_ms,
+        "first_call_tracemalloc_peak_bytes": first_call_peak,
+        "hot_call_ms": {
+            "median": statistics.median(sorted_hot),
+            "p95": sorted_hot[int(len(sorted_hot) * 0.95) - 1],
+            "tracemalloc_peak_bytes": hot_peak,
+        },
+    }
+
+
+async def _create_dispatcher(workspace: Path) -> None:
+    FunctionDispatcher(ResourceCatalog.load(workspace))
+
+
+async def _dispatch_once(workspace: Path, call: FunctionCall) -> None:
+    await FunctionDispatcher(ResourceCatalog.load(workspace)).dispatch(call)
+
+
+async def _dispatch_many(workspace: Path, call: FunctionCall, calls: int) -> None:
+    dispatcher = FunctionDispatcher(ResourceCatalog.load(workspace))
+    for _ in range(calls):
+        await dispatcher.dispatch(call)
+
+
+async def _tracemalloc_peak(operation: Callable[[], Awaitable[None]]) -> int:
+    tracemalloc.start()
+    try:
+        await operation()
+        return tracemalloc.get_traced_memory()[1]
+    finally:
+        tracemalloc.stop()
+
+
+def _write_function_resources(workspace: Path, packs: int, functions_per_pack: int) -> None:
+    root = workspace / "resources"
+    index: list[str] = []
+    for pack_index in range(packs):
+        name = f"pack-{pack_index}"
+        index.append(name)
+        pack = root / name
+        functions = pack / "functions"
+        functions.mkdir(parents=True)
+        (pack / "metadata.yml").write_text(
+            f'id: {name}\nname: {name}\nversion: "1"\n',
+            encoding="utf-8",
+        )
+        for function_index in range(functions_per_pack):
+            (functions / f"benchmark-{pack_index}-{function_index}.lyf").write_text(
+                "var value=1\nvar rendered=${value}\n",
+                encoding="utf-8",
+            )
+    (root / "index.json").write_text(json.dumps(index), encoding="utf-8")
 
 
 def _peak_rss_bytes() -> int:
@@ -129,11 +236,23 @@ def _windows_peak_rss() -> int:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--events", type=int, default=5000)
+    parser.add_argument("--function-packs", type=int, default=8)
+    parser.add_argument("--functions-per-pack", type=int, default=16)
+    parser.add_argument("--function-calls", type=int, default=1000)
     parser.add_argument("--output", type=Path, default=Path("benchmark.json"))
     args = parser.parse_args()
     if args.events < 100:
         parser.error("--events must be at least 100")
-    result = asyncio.run(benchmark(args.events))
+    if args.function_packs < 1 or args.functions_per_pack < 1 or args.function_calls < 0:
+        parser.error("function benchmark counts must be positive, except --function-calls may be zero")
+    result = asyncio.run(
+        benchmark(
+            args.events,
+            function_packs=args.function_packs,
+            functions_per_pack=args.functions_per_pack,
+            function_calls=args.function_calls,
+        )
+    )
     args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(result, indent=2))
     return 0

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -28,6 +28,7 @@ from .runtime import (
 )
 from .services import ServiceRegistry
 from .status import KERNEL_STATUS_SERVICE, KernelStatusSnapshot
+from .tasks import ManagedTasks
 
 
 class AppState(StrEnum):
@@ -146,6 +147,7 @@ class LiteyukiApp:
         self._runtime_state_directories: dict[str, Any] = {}
         self.resources: ResourceCatalog | None = None
         self.functions: FunctionDispatcher | None = None
+        self._function_tasks = ManagedTasks("functions", on_failure=self._function_task_failed)
         runtime_plugins = RuntimeCatalog().discover()
         for runtime_id, runtime in settings.runtimes.items():
             if not runtime.enabled:
@@ -216,7 +218,7 @@ class LiteyukiApp:
                 for declaration in definition.manifest.resource_packs
             )
             self.resources = ResourceCatalog.load(self.resource_workspace, plugin_packs=declarations)
-            self.functions = FunctionDispatcher(self.resources)
+            self.functions = FunctionDispatcher(self.resources, task_owner=self._function_tasks)
             self.services.provide(RESOURCE_CATALOG_SERVICE, self.resources, provider="liteyukibot.kernel")
             self.services.provide(FUNCTION_DISPATCH_SERVICE, self.functions, provider="liteyukibot.kernel")
             plugin_configs = self._plugin_configs(self.settings.plugins.config)
@@ -339,6 +341,11 @@ class LiteyukiApp:
             except BaseException as error:
                 errors.append(error)
             self._plugins_setup = False
+        if self.functions is not None:
+            try:
+                await self.functions.aclose()
+            except BaseException as error:
+                errors.append(error)
         if self._runtimes_started or self.runtimes.records:
             try:
                 await self.runtimes.stop()
@@ -353,6 +360,9 @@ class LiteyukiApp:
             self._logging_started = False
         if errors:
             raise BaseExceptionGroup("application cleanup failed", errors)
+
+    def _function_task_failed(self, name: str, error: BaseException) -> None:
+        self.logger.bind(component="functions").error("function task {} failed: {}", name, error)
 
     async def _ingest_runtime_event(self, runtime_id: str, payload: dict[str, Any]) -> str:
         if not self._accepting_events:

--- a/src/liteyukibot/functions.py
+++ b/src/liteyukibot/functions.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Awaitable, Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from importlib import metadata
 from pathlib import PurePosixPath
 from typing import Any, Protocol
 
 from .resource_packs import ResourceCatalog, ResourceFile
 from .services import ServiceKey
+from .tasks import ManagedTasks
 
 FUNCTION_DISPATCH_SERVICE = ServiceKey("liteyukibot.functions", 1)
 
@@ -47,6 +48,7 @@ class FunctionCall:
     arguments: Mapping[str, Any]
     positional: tuple[str, ...] = ()
     capabilities: object | None = None
+    task_owner: ManagedTasks | None = field(default=None, repr=False, compare=False)
 
 
 type FunctionInvoker = Callable[[FunctionCall], Awaitable[object]]
@@ -90,9 +92,21 @@ class FunctionCatalog:
 class FunctionDispatcher:
     ENTRY_POINT_GROUP = "liteyukibot.function_executors"
 
-    def __init__(self, resources: ResourceCatalog, executors: Mapping[str, FunctionExecutor] | None = None) -> None:
+    def __init__(
+        self,
+        resources: ResourceCatalog,
+        executors: Mapping[str, FunctionExecutor] | None = None,
+        *,
+        task_owner: ManagedTasks | None = None,
+    ) -> None:
         self.catalog = FunctionCatalog(resources)
         self._executors = dict(executors) if executors is not None else self.discover_executors()
+        self._task_owner = task_owner or ManagedTasks("functions")
+        self._closed = False
+
+    @property
+    def background_task_count(self) -> int:
+        return self._task_owner.count
 
     @classmethod
     def discover_executors(cls) -> dict[str, FunctionExecutor]:
@@ -114,9 +128,18 @@ class FunctionDispatcher:
         return executors
 
     async def dispatch(self, call: FunctionCall) -> object:
+        if self._closed:
+            raise FunctionError("function dispatcher is closed")
         return await self._dispatch(call, ())
 
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._task_owner.stop()
+
     async def _dispatch(self, call: FunctionCall, stack: tuple[str, ...]) -> object:
+        call = replace(call, task_owner=self._task_owner)
         document = self.catalog.require(call.id)
         if document.id in stack:
             cycle = " -> ".join((*stack, document.id))

--- a/src/liteyukibot/tasks.py
+++ b/src/liteyukibot/tasks.py
@@ -16,6 +16,10 @@ class ManagedTasks:
         self._tasks: set[asyncio.Task[Any]] = set()
         self._closing = False
 
+    @property
+    def count(self) -> int:
+        return len(self._tasks)
+
     def start(self, awaitable: Coroutine[Any, Any, Any], *, name: str) -> asyncio.Task[Any]:
         if self._closing:
             raise RuntimeError(f"task owner {self.owner} is stopping")

--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -35,6 +35,7 @@ from liteyukibot.events import (
     SendMessage,
 )
 from liteyukibot.exceptions import PluginError
+from liteyukibot.functions import FunctionCall
 from liteyukibot.plugins import PluginDefinition, PluginHandle, PluginManifest
 from liteyukibot.runtime.protocol import EventAccepted
 from liteyukibot.services import ServiceKey, ServiceRequirement
@@ -59,6 +60,31 @@ class FakeLogger:
 
     def exception(self, message: str, *args: Any, **kwargs: Any) -> None:
         pass
+
+
+@pytest.mark.asyncio
+async def test_app_shutdown_cancels_function_background_tasks(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    functions = workspace / "resources" / "legacy" / "functions"
+    functions.mkdir(parents=True)
+    (functions.parent / "metadata.yml").write_text(
+        'id: legacy\nname: Legacy\nversion: "6"\n',
+        encoding="utf-8",
+    )
+    (functions / "background.lyf").write_text("nohup sleep 60\n", encoding="utf-8")
+    (workspace / "resources" / "index.json").write_text('["legacy"]', encoding="utf-8")
+    settings = AppSettings(core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"))
+    app = LiteyukiApp(settings, logger=FakeLogger(), resource_workspace=str(workspace))  # type: ignore[arg-type]
+
+    await app.start()
+    assert app.functions is not None
+    await app.functions.dispatch(FunctionCall("background", {}))
+    await asyncio.sleep(0)
+    assert app.functions.background_task_count == 1
+
+    await app.stop()
+
+    assert app.functions.background_task_count == 0
 
 
 def test_kernel_status_service_is_available_before_plugin_resolution(tmp_path: Path) -> None:

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -25,11 +25,11 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a6"),
+        ("root", "v7.0.0a7"),
         ("permissions", "permissions-v0.2.0a1"),
         ("commands", "commands-v0.2.0a1"),
         ("resources", "resources-v0.1.0a1"),
-        ("functions", "functions-v0.1.0a1"),
+        ("functions", "functions-v0.1.0a2"),
         ("profile", "profile-v0.1.0a1"),
         ("essentials", "essentials-v0.2.0a2"),
         ("runtime-nonebot", "runtime-nonebot-v0.1.0a1"),

--- a/uv.lock
+++ b/uv.lock
@@ -1113,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a6"
+version = "7.0.0a7"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1221,7 +1221,7 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-functions"
-version = "0.1.0a1"
+version = "0.1.0a2"
 source = { editable = "packages/functions" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Summary
- cache v6 function source for the read-only dispatcher lifetime and add a configurable function benchmark
- manage v6 nohup tasks through the dispatcher/application lifecycle, including nested function calls and Yukilog failure reporting
- release liteyukibot-v7 7.0.0a7 and liteyukibot-v7-functions 0.1.0a2

## Validation
- uv run ruff check .
- uv run mypy
- uv run pytest -q (345 passed)
- isolated root and combined root/functions wheel verification
- 8 packs, 128 functions, 10,000 hot calls: median about 0.052 ms to 0.014 ms