### PR TITLE
feat: add native adapter runtime host

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+.gitattributes text eol=lf
 * text=auto
 
 *.py text eol=lf
@@ -8,6 +9,7 @@
 *.yml text eol=lf
 *.md text eol=lf
 *.txt text eol=lf
+*.lang text eol=lf
 *.ps1 text eol=crlf
 *.bat text eol=crlf
 *.cmd text eol=crlf

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
           uv run python scripts/check_release.py --package functions
           uv run python scripts/check_release.py --package essentials
           uv run python scripts/check_release.py --package runtime-nonebot
+          uv run python scripts/check_release.py --package runtime-adapter
           uv run python scripts/check_release.py --package runtime-v6
           uv run python scripts/check_release.py --package agent
           uv run python scripts/check_release.py --package runtime-astrbot
@@ -56,6 +57,7 @@ jobs:
           uv run python -m scripts.run_functions_install
           uv run python -m scripts.run_essentials_install
           uv run python -m scripts.run_nonebot_runtime_install
+          uv run python -m scripts.run_adapter_runtime_install
           uv run python -m scripts.run_v6_runtime_install
           uv run python -m scripts.run_agent_install
           uv run python -m scripts.run_astrbot_runtime_install

--- a/.github/workflows/publish-plugins.yaml
+++ b/.github/workflows/publish-plugins.yaml
@@ -10,6 +10,7 @@ on:
       - "profile-v*"
       - "essentials-v*"
       - "runtime-nonebot-v*"
+      - "runtime-adapter-v*"
       - "runtime-v6-v*"
       - "runtime-astrbot-v*"
       - "runtime-mofox-v*"
@@ -29,6 +30,7 @@ on:
           - profile
           - essentials
           - runtime-nonebot
+          - runtime-adapter
           - runtime-v6
           - runtime-astrbot
           - runtime-mofox
@@ -49,7 +51,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && format('{0}-v{1}', inputs.package, inputs.version) || github.ref_name }}
     environment:
-      name: ${{ github.event_name == 'workflow_dispatch' && inputs.package == 'functions' && 'pypi-lyfunctions' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-v6' && 'pypi-v6-compat' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-astrbot' && 'pypi-astrbot-runtime' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-mofox' && 'pypi-mofox-runtime' || github.event_name == 'workflow_dispatch' && inputs.package == 'agent-resolver' && 'pypi-agent-resolver' || github.event_name == 'workflow_dispatch' && format('pypi-{0}', inputs.package) || startsWith(github.ref_name, 'permissions-v') && 'pypi-permissions' || startsWith(github.ref_name, 'commands-v') && 'pypi-commands' || startsWith(github.ref_name, 'resources-v') && 'pypi-resources' || startsWith(github.ref_name, 'functions-v') && 'pypi-lyfunctions' || startsWith(github.ref_name, 'profile-v') && 'pypi-profile' || startsWith(github.ref_name, 'runtime-nonebot-v') && 'pypi-runtime-nonebot' || startsWith(github.ref_name, 'runtime-v6-v') && 'pypi-v6-compat' || startsWith(github.ref_name, 'runtime-astrbot-v') && 'pypi-astrbot-runtime' || startsWith(github.ref_name, 'runtime-mofox-v') && 'pypi-mofox-runtime' || startsWith(github.ref_name, 'agent-resolver-v') && 'pypi-agent-resolver' || startsWith(github.ref_name, 'agent-v') && 'pypi-agent' || 'pypi-essentials' }}
+      name: ${{ github.event_name == 'workflow_dispatch' && inputs.package == 'functions' && 'pypi-lyfunctions' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-v6' && 'pypi-v6-compat' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-adapter' && 'pypi-runtime-adapter' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-astrbot' && 'pypi-astrbot-runtime' || github.event_name == 'workflow_dispatch' && inputs.package == 'runtime-mofox' && 'pypi-mofox-runtime' || github.event_name == 'workflow_dispatch' && inputs.package == 'agent-resolver' && 'pypi-agent-resolver' || github.event_name == 'workflow_dispatch' && format('pypi-{0}', inputs.package) || startsWith(github.ref_name, 'permissions-v') && 'pypi-permissions' || startsWith(github.ref_name, 'commands-v') && 'pypi-commands' || startsWith(github.ref_name, 'resources-v') && 'pypi-resources' || startsWith(github.ref_name, 'functions-v') && 'pypi-lyfunctions' || startsWith(github.ref_name, 'profile-v') && 'pypi-profile' || startsWith(github.ref_name, 'runtime-nonebot-v') && 'pypi-runtime-nonebot' || startsWith(github.ref_name, 'runtime-adapter-v') && 'pypi-runtime-adapter' || startsWith(github.ref_name, 'runtime-v6-v') && 'pypi-v6-compat' || startsWith(github.ref_name, 'runtime-astrbot-v') && 'pypi-astrbot-runtime' || startsWith(github.ref_name, 'runtime-mofox-v') && 'pypi-mofox-runtime' || startsWith(github.ref_name, 'agent-resolver-v') && 'pypi-agent-resolver' || startsWith(github.ref_name, 'agent-v') && 'pypi-agent' || 'pypi-essentials' }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- added `liteyukibot-v7-runtime-adapter`, a separately published Python
+  platform-adapter host with managed-generation and entry-point boundaries;
+- extended resource-pack metadata with localized presentation keys and optional
+  validated local PNG icons for a future WebUI, without adding a WebUI route;
 - added the kernel-owned `liteyukibot.i18n@1` service backed by layered resource
   packs, including per-user locale rendering for essential commands;
 - moved first-party profile/resource command text and custom-init package labels

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a10`. Kernel stabilization,
+The current pre-release is `liteyukibot-v7==7.0.0a11`. Kernel stabilization,
 the first bounded compatibility phase, and the first-party plugin foundation
 are complete. Runtime protocol v4 remains an alpha contract and may change
 under ADR 0011 before the first stable release.
@@ -77,6 +77,13 @@ Framework hosts are independent packages. Install NoneBot2 with an adapter:
 ```bash
 uv add "liteyukibot-v7-runtime-nonebot[onebot]"
 # or: uv add "liteyukibot-v7-runtime-nonebot[satori]"
+```
+
+Install the Python platform-adapter host independently. It contains no platform
+SDK; protocol and platform adapters are separately published packages:
+
+```bash
+uv add liteyukibot-v7-runtime-adapter
 ```
 
 Install bounded v6 compatibility when legacy plugins are required:
@@ -159,6 +166,7 @@ uv run python -m scripts.run_functions_install
 uv run python -m scripts.run_profile_install
 uv run python -m scripts.run_essentials_install
 uv run python -m scripts.run_nonebot_runtime_install
+uv run python -m scripts.run_adapter_runtime_install
 ```
 
 The architecture overview is documented in `docs/architecture/v7.md`; accepted

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -89,6 +89,13 @@ structured messages into frozen core envelopes, and reconstructs native
 messages for replies and supported proactive routes. Adapter packages remain
 optional and adapter objects never cross the runtime boundary.
 
+The `liteyukibot-v7-runtime-adapter` package is the independent Python host
+for new protocol and platform adapter packages. Adapters publish a controlled
+`liteyukibot.adapters` entry point and own their SDK objects, credentials,
+network connections, and event/action conversion inside that child process.
+The kernel exchanges only frozen envelopes. Managed runtime generations permit
+only their selected adapter entry points; the host ships without a platform SDK.
+
 The `liteyukibot-v7-runtime-v6` package owns the `liteyuki` compatibility
 namespace and v6 child host. The kernel is the only runtime communication hub.
 Configured event routes

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -51,9 +51,19 @@ manifest = PluginManifest(
 ```
 
 The declared package root defaults to `resources/` and must contain
-`metadata.yml`. Enabled plugin packs overlay kernel resources but are overridden
-by workspace packs. Declare `RESOURCE_CATALOG_SERVICE` when a plugin needs to
-read the resolved catalog.
+`metadata.yml`. Declare a pack only when the plugin has visible text, static
+assets, or future control-plane presentation. Use package `lang/en-US.lang`
+and `lang/zh-CN.lang` catalogs for visible text; declare `I18N_SERVICE` and
+resolve text through the injected `Translator`, never a package-local Python
+dictionary. Prefix keys with the plugin ID, for example `example.echo.name`.
+
+`metadata.yml` may contain `name_key`, `description_key`, and `icon`. The icon
+is package-relative, local-only `icon.png`: a transparent square PNG no larger
+than 512 KiB. Resource metadata and `ResourceCatalog.icon()` form a read-only
+future WebUI interface; v7 does not yet expose an HTTP asset route or WebUI.
+Enabled plugin packs overlay kernel resources but are overridden by workspace
+packs. Declare `RESOURCE_CATALOG_SERVICE` when a plugin needs to read the
+resolved catalog.
 
 `FUNCTION_DISPATCH_SERVICE` resolves read-only files under `functions/` and
 dispatches them to a separately installed executor registered through

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -23,6 +23,7 @@ Before the first plugin upload, create these Pending Publishers:
 | `liteyukibot-v7-profile` | `pypi-profile` |
 | `liteyukibot-v7-essentials` | `pypi-essentials` |
 | `liteyukibot-v7-runtime-nonebot` | `pypi-runtime-nonebot` |
+| `liteyukibot-v7-runtime-adapter` | `pypi-runtime-adapter` |
 | `liteyukibot-v7-runtime-v6` | `pypi-runtime-v6` |
 
 PyPI requires different pending project names to use distinct publisher
@@ -38,7 +39,7 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a10` | `pyproject.toml` | `v7.0.0a10` |
+| `liteyukibot-v7==7.0.0a11` | `pyproject.toml` | `v7.0.0a11` |
 | `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |
@@ -46,6 +47,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-profile==0.1.0a2` | `packages/profile` | `profile-v0.1.0a2` |
 | `liteyukibot-v7-essentials==0.2.0a3` | `packages/essentials` | `essentials-v0.2.0a3` |
 | `liteyukibot-v7-runtime-nonebot==0.1.0a1` | `packages/runtime-nonebot` | `runtime-nonebot-v0.1.0a1` |
+| `liteyukibot-v7-runtime-adapter==0.1.0a1` | `packages/runtime-adapter` | `runtime-adapter-v0.1.0a1` |
 | `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
@@ -55,7 +57,7 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a10`;
+1. `v7.0.0a11`;
 2. `permissions-v0.2.0a1`;
 3. `commands-v0.2.0a2`;
 4. `resources-v0.1.0a2`;
@@ -63,7 +65,8 @@ Push and wait for each release before creating the next tag:
 6. `profile-v0.1.0a2`;
 7. `essentials-v0.2.0a3`;
 8. `runtime-nonebot-v0.1.0a1`.
-9. `runtime-v6-v0.1.0a1`.
+9. `runtime-adapter-v0.1.0a1`.
+10. `runtime-v6-v0.1.0a1`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/packages/runtime-adapter/LICENSE
+++ b/packages/runtime-adapter/LICENSE
@@ -1,0 +1,6 @@
+Liteyuki Shared License
+
+Copyright (c) LiteyukiStudio.
+
+Use, modification, and redistribution are governed by the repository-level
+license terms.

--- a/packages/runtime-adapter/README.md
+++ b/packages/runtime-adapter/README.md
@@ -1,0 +1,30 @@
+# LiteyukiBot Python Adapter Runtime
+
+`liteyukibot-v7-runtime-adapter` hosts Python platform adapters as supervised
+LiteyukiBot child runtimes. Install this package with one or more separately
+published adapter distributions; the base host intentionally includes no
+platform SDK or protocol implementation.
+
+Adapter distributions publish an entry point in `liteyukibot.adapters`. Each
+adapter owns its credentials and SDK objects inside this child process and
+exchanges only frozen LiteyukiBot Event and Action envelopes with the kernel.
+
+```bash
+uv add liteyukibot-v7-runtime-adapter
+```
+
+Runtime configuration names individual adapter instances. `kind` selects the
+adapter entry point while `config` is opaque to the adapter package:
+
+```toml
+[runtimes.platform]
+kind = "adapter"
+
+[runtimes.platform.options.adapters.qq-main]
+kind = "qq"
+bot_id = "123456"
+config = { app_id = "..." }
+```
+
+The first release defines only the host contract. OneBot v11, OneBot v12, and
+Satori adapters are separately delivered packages.

--- a/packages/runtime-adapter/pyproject.toml
+++ b/packages/runtime-adapter/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "liteyukibot-v7-runtime-adapter"
+version = "0.1.0a1"
+description = "Python platform adapter host for LiteyukiBot v7."
+readme = "README.md"
+requires-python = ">=3.14"
+license = "LicenseRef-LSO"
+license-files = ["LICENSE"]
+authors = [
+    { name = "LiteyukiStudio" },
+]
+dependencies = [
+    "liteyukibot-v7>=7.0.0a10,<8",
+]
+
+[project.entry-points."liteyukibot.runtimes"]
+adapter = "liteyukibot_runtime_adapter:runtime_plugin"
+
+[build-system]
+requires = ["uv_build>=0.11.32,<0.12"]
+build-backend = "uv_build"
+
+[tool.uv.sources]
+liteyukibot-v7 = { workspace = true }
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "liteyukibot_runtime_adapter"

--- a/packages/runtime-adapter/src/liteyukibot_runtime_adapter/__init__.py
+++ b/packages/runtime-adapter/src/liteyukibot_runtime_adapter/__init__.py
@@ -1,0 +1,26 @@
+"""LiteyukiBot's separately distributed Python platform adapter host."""
+
+from __future__ import annotations
+
+import sys
+
+from liteyukibot.runtime import RuntimeInitSpec, RuntimePlugin
+
+from .facets import AdapterFacetInstaller
+
+
+def runtime_plugin() -> RuntimePlugin:
+    return RuntimePlugin(
+        kind="adapter",
+        command=(sys.executable, "-m", "liteyukibot_runtime_adapter"),
+        distribution="liteyukibot-v7-runtime-adapter",
+        facet_installer=AdapterFacetInstaller(),
+        init_spec=RuntimeInitSpec(
+            default_id="platform",
+            description="Python platform adapter host. Configure adapter instances in runtime options.",
+            default_options={"adapters": {}},
+        ),
+    )
+
+
+__all__ = ["runtime_plugin"]

--- a/packages/runtime-adapter/src/liteyukibot_runtime_adapter/__main__.py
+++ b/packages/runtime-adapter/src/liteyukibot_runtime_adapter/__main__.py
@@ -1,0 +1,3 @@
+from .host import run
+
+run()

--- a/packages/runtime-adapter/src/liteyukibot_runtime_adapter/contracts.py
+++ b/packages/runtime-adapter/src/liteyukibot_runtime_adapter/contracts.py
@@ -1,0 +1,56 @@
+"""Public contracts implemented by separately published Python adapter packages."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
+from liteyukibot.events import ActionEnvelope, EventEnvelope
+from liteyukibot.runtime.protocol import JsonValue
+
+EventEmitter = Callable[[EventEnvelope], Awaitable[None]]
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterContext:
+    """Immutable identity and opaque configuration for one adapter instance."""
+
+    runtime_id: str
+    instance_id: str
+    kind: str
+    bot_id: str
+    config: Mapping[str, JsonValue]
+
+
+class AdapterConnection(Protocol):
+    """One live platform connection; SDK objects never leave this process."""
+
+    async def start(self, emit: EventEmitter) -> None:
+        """Connect and return only after the adapter can accept Actions."""
+
+    async def execute(self, action: ActionEnvelope) -> JsonValue:
+        """Execute one Action already routed to this connection's bot ID."""
+
+    async def close(self) -> None:
+        """Release platform connections and background tasks."""
+
+
+AdapterFactory = Callable[[AdapterContext], Awaitable[AdapterConnection]]
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterPlugin:
+    """One installable platform or protocol adapter discovered by entry point."""
+
+    kind: str
+    create: AdapterFactory
+
+    def __post_init__(self) -> None:
+        if not self.kind or self.kind != self.kind.strip():
+            raise ValueError("adapter kind must be a non-empty trimmed string")
+        if not callable(self.create):
+            raise TypeError("adapter factory must be callable")
+
+
+__all__ = ["AdapterConnection", "AdapterContext", "AdapterFactory", "AdapterPlugin", "EventEmitter"]

--- a/packages/runtime-adapter/src/liteyukibot_runtime_adapter/facets.py
+++ b/packages/runtime-adapter/src/liteyukibot_runtime_adapter/facets.py
@@ -1,0 +1,48 @@
+"""Adapter-runtime ownership of immutable adapter wheel generation loading."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from liteyukibot.plugin_store import ArtifactStore, PluginFacet, PluginStoreError
+
+
+class AdapterFacetInstaller:
+    """Restrict a managed generation to explicitly resolved adapter entry points."""
+
+    def materialize(
+        self,
+        _artifacts: ArtifactStore,
+        _generation: Path,
+        facets: Mapping[str, PluginFacet],
+    ) -> dict[str, Any]:
+        adapters: list[str] = []
+        for bundle_id, facet in sorted(facets.items()):
+            if facet.runtime_kind != "adapter":
+                raise PluginStoreError(
+                    f"adapter installer cannot materialize {facet.runtime_kind!r} facet {bundle_id!r}"
+                )
+            declared = _adapter_list(facet.load)
+            if not declared:
+                raise PluginStoreError(f"adapter facet {bundle_id!r} requires adapter entry points")
+            if facet.artifacts:
+                raise PluginStoreError("adapter facets must install adapter distributions as verified wheels")
+            adapters.extend(declared)
+        if len(set(adapters)) != len(adapters):
+            raise PluginStoreError("adapter load plan cannot repeat adapter entry points")
+        return {"adapters": adapters}
+
+
+def _adapter_list(load: Mapping[str, object]) -> tuple[str, ...]:
+    value = load.get("adapters", [])
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise PluginStoreError("adapter facet load 'adapters' must be an array")
+    adapters = tuple(str(item) for item in value)
+    if any(not item or item != item.strip() for item in adapters):
+        raise PluginStoreError("adapter facet load 'adapters' contains an invalid entry point name")
+    return adapters
+
+
+__all__ = ["AdapterFacetInstaller"]

--- a/packages/runtime-adapter/src/liteyukibot_runtime_adapter/host.py
+++ b/packages/runtime-adapter/src/liteyukibot_runtime_adapter/host.py
@@ -1,0 +1,212 @@
+"""Supervised host for entry-point discovered Python platform adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import Mapping, Sequence
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+from liteyukibot.events import ActionEnvelope, EventEnvelope
+from liteyukibot.logging import configure_runtime_child_logging, get_logger
+from liteyukibot.runtime import RuntimeClient
+from liteyukibot.runtime.protocol import ActionRequest, ActionResponse, EventMessage, Shutdown, json_value
+
+from .contracts import AdapterConnection, AdapterContext, AdapterPlugin
+
+logger = get_logger(component="adapter", runtime=os.environ.get("LITEYUKI_RUNTIME_ID"))
+
+
+class AdapterHost:
+    """Load configured adapter instances and mediate their IPC-only kernel access."""
+
+    def __init__(self, client: RuntimeClient, plugins: Mapping[str, AdapterPlugin]) -> None:
+        self.client = client
+        self.plugins = dict(plugins)
+        self.connections: dict[str, AdapterConnection] = {}
+        self._emit_lock = asyncio.Lock()
+
+    async def start(self, options: Mapping[str, Any]) -> None:
+        adapters = _adapter_instances(options)
+        for instance_id, instance in adapters.items():
+            kind = _required_string(instance, "kind")
+            bot_id = _required_string(instance, "bot_id")
+            config = _json_object(instance.get("config", {}), "adapter config")
+            try:
+                plugin = self.plugins[kind]
+            except KeyError as error:
+                raise RuntimeError(f"adapter kind {kind!r} is not installed") from error
+            context = AdapterContext(
+                runtime_id=self.client.runtime_id,
+                instance_id=instance_id,
+                kind=kind,
+                bot_id=bot_id,
+                config=config,
+            )
+            connection = await plugin.create(context)
+            if bot_id in self.connections:
+                await connection.close()
+                raise RuntimeError(f"adapter bot ID {bot_id!r} is configured more than once")
+            self.connections[bot_id] = connection
+
+            async def emit(event: EventEnvelope, *, owned_bot_id: str = bot_id) -> None:
+                await self.emit(owned_bot_id, event)
+
+            try:
+                await connection.start(emit)
+            except BaseException:
+                self.connections.pop(bot_id, None)
+                await connection.close()
+                raise
+
+    async def emit(self, bot_id: str, event: EventEnvelope) -> None:
+        """Forward only events whose identity is owned by the emitting connection."""
+
+        if event.runtime_id != self.client.runtime_id:
+            raise ValueError("adapter event runtime_id does not match this runtime")
+        if event.bot_id != bot_id:
+            raise ValueError("adapter event bot_id does not match its connection")
+        async with self._emit_lock:
+            await self.client.send(EventMessage(correlation_id=event.id, payload=event.model_dump(mode="json")))
+
+    async def execute(self, request: ActionRequest) -> ActionResponse:
+        try:
+            envelope = ActionEnvelope.model_validate(request.payload)
+            if envelope.runtime_id != self.client.runtime_id:
+                raise ValueError("action runtime_id does not match this runtime")
+            connection = self.connections[envelope.bot_id]
+            return ActionResponse(
+                correlation_id=request.correlation_id,
+                ok=True,
+                data=json_value(await connection.execute(envelope)),
+            )
+        except Exception as error:
+            return ActionResponse(
+                correlation_id=request.correlation_id,
+                ok=False,
+                error=f"{type(error).__name__}: {error}",
+            )
+
+    async def close(self) -> None:
+        connections, self.connections = tuple(self.connections.values()), {}
+        results = await asyncio.gather(*(connection.close() for connection in connections), return_exceptions=True)
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.error("adapter connection cleanup failed: {}", result)
+
+    async def run(self, options: Mapping[str, Any]) -> None:
+        await self.start(options)
+        await self.client.ready(("adapter.events", "adapter.actions"))
+        while True:
+            message = await self.client.receive()
+            if isinstance(message, Shutdown):
+                return
+            if isinstance(message, ActionRequest):
+                await self.client.send(await self.execute(message))
+
+
+def discover_adapter_plugins(allowed: Sequence[str] | None = None) -> dict[str, AdapterPlugin]:
+    """Discover adapter packages without importing unselected managed-generation code."""
+
+    permitted = None if allowed is None else frozenset(allowed)
+    plugins: dict[str, AdapterPlugin] = {}
+    diagnostics: list[str] = []
+    for entry in metadata.entry_points(group="liteyukibot.adapters"):
+        if permitted is not None and entry.name not in permitted:
+            continue
+        try:
+            loaded = entry.load()
+            if not callable(loaded):
+                raise TypeError("entry point is not callable")
+            plugin = loaded()
+            if not isinstance(plugin, AdapterPlugin):
+                raise TypeError("entry point did not return AdapterPlugin")
+            if plugin.kind != entry.name:
+                raise ValueError(f"returned mismatched kind {plugin.kind!r}")
+            if plugin.kind in plugins:
+                raise ValueError("duplicates an installed adapter kind")
+            plugins[plugin.kind] = plugin
+        except Exception as error:
+            diagnostics.append(f"adapter {entry.name!r} is unavailable: {type(error).__name__}: {error}")
+    if permitted is not None:
+        missing = permitted - plugins.keys()
+        diagnostics.extend(f"adapter {name!r} is not installed" for name in sorted(missing))
+    if diagnostics:
+        raise RuntimeError("; ".join(diagnostics))
+    return plugins
+
+
+def managed_adapter_names() -> tuple[str, ...] | None:
+    raw_generation = os.environ.get("LITEYUKI_RUNTIME_GENERATION_DIR")
+    if raw_generation is None:
+        return None
+    generation = Path(raw_generation).resolve(strict=True)
+    plan_path = generation / "load-plan.json"
+    try:
+        document = json.loads(plan_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        raise RuntimeError("managed adapter generation has an invalid load plan") from error
+    if not isinstance(document, Mapping):
+        raise RuntimeError("managed adapter generation load plan must be an object")
+    value = document.get("adapters", [])
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise RuntimeError("managed adapter generation load plan adapters must be an array")
+    adapters = tuple(value)
+    if any(not isinstance(item, str) or not item or item != item.strip() for item in adapters):
+        raise RuntimeError("managed adapter generation load plan contains an invalid adapter name")
+    if len(set(adapters)) != len(adapters):
+        raise RuntimeError("managed adapter generation load plan repeats adapter names")
+    return adapters
+
+
+def _adapter_instances(options: Mapping[str, Any]) -> dict[str, Mapping[str, Any]]:
+    value = options.get("adapters", {})
+    if not isinstance(value, Mapping):
+        raise ValueError("adapter runtime option 'adapters' must be an object")
+    result: dict[str, Mapping[str, Any]] = {}
+    for instance_id, raw in value.items():
+        if not isinstance(instance_id, str) or not instance_id or instance_id != instance_id.strip():
+            raise ValueError("adapter instance IDs must be non-empty trimmed strings")
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"adapter instance {instance_id!r} must be an object")
+        result[instance_id] = raw
+    return result
+
+
+def _required_string(value: Mapping[str, Any], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item or item != item.strip():
+        raise ValueError(f"adapter instance {key!r} must be a non-empty trimmed string")
+    return item
+
+
+def _json_object(value: object, subject: str) -> dict[str, Any]:
+    try:
+        normalized = json_value(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{subject} must be JSON-safe") from error
+    if not isinstance(normalized, dict):
+        raise ValueError(f"{subject} must be an object")
+    return normalized
+
+
+async def _run() -> None:
+    configure_runtime_child_logging()
+    client = RuntimeClient.from_environment("adapter")
+    options = await client.connect()
+    host = AdapterHost(client, discover_adapter_plugins(managed_adapter_names()))
+    try:
+        await host.run(options)
+    finally:
+        await host.close()
+        await client.close()
+
+
+def run() -> None:
+    asyncio.run(_run())
+
+
+__all__ = ["AdapterHost", "discover_adapter_plugins", "managed_adapter_names", "run"]

--- a/packages/runtime-adapter/tests/test_adapter_facets.py
+++ b/packages/runtime-adapter/tests/test_adapter_facets.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from liteyukibot_runtime_adapter.facets import AdapterFacetInstaller
+
+from liteyukibot.plugin_store import ArtifactSpec, PluginFacet, PluginStoreError
+
+_WHEEL = ArtifactSpec("https://example.invalid/adapter.whl", "a" * 64)
+_ARCHIVE = ArtifactSpec("https://example.invalid/adapter.zip", "b" * 64)
+
+
+def test_adapter_facet_generates_entry_point_load_plan(tmp_path: Path) -> None:
+    plan = AdapterFacetInstaller().materialize(
+        None,  # type: ignore[arg-type]
+        tmp_path / "generation",
+        {"example.onebot": PluginFacet("adapter", (), wheels=(_WHEEL,), load={"adapters": ["onebot-v11"]})},
+    )
+
+    assert plan == {"adapters": ["onebot-v11"]}
+
+
+def test_adapter_facet_requires_wheels_not_archives(tmp_path: Path) -> None:
+    facet = PluginFacet("adapter", (_ARCHIVE,), load={"adapters": ["example"]})
+
+    with pytest.raises(PluginStoreError, match="verified wheels"):
+        AdapterFacetInstaller().materialize(None, tmp_path / "generation", {"example": facet})  # type: ignore[arg-type]

--- a/packages/runtime-adapter/tests/test_adapter_runtime.py
+++ b/packages/runtime-adapter/tests/test_adapter_runtime.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from liteyukibot_runtime_adapter.contracts import AdapterConnection, AdapterContext, AdapterPlugin
+from liteyukibot_runtime_adapter.host import AdapterHost, managed_adapter_names
+
+from liteyukibot.events import ActionEnvelope, ConversationRef, EventEnvelope, Message, SendMessage
+from liteyukibot.runtime.protocol import ActionRequest, EventMessage
+
+
+class FakeClient:
+    runtime_id = "platform"
+
+    def __init__(self) -> None:
+        self.sent: list[object] = []
+
+    async def send(self, message: object) -> None:
+        self.sent.append(message)
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.emitter: object | None = None
+        self.actions: list[ActionEnvelope] = []
+        self.closed = False
+
+    async def start(self, emit: object) -> None:
+        self.emitter = emit
+
+    async def execute(self, action: ActionEnvelope) -> str:
+        self.actions.append(action)
+        return "sent"
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _plugin(connection: FakeConnection) -> AdapterPlugin:
+    async def create(_context: AdapterContext) -> AdapterConnection:
+        return connection
+
+    return AdapterPlugin("example", create)
+
+
+@pytest.mark.asyncio
+async def test_adapter_host_routes_owned_events_and_actions() -> None:
+    client = FakeClient()
+    connection = FakeConnection()
+    host = AdapterHost(client, {"example": _plugin(connection)})  # type: ignore[arg-type]
+    await host.start({"adapters": {"example-main": {"kind": "example", "bot_id": "bot", "config": {}}}})
+
+    event = EventEnvelope(
+        id="event-1",
+        runtime_id="platform",
+        adapter="example",
+        bot_id="bot",
+        type="message.created",
+        conversation=ConversationRef(id="conversation", type="private"),
+        message=Message(),
+    )
+    await host.emit("bot", event)
+    response = await host.execute(
+        ActionRequest(
+            correlation_id="action-1",
+            payload=ActionEnvelope(
+                action_id="action-1",
+                runtime_id="platform",
+                bot_id="bot",
+                action=SendMessage(
+                    message=Message(),
+                    conversation=ConversationRef(id="conversation", type="private"),
+                ),
+            ).model_dump(mode="json"),
+        )
+    )
+
+    assert isinstance(client.sent[0], EventMessage)
+    assert response.ok
+    assert response.data == "sent"
+    assert connection.actions[0].bot_id == "bot"
+    await host.close()
+    assert connection.closed
+
+
+def test_managed_adapter_names_rejects_duplicates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "load-plan.json").write_text(json.dumps({"adapters": ["example", "example"]}), encoding="utf-8")
+    monkeypatch.setenv("LITEYUKI_RUNTIME_GENERATION_DIR", str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="repeats"):
+        managed_adapter_names()
+
+
+def test_managed_adapter_names_reads_safe_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "load-plan.json").write_text(json.dumps({"adapters": ["onebot-v11"]}), encoding="utf-8")
+    monkeypatch.setenv("LITEYUKI_RUNTIME_GENERATION_DIR", str(tmp_path))
+
+    assert managed_adapter_names() == ("onebot-v11",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a10"
+version = "7.0.0a11"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -97,6 +97,14 @@ RELEASE_PROJECTS: dict[str, ReleaseProject] = {
         tag_selector="runtime-nonebot-v",
         verifier="scripts/verify_nonebot_runtime_install.py",
     ),
+    "runtime-adapter": ReleaseProject(
+        name="runtime-adapter",
+        project_dir="packages/runtime-adapter",
+        distribution="liteyukibot-v7-runtime-adapter",
+        tag_prefix="runtime-adapter-v",
+        tag_selector="runtime-adapter-v",
+        verifier="scripts/verify_adapter_runtime_install.py",
+    ),
     "runtime-v6": ReleaseProject(
         name="runtime-v6",
         project_dir="packages/runtime-v6",

--- a/scripts/run_adapter_runtime_install.py
+++ b/scripts/run_adapter_runtime_install.py
@@ -1,0 +1,37 @@
+"""Run the adapter runtime verifier against workspace-built wheels."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from scripts.run_isolated_install import _clean_environment
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _one_wheel(distribution: str) -> Path:
+    matches = tuple((ROOT / "dist" / "workspace").glob(f"{distribution}-*-py3-none-any.whl"))
+    if len(matches) != 1:
+        raise RuntimeError(f"expected one {distribution} wheel in dist/workspace, found {len(matches)}")
+    return matches[0].resolve()
+
+
+def main() -> int:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv executable was not found")
+    command = [uv, "run", "--no-project", "--python", "3.14"]
+    for wheel in (_one_wheel("liteyukibot_v7"), _one_wheel("liteyukibot_v7_runtime_adapter")):
+        command.extend(("--with", str(wheel)))
+    command.extend(("python", str(ROOT / "scripts" / "verify_adapter_runtime_install.py")))
+    with tempfile.TemporaryDirectory() as directory:
+        subprocess.run(command, cwd=directory, env=_clean_environment(os.environ), check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_adapter_runtime_install.py
+++ b/scripts/verify_adapter_runtime_install.py
@@ -1,0 +1,38 @@
+"""Verify the installed Python adapter runtime wheel without workspace sources."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+from pathlib import Path
+
+import liteyukibot_runtime_adapter
+
+import liteyukibot
+from liteyukibot.runtime import RuntimeCatalog
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def verify(expected_version: str | None = None) -> None:
+    imported = (Path(liteyukibot.__file__).resolve(), Path(liteyukibot_runtime_adapter.__file__).resolve())
+    if any(path.is_relative_to(SOURCE_ROOT) for path in imported):
+        raise RuntimeError(f"workspace source import detected: {imported}")
+    plugin = RuntimeCatalog().discover().get("adapter")
+    if plugin is None or plugin.command[2:] != ("liteyukibot_runtime_adapter",):
+        raise RuntimeError(f"adapter runtime entry point was not discovered: {plugin}")
+    observed = {
+        name: importlib.metadata.version(name)
+        for name in ("liteyukibot-v7", "liteyukibot-v7-runtime-adapter")
+    }
+    if expected_version is not None and observed["liteyukibot-v7-runtime-adapter"] != expected_version:
+        raise RuntimeError(f"expected liteyukibot-v7-runtime-adapter {expected_version}; observed {observed}")
+    print(json.dumps(observed, sort_keys=True))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected-version")
+    arguments = parser.parse_args()
+    verify(arguments.expected_version)

--- a/src/liteyukibot/resource_packs.py
+++ b/src/liteyukibot/resource_packs.py
@@ -54,6 +54,9 @@ class ResourcePackMetadata:
     version: str
     description: str
     origin: str
+    name_key: str | None = None
+    description_key: str | None = None
+    icon: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,6 +96,20 @@ class ResourceCatalog:
     @property
     def packs(self) -> tuple[ResourcePackMetadata, ...]:
         return tuple(pack.metadata for pack in self._packs)
+
+    def pack(self, pack_id: str) -> ResourcePackMetadata:
+        for pack in self._packs:
+            if pack.metadata.id == pack_id:
+                return pack.metadata
+        raise ResourcePackError(f"resource pack does not exist: {pack_id}")
+
+    def icon(self, pack_id: str) -> ResourceFile | None:
+        """Return a validated package icon for a future local presentation client."""
+
+        for pack in self._packs:
+            if pack.metadata.id == pack_id:
+                return pack.files.get(pack.metadata.icon) if pack.metadata.icon else None
+        raise ResourcePackError(f"resource pack does not exist: {pack_id}")
 
     def get(self, path: str) -> ResourceFile | None:
         return self._files.get(_relative_path(path))
@@ -138,13 +155,29 @@ def _metadata(value: object, origin: str, fallback_id: str) -> ResourcePackMetad
     if not isinstance(value, dict):
         raise ResourcePackError(f"resource pack metadata must be an object: {origin}")
     pack_id = _token(value.get("id", fallback_id), "id")
+    name_key = _optional_token(value.get("name_key"), "name_key")
+    description_key = _optional_token(value.get("description_key"), "description_key")
+    icon = _optional_token(value.get("icon"), "icon")
+    if icon is not None:
+        icon = _relative_path(icon)
+        if not icon.endswith(".png"):
+            raise ResourcePackError("resource pack icon must be a PNG file")
     return ResourcePackMetadata(
         id=pack_id,
         name=_token(value.get("name", pack_id), "name"),
         version=_token(value.get("version", "0.0.0"), "version"),
         description=str(value.get("description", "")),
         origin=origin,
+        name_key=name_key,
+        description_key=description_key,
+        icon=icon,
     )
+
+
+def _optional_token(value: object, subject: str) -> str | None:
+    if value is None:
+        return None
+    return _token(value, subject)
 
 
 def _read_metadata(raw: str, origin: str, fallback_id: str) -> ResourcePackMetadata:
@@ -169,6 +202,7 @@ def _load_directory(root: Path, origin: str) -> ResourcePack:
             raise ResourcePackError(f"resource pack contains an unsafe file: {candidate}")
         relative = _relative_path(candidate.relative_to(root).as_posix())
         files[relative] = ResourceFile(metadata.id, relative, candidate.read_bytes)
+    _validate_icon(metadata, files)
     return ResourcePack(metadata, files)
 
 
@@ -188,6 +222,7 @@ def _load_traversable(root: resources.abc.Traversable, origin: str) -> ResourceP
                 files[relative] = ResourceFile(metadata.id, relative, child.read_bytes)
 
     visit(root)
+    _validate_icon(metadata, files)
     return ResourcePack(metadata, files)
 
 
@@ -214,7 +249,28 @@ def _load_zip(path: Path) -> ResourcePack:
         )
         for name in entries
     }
+    _validate_icon(metadata, files)
     return ResourcePack(metadata, files)
+
+
+def _validate_icon(metadata: ResourcePackMetadata, files: Mapping[str, ResourceFile]) -> None:
+    if metadata.icon is None:
+        return
+    try:
+        raw = files[metadata.icon].read_bytes()
+    except KeyError as error:
+        raise ResourcePackError(f"resource pack icon does not exist: {metadata.icon}") from error
+    if len(raw) > 512 * 1024:
+        raise ResourcePackError("resource pack icon exceeds 512 KiB")
+    if len(raw) < 29 or raw[:8] != b"\x89PNG\r\n\x1a\n" or raw[12:16] != b"IHDR":
+        raise ResourcePackError("resource pack icon is not a valid PNG")
+    width = int.from_bytes(raw[16:20], "big")
+    height = int.from_bytes(raw[20:24], "big")
+    color_type = raw[25]
+    if width != height or width == 0:
+        raise ResourcePackError("resource pack icon must be a non-empty square image")
+    if color_type not in {4, 6}:
+        raise ResourcePackError("resource pack icon must include an alpha channel")
 
 
 def _read_zip_entry(path: Path, name: str) -> bytes:

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -25,7 +25,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a10"),
+        ("root", "v7.0.0a11"),
         ("permissions", "permissions-v0.2.0a1"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),
@@ -33,6 +33,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("profile", "profile-v0.1.0a2"),
         ("essentials", "essentials-v0.2.0a3"),
         ("runtime-nonebot", "runtime-nonebot-v0.1.0a1"),
+        ("runtime-adapter", "runtime-adapter-v0.1.0a1"),
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
         ("agent", "agent-v0.1.0a3"),

--- a/tests/test_resource_packs.py
+++ b/tests/test_resource_packs.py
@@ -83,6 +83,56 @@ def test_resource_zip_rejects_path_traversal(tmp_path: Path) -> None:
         ResourceCatalog.load(tmp_path)
 
 
+def test_resource_pack_exposes_validated_presentation_metadata(tmp_path: Path) -> None:
+    resources = tmp_path / "resources"
+    pack = _pack(resources, "presentation")
+    icon = (
+        b"\x89PNG\r\n\x1a\n"
+        + (13).to_bytes(4, "big")
+        + b"IHDR"
+        + (1).to_bytes(4, "big")
+        + (1).to_bytes(4, "big")
+        + b"\x08\x06\x00\x00\x00"
+        + b"\x00\x00\x00\x00"
+    )
+    (pack / "icon.png").write_bytes(icon)
+    (pack / "metadata.yml").write_text(
+        "id: presentation\nname: Presentation\nversion: 1.0.0\n"
+        "name_key: presentation.name\ndescription_key: presentation.description\nicon: icon.png\n",
+        encoding="utf-8",
+    )
+    (resources / "index.json").write_text('["presentation"]', encoding="utf-8")
+
+    catalog = ResourceCatalog.load(tmp_path)
+
+    assert catalog.pack("presentation").name_key == "presentation.name"
+    assert catalog.pack("presentation").description_key == "presentation.description"
+    assert catalog.icon("presentation") is not None
+
+
+def test_resource_pack_rejects_non_alpha_icon(tmp_path: Path) -> None:
+    resources = tmp_path / "resources"
+    pack = _pack(resources, "presentation")
+    icon = (
+        b"\x89PNG\r\n\x1a\n"
+        + (13).to_bytes(4, "big")
+        + b"IHDR"
+        + (1).to_bytes(4, "big")
+        + (1).to_bytes(4, "big")
+        + b"\x08\x02\x00\x00\x00"
+        + b"\x00\x00\x00\x00"
+    )
+    (pack / "icon.png").write_bytes(icon)
+    (pack / "metadata.yml").write_text(
+        "id: presentation\nname: Presentation\nversion: 1.0.0\nicon: icon.png\n",
+        encoding="utf-8",
+    )
+    (resources / "index.json").write_text('["presentation"]', encoding="utf-8")
+
+    with pytest.raises(ResourcePackError, match="alpha"):
+        ResourceCatalog.load(tmp_path)
+
+
 def test_function_dispatch_reports_missing_executor(tmp_path: Path) -> None:
     resources = tmp_path / "resources"
     _pack(resources, "functions", function="return nothing")

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,7 @@ members = [
     "liteyukibot-v7-permissions",
     "liteyukibot-v7-profile",
     "liteyukibot-v7-resources",
+    "liteyukibot-v7-runtime-adapter",
     "liteyukibot-v7-runtime-astrbot",
     "liteyukibot-v7-runtime-mofox",
     "liteyukibot-v7-runtime-nonebot",
@@ -1395,7 +1396,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a10"
+version = "7.0.0a11"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1554,6 +1555,17 @@ requires-dist = [
     { name = "liteyukibot-v7-commands", editable = "packages/commands" },
     { name = "liteyukibot-v7-permissions", editable = "packages/permissions" },
 ]
+
+[[package]]
+name = "liteyukibot-v7-runtime-adapter"
+version = "0.1.0a1"
+source = { editable = "packages/runtime-adapter" }
+dependencies = [
+    { name = "liteyukibot-v7" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-runtime-astrbot"


### PR DESCRIPTION
## Summary
- add the separately published Python adapter runtime and managed adapter entry-point contract
- add resource-pack presentation metadata and validated local PNG icon interface without a WebUI route
- register release, wheel isolation, and Trusted Publisher support for runtime-adapter

## Validation
- uv run pytest -q (412 passed)
- uv run ruff check .
- uv run mypy
- uv build --all-packages --out-dir dist/workspace --clear
- uv run python -m scripts.run_adapter_runtime_install
- uv lock --check