### PR TITLE
feat(runtime): bind child actions to event provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a11`. Kernel stabilization,
+The current pre-release is `liteyukibot-v7==7.0.0a12`. Kernel stabilization,
 the first bounded compatibility phase, and the first-party plugin foundation
 are complete. Runtime protocol v4 remains an alpha contract and may change
 under ADR 0011 before the first stable release.

--- a/docs/adr/0022-runtime-ipc-protocol-v4.md
+++ b/docs/adr/0022-runtime-ipc-protocol-v4.md
@@ -47,3 +47,11 @@ framework object or opening a direct child-to-child channel.
 Completion is intentionally not delivery retry, distributed transactions, or a
 cross-runtime RPC result. Retry policy and durable observability remain kernel
 concerns and need their own configuration and recovery design.
+
+For a v4 child Action causally produced by a delivered Event, the child may
+include that Event's delivery correlation ID in `ActionRequest`. The supervisor
+only accepts it while the delivery is active and passes the kernel-validated
+`EventTrace` plus original Event payload to the action sink. The sink can then
+enforce that action event/runtime/bot routing matches the source Event before
+performing adapter-specific authorization. V3 Actions retain the existing
+unattributed shape and cannot claim this provenance.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -150,6 +150,12 @@ are denied. Plugins check capabilities rather than deployment role names. The
 service is application policy for trusted plugins; it is not a sandbox
 boundary.
 
+Kernel-owned privileged capability names are defined in `liteyukibot.capabilities`.
+In beta1, a child-originated `CallApi` action requires
+`liteyukibot.adapter.call_api`, a v4 source-event provenance record, and an
+enabled permission service. `SendMessage` remains protocol-neutral and uses its
+existing event/runtime/bot routing checks.
+
 ## Commands
 
 The first-party `liteyukibot-v7-commands` package provides

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -40,7 +40,7 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a11` | `pyproject.toml` | `v7.0.0a11` |
+| `liteyukibot-v7==7.0.0a12` | `pyproject.toml` | `v7.0.0a12` |
 | `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |
@@ -51,6 +51,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-runtime-adapter==0.1.0a2` | `packages/runtime-adapter` | `runtime-adapter-v0.1.0a2` |
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
+| `liteyukibot-v7-agent==0.1.0a4` | `packages/agent` | `agent-v0.1.0a4` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
 tag that does not exactly match the selected source version and distribution.
@@ -59,7 +60,7 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a11`;
+1. `v7.0.0a12`;
 2. `permissions-v0.2.0a1`;
 3. `commands-v0.2.0a2`;
 4. `resources-v0.1.0a2`;
@@ -70,6 +71,7 @@ Push and wait for each release before creating the next tag:
 9. `runtime-adapter-v0.1.0a2`.
 10. `adapter-onebot-v0.1.0a1`.
 11. `runtime-v6-v0.1.0a1`.
+12. `agent-v0.1.0a4`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/packages/agent/pyproject.toml
+++ b/packages/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Native OpenAI-compatible agent harness for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -9,7 +9,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a10,<8",
+    "liteyukibot-v7>=7.0.0a12,<8",
     "liteyukibot-v7-agent-resolver>=0.1.0a1,<0.2",
     "openai>=2,<3",
 ]

--- a/packages/agent/src/liteyukibot_agent/__init__.py
+++ b/packages/agent/src/liteyukibot_agent/__init__.py
@@ -54,7 +54,7 @@ def runtime_plugin() -> RuntimePlugin:
 try:
     __version__ = version("liteyukibot-v7-agent")
 except PackageNotFoundError:
-    __version__ = "0.1.0a3"
+    __version__ = "0.1.0a4"
 
 plugin: PluginDefinition = create_plugin(__version__)
 

--- a/packages/agent/src/liteyukibot_agent/host.py
+++ b/packages/agent/src/liteyukibot_agent/host.py
@@ -163,6 +163,7 @@ class NativeAgentHost:
                     response = await self.client.execute_action(
                         action.action_id,
                         action.model_dump(mode="json"),
+                        delivery_correlation_id=delivery_correlation_id,
                     )
                     if not response.ok:
                         raise RuntimeError(response.error or "source runtime rejected agent output")

--- a/packages/agent/tests/test_native_agent.py
+++ b/packages/agent/tests/test_native_agent.py
@@ -28,7 +28,14 @@ class FakeClient:
     async def send(self, message: object) -> None:
         self.sent.append(message)
 
-    async def execute_action(self, _correlation_id: str, payload: dict[str, object]) -> ActionResponse:
+    async def execute_action(
+        self,
+        _correlation_id: str,
+        payload: dict[str, object],
+        *,
+        delivery_correlation_id: str | None = None,
+    ) -> ActionResponse:
+        assert delivery_correlation_id == "delivery-1"
         self.actions.append(payload)
         return ActionResponse(correlation_id="action", ok=True)
 

--- a/packages/runtime-v6/tests/test_legacy_v6.py
+++ b/packages/runtime-v6/tests/test_legacy_v6.py
@@ -20,7 +20,7 @@ from liteyukibot.events import (
     SendMessage,
 )
 from liteyukibot.exceptions import LegacyUnsupportedError
-from liteyukibot.runtime import ActionSinkResult, RuntimeSpec, RuntimeSupervisor
+from liteyukibot.runtime import ActionProvenance, ActionSinkResult, RuntimeSpec, RuntimeSupervisor
 
 
 def test_v6_compatibility_namespace_uses_kernel_version() -> None:
@@ -116,6 +116,7 @@ async def echo(event: MessageEvent):
     async def execute_action(
         source_runtime_id: str,
         payload: dict[str, Any],
+        _provenance: ActionProvenance | None,
     ) -> ActionSinkResult:
         assert source_runtime_id == "legacy"
         action = ActionEnvelope.model_validate(payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a11"
+version = "7.0.0a12"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -11,9 +11,10 @@ from typing import Any
 
 from ._version import __version__
 from .agents import AGENT_TOOL_BROKER_SERVICE, AgentToolBroker, AgentToolCatalog, AgentToolResult
+from .capabilities import ADAPTER_CALL_API, PERMISSION_SERVICE_MAJOR, PERMISSION_SERVICE_NAME
 from .config import AppSettings, RuntimeEventRoute
 from .control import ControlServer
-from .events import ActionEnvelope, ActionResult, EventBus, EventEnvelope
+from .events import ActionEnvelope, ActionResult, CallApi, EventBus, EventEnvelope
 from .functions import FUNCTION_DISPATCH_SERVICE, FunctionDispatcher
 from .http import HttpServer
 from .i18n import I18N_SERVICE, Translator
@@ -22,6 +23,7 @@ from .plugin_store import RuntimeGenerationStore
 from .plugins import PluginManager
 from .resource_packs import RESOURCE_CATALOG_SERVICE, ResourceCatalog
 from .runtime import (
+    ActionProvenance,
     ActionSinkResult,
     AgentToolSinkResult,
     RuntimeCatalog,
@@ -29,7 +31,7 @@ from .runtime import (
     RuntimeSupervisor,
     json_value,
 )
-from .services import ServiceRegistry
+from .services import ServiceKey, ServiceRegistry
 from .status import KERNEL_STATUS_SERVICE, KernelStatusSnapshot
 from .tasks import ManagedTasks
 
@@ -79,6 +81,9 @@ class ActionService:
         )
 
 
+_PERMISSION_SERVICE = ServiceKey(PERMISSION_SERVICE_NAME, PERMISSION_SERVICE_MAJOR)
+
+
 class _AppStatusProvider:
     def __init__(self, app: LiteyukiApp) -> None:
         self._app = app
@@ -118,6 +123,7 @@ class LiteyukiApp:
             handler_timeout=core.handler_timeout_seconds,
             max_concurrent_events=core.max_concurrent_events,
             action_executor=self.actions.execute,
+            action_guard=self._authorize_action,
             logger=self.logger,
         )
         self.plugins = PluginManager(
@@ -474,7 +480,12 @@ class LiteyukiApp:
         result = await self.events.publish(event)
         return "accepted" if result.status == "processed" else result.status
 
-    async def _execute_runtime_action(self, source_runtime_id: str, payload: dict[str, Any]) -> ActionSinkResult:
+    async def _execute_runtime_action(
+        self,
+        source_runtime_id: str,
+        payload: dict[str, Any],
+        provenance: ActionProvenance | None,
+    ) -> ActionSinkResult:
         try:
             action = ActionEnvelope.model_validate(payload)
         except ValueError as error:
@@ -482,16 +493,73 @@ class LiteyukiApp:
                 "runtime action failed validation: {}", error
             )
             return ActionSinkResult(ok=False, error="invalid ActionEnvelope")
+        if provenance is not None:
+            try:
+                source_event = EventEnvelope.model_validate(provenance.event_payload)
+            except ValueError:
+                return ActionSinkResult(ok=False, error="action provenance has an invalid EventEnvelope")
+            if (
+                action.event_id != source_event.id
+                or action.runtime_id != source_event.runtime_id
+                or action.bot_id != source_event.bot_id
+            ):
+                return ActionSinkResult(
+                    ok=False,
+                    error="child action does not match its source event provenance",
+                )
         if action.runtime_id == source_runtime_id:
             return ActionSinkResult(
                 ok=False,
                 error="child-originated action cannot target its source runtime",
+            )
+        guarded = self._authorize_action(source_event if provenance is not None else None, action)
+        if guarded is not None:
+            return ActionSinkResult(
+                ok=guarded.success,
+                data=guarded.model_dump(mode="json"),
+                error=guarded.error_message,
             )
         result = await self.actions.execute(action)
         return ActionSinkResult(
             ok=result.success,
             data=result.model_dump(mode="json"),
             error=result.error_message,
+        )
+
+    def _authorize_action(self, event: EventEnvelope | None, action: ActionEnvelope) -> ActionResult | None:
+        if not isinstance(action.action, CallApi):
+            return None
+        if event is None:
+            return ActionResult(
+                action_id=action.action_id,
+                success=False,
+                error_code="ACTION_PERMISSION_DENIED",
+                error_message="adapter API action requires a source event",
+            )
+        if action.event_id != event.id or action.runtime_id != event.runtime_id or action.bot_id != event.bot_id:
+            return ActionResult(
+                action_id=action.action_id,
+                success=False,
+                error_code="ACTION_PERMISSION_DENIED",
+                error_message="adapter API action does not match its source event",
+            )
+        permissions = self.services.get(_PERMISSION_SERVICE)
+        allows = getattr(permissions, "allows", None)
+        allowed = callable(allows) and allows(event, ADAPTER_CALL_API)
+        self.logger.bind(
+            runtime=event.runtime_id,
+            component="permissions",
+            capability=ADAPTER_CALL_API,
+            event_id=event.id,
+            allowed=allowed,
+        ).info("adapter API action permission {}", "granted" if allowed else "denied")
+        if allowed:
+            return None
+        return ActionResult(
+            action_id=action.action_id,
+            success=False,
+            error_code="ACTION_PERMISSION_DENIED",
+            error_message="adapter API action permission is denied",
         )
 
     def _event_routes(self, settings: AppSettings) -> tuple[RuntimeEventRoute, ...]:

--- a/src/liteyukibot/capabilities.py
+++ b/src/liteyukibot/capabilities.py
@@ -1,0 +1,7 @@
+"""Kernel-owned capability identifiers for privileged cross-package surfaces."""
+
+ADAPTER_CALL_API = "liteyukibot.adapter.call_api"
+PERMISSION_SERVICE_NAME = "liteyukibot.permissions"
+PERMISSION_SERVICE_MAJOR = 1
+
+__all__ = ["ADAPTER_CALL_API", "PERMISSION_SERVICE_MAJOR", "PERMISSION_SERVICE_NAME"]

--- a/src/liteyukibot/events/__init__.py
+++ b/src/liteyukibot/events/__init__.py
@@ -1,4 +1,4 @@
-from .bus import ActionExecutor, EventBus, EventHandler, Subscription
+from .bus import ActionExecutor, ActionGuard, EventBus, EventHandler, Subscription
 from .models import (
     Action,
     ActionEnvelope,
@@ -20,6 +20,7 @@ __all__ = [
     "Action",
     "ActionEnvelope",
     "ActionExecutor",
+    "ActionGuard",
     "ActionResult",
     "ActorRef",
     "CallApi",

--- a/src/liteyukibot/events/bus.py
+++ b/src/liteyukibot/events/bus.py
@@ -14,6 +14,7 @@ from .models import ActionEnvelope, ActionResult, DispatchResult, EventEnvelope,
 
 type EventHandler = Callable[[EventEnvelope], Awaitable[HandlerResult | None] | HandlerResult | None]
 type ActionExecutor = Callable[[ActionEnvelope], Awaitable[ActionResult] | ActionResult]
+type ActionGuard = Callable[[EventEnvelope, ActionEnvelope], Awaitable[ActionResult | None] | ActionResult | None]
 
 @dataclass(frozen=True, slots=True)
 class Subscription:
@@ -46,6 +47,7 @@ class EventBus:
         handler_timeout: float = 30.0,
         max_concurrent_events: int = 100,
         action_executor: ActionExecutor | None = None,
+        action_guard: ActionGuard | None = None,
         logger: Logger | None = None,
     ) -> None:
         if queue_capacity < 1:
@@ -61,6 +63,7 @@ class EventBus:
         self._enqueue_timeout = enqueue_timeout
         self._handler_timeout = handler_timeout
         self._action_executor = action_executor
+        self._action_guard = action_guard
         self._logger = logger or get_logger(component="events")
         self._capacity = asyncio.BoundedSemaphore(queue_capacity)
         self._concurrency = asyncio.Semaphore(max_concurrent_events)
@@ -245,7 +248,7 @@ class EventBus:
                 continue
 
             for action in result.actions:
-                action_results.append(await self._execute_action(action))
+                action_results.append(await self._execute_action(event, action))
             if result.stop_propagation:
                 stopped = True
                 break
@@ -259,7 +262,28 @@ class EventBus:
             failures=tuple(failures),
         )
 
-    async def _execute_action(self, action: ActionEnvelope) -> ActionResult:
+    async def _execute_action(self, event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
+        if self._action_guard is not None:
+            try:
+                guarded: Any = self._action_guard(event, action)
+                if inspect.isawaitable(guarded):
+                    guarded = await guarded
+                if guarded is not None:
+                    if not isinstance(guarded, ActionResult):
+                        raise TypeError(f"expected ActionResult or None, got {type(guarded).__name__}")
+                    if guarded.action_id != action.action_id:
+                        raise ValueError("action guard result correlation id does not match the action")
+                    return guarded
+            except Exception as exc:
+                self._logger.bind(event_id=event.id, runtime=event.runtime_id, bot_id=event.bot_id).exception(
+                    "action guard failed for action {}", action.action_id
+                )
+                return ActionResult(
+                    action_id=action.action_id,
+                    success=False,
+                    error_code="ACTION_GUARD_ERROR",
+                    error_message=f"{type(exc).__name__}: {exc}",
+                )
         if self._action_executor is None:
             return ActionResult(
                 action_id=action.action_id,

--- a/src/liteyukibot/runtime/__init__.py
+++ b/src/liteyukibot/runtime/__init__.py
@@ -31,6 +31,7 @@ from .protocol import (
     write_message,
 )
 from .supervisor import (
+    ActionProvenance,
     ActionSink,
     ActionSinkResult,
     AgentToolSink,
@@ -51,6 +52,7 @@ __all__ = [
     "AgentToolResponse",
     "AgentToolSink",
     "AgentToolSinkResult",
+    "ActionProvenance",
     "ActionSink",
     "ActionSinkResult",
     "ConfigMessage",

--- a/src/liteyukibot/runtime/client.py
+++ b/src/liteyukibot/runtime/client.py
@@ -160,12 +160,18 @@ class RuntimeClient:
         self,
         correlation_id: str,
         payload: Mapping[str, Any],
+        *,
+        delivery_correlation_id: str | None = None,
         timeout_seconds: float = 30.0,
     ) -> ActionResponse:
         if timeout_seconds <= 0:
             raise ValueError("runtime action timeout must be positive")
         if self.negotiated_protocol not in (3, 4):
             raise RuntimeError("child-originated actions require runtime protocol v3 or v4")
+        if delivery_correlation_id is not None and (
+            not delivery_correlation_id or self.negotiated_protocol != 4
+        ):
+            raise RuntimeError("action delivery correlation id requires runtime protocol v4")
         if self._heartbeat_task is None:
             raise RuntimeError("runtime client is not ready")
         if "runtime.actions.send" not in self._capabilities:
@@ -176,6 +182,7 @@ class RuntimeClient:
         request = ActionRequest(
             correlation_id=correlation_id,
             payload=json_mapping(payload),
+            delivery_correlation_id=delivery_correlation_id,
         )
         future: asyncio.Future[ActionResponse] = asyncio.get_running_loop().create_future()
         self._pending_actions[correlation_id] = future

--- a/src/liteyukibot/runtime/protocol.py
+++ b/src/liteyukibot/runtime/protocol.py
@@ -94,6 +94,7 @@ class ActionRequest(WireModel):
     type: Literal["action"] = "action"
     correlation_id: str
     payload: dict[str, JsonValue]
+    delivery_correlation_id: str | None = None
 
 
 class ActionResponse(WireModel):

--- a/src/liteyukibot/runtime/supervisor.py
+++ b/src/liteyukibot/runtime/supervisor.py
@@ -52,7 +52,16 @@ class ActionSinkResult:
     error: str | None = None
 
 
-ActionSink = Callable[[str, dict[str, JsonValue]], Awaitable[ActionSinkResult]]
+@dataclass(frozen=True, slots=True)
+class ActionProvenance:
+    """Kernel-validated source event context for a v4 child Action."""
+
+    delivery_correlation_id: str
+    trace: EventTrace
+    event_payload: dict[str, JsonValue]
+
+
+ActionSink = Callable[[str, dict[str, JsonValue], ActionProvenance | None], Awaitable[ActionSinkResult]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -541,6 +550,37 @@ class RuntimeSupervisor:
                 "child runtime did not declare runtime.actions.send",
             )
             return
+        provenance: ActionProvenance | None = None
+        if request.delivery_correlation_id is not None:
+            self._clear_expired_delivery_contexts(record)
+            if record.protocol_version != 4:
+                await self._reject_child_action(
+                    record,
+                    request,
+                    "action delivery correlation id requires runtime protocol v4",
+                )
+                return
+            context = record.active_delivery_contexts.get(request.delivery_correlation_id)
+            if context is None:
+                await self._reject_child_action(
+                    record,
+                    request,
+                    "action request is not bound to an active event delivery",
+                )
+                return
+            _deadline, event_payload, trace = context
+            if trace is None:
+                await self._reject_child_action(
+                    record,
+                    request,
+                    "action delivery does not carry v4 trace context",
+                )
+                return
+            provenance = ActionProvenance(
+                delivery_correlation_id=request.delivery_correlation_id,
+                trace=trace,
+                event_payload=dict(event_payload),
+            )
         if self.action_sink is None:
             await self._reject_child_action(record, request, "core action sink is unavailable")
             return
@@ -553,15 +593,27 @@ class RuntimeSupervisor:
             return
 
         task = asyncio.create_task(
-            self._execute_child_action(record, request),
+            self._execute_child_action(record, request, provenance),
             name=f"runtime-action:{record.spec.id}:{request.correlation_id}",
         )
         record.inbound_actions[request.correlation_id] = task
 
-    async def _execute_child_action(self, record: RuntimeRecord, request: ActionRequest) -> None:
+    async def _execute_child_action(
+        self,
+        record: RuntimeRecord,
+        request: ActionRequest,
+        provenance: ActionProvenance | None,
+    ) -> None:
         try:
             assert self.action_sink is not None
-            result = await self.action_sink(record.spec.id, request.payload)
+            self._log_payload(
+                record,
+                "action.child_request",
+                request.correlation_id,
+                request.payload,
+                trace=provenance.trace if provenance is not None else None,
+            )
+            result = await self.action_sink(record.spec.id, request.payload, provenance)
             response = ActionResponse(
                 correlation_id=request.correlation_id,
                 ok=result.ok,
@@ -569,7 +621,9 @@ class RuntimeSupervisor:
                 error=result.error,
             )
         except Exception as error:
-            self.logger.error(
+            self.logger.bind(
+                trace_id=provenance.trace.trace_id if provenance is not None else None
+            ).error(
                 "runtime {} child action {} failed: {}",
                 record.spec.id,
                 request.correlation_id,

--- a/src/liteyukibot/testing.py
+++ b/src/liteyukibot/testing.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -27,7 +27,7 @@ from .runtime import (
     RuntimeSupervisor,
 )
 from .runtime.protocol import JsonValue, json_mapping
-from .runtime.supervisor import ActionSink, ActionSinkResult, EventSink
+from .runtime.supervisor import ActionProvenance, ActionSinkResult, EventSink
 from .services import ServiceKey, ServiceRegistry
 
 
@@ -161,7 +161,7 @@ class RuntimeTestHarness:
         spec: RuntimeSpec,
         *,
         event_sink: EventSink | None = None,
-        action_sink: ActionSink | None = None,
+        action_sink: Callable[[str, dict[str, JsonValue]], Awaitable[ActionSinkResult]] | None = None,
     ) -> None:
         if spec.command is None or not spec.command:
             raise ValueError("runtime test harness requires an explicit child command")
@@ -264,7 +264,10 @@ class RuntimeTestHarness:
         return await self._event_sink(runtime_id, payload)
 
     async def _record_action(
-        self, runtime_id: str, payload: dict[str, JsonValue]
+        self,
+        runtime_id: str,
+        payload: dict[str, JsonValue],
+        _provenance: ActionProvenance | None,
     ) -> ActionSinkResult:
         self._child_actions.append((runtime_id, json_mapping(payload)))
         if self._action_sink is None:

--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -28,6 +28,8 @@ from liteyukibot.control import ControlError, ControlServer, request_control
 from liteyukibot.events import (
     ActionEnvelope,
     ActionResult,
+    ActorRef,
+    CallApi,
     ConversationRef,
     EventEnvelope,
     Message,
@@ -37,7 +39,8 @@ from liteyukibot.events import (
 from liteyukibot.exceptions import PluginError
 from liteyukibot.functions import FunctionCall
 from liteyukibot.plugins import PluginDefinition, PluginHandle, PluginManifest
-from liteyukibot.runtime.protocol import EventAccepted
+from liteyukibot.runtime.protocol import EventAccepted, EventTrace
+from liteyukibot.runtime.supervisor import ActionProvenance
 from liteyukibot.services import ServiceKey, ServiceRequirement
 from liteyukibot.status import KERNEL_STATUS_SERVICE
 
@@ -60,6 +63,16 @@ class FakeLogger:
 
     def exception(self, message: str, *args: Any, **kwargs: Any) -> None:
         pass
+
+
+class PermissionFixture:
+    def __init__(self, allowed: bool) -> None:
+        self.allowed = allowed
+        self.observed: list[tuple[EventEnvelope, str]] = []
+
+    def allows(self, event: EventEnvelope, capability: str) -> bool:
+        self.observed.append((event, capability))
+        return self.allowed
 
 
 @pytest.mark.asyncio
@@ -279,7 +292,7 @@ async def test_app_routes_child_action_to_distinct_adapter_runtime(
 
     monkeypatch.setattr(app.actions, "execute", execute)
     result = await app._execute_runtime_action(
-        "compat", action.model_dump(mode="json")
+        "compat", action.model_dump(mode="json"), None
     )
 
     assert result.ok is True
@@ -301,7 +314,7 @@ async def test_app_rejects_invalid_and_self_targeted_child_actions(tmp_path: Pat
     )
     app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
 
-    invalid = await app._execute_runtime_action("compat", {"invalid": True})
+    invalid = await app._execute_runtime_action("compat", {"invalid": True}, None)
     self_target = await app._execute_runtime_action(
         "compat",
         ActionEnvelope(
@@ -313,12 +326,103 @@ async def test_app_rejects_invalid_and_self_targeted_child_actions(tmp_path: Pat
                 reply_token="reply-token",
             ),
         ).model_dump(mode="json"),
+        None,
     )
 
     assert invalid.ok is False
     assert invalid.error == "invalid ActionEnvelope"
     assert self_target.ok is False
     assert self_target.error == "child-originated action cannot target its source runtime"
+
+
+@pytest.mark.asyncio
+async def test_app_rejects_child_action_that_does_not_match_v4_source_event(tmp_path: Path) -> None:
+    settings = AppSettings(core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"))
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+    source = EventEnvelope(
+        id="event-1",
+        runtime_id="adapter",
+        adapter="onebot-v11",
+        bot_id="bot-1",
+        type="message.group.normal",
+        conversation=ConversationRef(id="group-1", type="group"),
+    )
+    action = ActionEnvelope(
+        event_id="event-1",
+        runtime_id="adapter",
+        bot_id="other-bot",
+        action=SendMessage(
+            message=Message(segments=(Segment(type="text", data={"text": "hello"}),)),
+            reply_token="reply-token",
+        ),
+    )
+    provenance = ActionProvenance(
+        delivery_correlation_id="delivery-1",
+        trace=EventTrace(
+            trace_id="event-1",
+            source_runtime_id="adapter",
+            source_event_id="event-1",
+        ),
+        event_payload=source.model_dump(mode="json"),
+    )
+
+    result = await app._execute_runtime_action("agent", action.model_dump(mode="json"), provenance)
+
+    assert result.ok is False
+    assert result.error == "child action does not match its source event provenance"
+
+
+@pytest.mark.asyncio
+async def test_app_call_api_requires_exact_event_capability_before_runtime_execution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = AppSettings(core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"))
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+    source = EventEnvelope(
+        id="event-1",
+        runtime_id="adapter",
+        adapter="onebot-v11",
+        bot_id="bot-1",
+        type="message.group.normal",
+        conversation=ConversationRef(id="group-1", type="group"),
+        actor=ActorRef(id="user-1"),
+    )
+    action = ActionEnvelope(
+        action_id="call-1",
+        event_id=source.id,
+        runtime_id=source.runtime_id,
+        bot_id=source.bot_id,
+        action=CallApi(api="get_status"),
+    )
+    provenance = ActionProvenance(
+        delivery_correlation_id="delivery-1",
+        trace=EventTrace(
+            trace_id=source.id,
+            source_runtime_id=source.runtime_id,
+            source_event_id=source.id,
+        ),
+        event_payload=source.model_dump(mode="json"),
+    )
+    executed: list[ActionEnvelope] = []
+
+    async def execute(envelope: ActionEnvelope) -> ActionResult:
+        executed.append(envelope)
+        return ActionResult(action_id=envelope.action_id, success=True)
+
+    monkeypatch.setattr(app.actions, "execute", execute)
+    denied = await app._execute_runtime_action("agent", action.model_dump(mode="json"), provenance)
+
+    assert denied.ok is False
+    assert denied.error == "adapter API action permission is denied"
+    assert executed == []
+
+    permissions = PermissionFixture(allowed=True)
+    app.services.provide(ServiceKey("liteyukibot.permissions", 1), permissions, provider="test")
+    allowed = await app._execute_runtime_action("agent", action.model_dump(mode="json"), provenance)
+
+    assert allowed.ok is True
+    assert permissions.observed == [(source, "liteyukibot.adapter.call_api")]
+    assert executed == [action]
 
 
 def _message_event() -> EventEnvelope:

--- a/tests/test_protocol_v7.py
+++ b/tests/test_protocol_v7.py
@@ -10,6 +10,7 @@ import pytest
 from liteyukibot.exceptions import RuntimeProtocolError
 from liteyukibot.runtime.protocol import (
     MAX_FRAME_SIZE,
+    ActionRequest,
     EventCompleted,
     EventMessage,
     EventTrace,
@@ -141,6 +142,20 @@ async def test_protocol_rejects_unsupported_hello_version() -> None:
 @pytest.mark.asyncio
 async def test_protocol_accepts_v4_event_completion() -> None:
     message = EventCompleted(correlation_id="delivery-1", status="completed")
+    writer = MemoryWriter()
+
+    await write_message(cast(asyncio.StreamWriter, writer), message)
+
+    assert await read_message(_reader(b"".join(writer.chunks))) == message
+
+
+@pytest.mark.asyncio
+async def test_protocol_preserves_v4_action_delivery_provenance() -> None:
+    message = ActionRequest(
+        correlation_id="action-1",
+        delivery_correlation_id="delivery-1",
+        payload={"type": "send_message"},
+    )
     writer = MemoryWriter()
 
     await write_message(cast(asyncio.StreamWriter, writer), message)

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -25,7 +25,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a11"),
+        ("root", "v7.0.0a12"),
         ("permissions", "permissions-v0.2.0a1"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),
@@ -37,7 +37,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("adapter-onebot", "adapter-onebot-v0.1.0a1"),
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
-        ("agent", "agent-v0.1.0a3"),
+        ("agent", "agent-v0.1.0a4"),
         ("runtime-astrbot", "runtime-astrbot-v0.1.0a3"),
         ("runtime-mofox", "runtime-mofox-v0.1.0a3"),
     ],

--- a/tests/test_runtime_v7.py
+++ b/tests/test_runtime_v7.py
@@ -28,7 +28,12 @@ from liteyukibot.runtime.protocol import (
     read_message,
     write_message,
 )
-from liteyukibot.runtime.supervisor import ActionSinkResult, AgentToolSinkResult, RuntimeRecord
+from liteyukibot.runtime.supervisor import (
+    ActionProvenance,
+    ActionSinkResult,
+    AgentToolSinkResult,
+    RuntimeRecord,
+)
 
 
 class FakeLogger:
@@ -328,7 +333,7 @@ async def test_v3_child_action_reaches_core_sink_with_correlation() -> None:
     observed: list[tuple[str, dict[str, Any]]] = []
 
     async def execute_child_action(
-        runtime_id: str, payload: dict[str, Any]
+        runtime_id: str, payload: dict[str, Any], _provenance: ActionProvenance | None
     ) -> ActionSinkResult:
         observed.append((runtime_id, payload))
         return ActionSinkResult(ok=True, data={"message_id": "sent-1"})
@@ -554,7 +559,11 @@ async def test_child_action_requires_v3_capability_and_sink(
     with_sink: bool,
     error: str,
 ) -> None:
-    async def sink(_runtime_id: str, _payload: dict[str, Any]) -> ActionSinkResult:
+    async def sink(
+        _runtime_id: str,
+        _payload: dict[str, Any],
+        _provenance: ActionProvenance | None,
+    ) -> ActionSinkResult:
         return ActionSinkResult(ok=True)
 
     supervisor = RuntimeSupervisor(
@@ -592,7 +601,11 @@ async def test_child_action_requires_v3_capability_and_sink(
 async def test_child_action_sink_failure_is_isolated(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def fail(_runtime_id: str, _payload: dict[str, Any]) -> ActionSinkResult:
+    async def fail(
+        _runtime_id: str,
+        _payload: dict[str, Any],
+        _provenance: ActionProvenance | None,
+    ) -> ActionSinkResult:
         raise RuntimeError("adapter failed")
 
     supervisor = RuntimeSupervisor(logger=FakeLogger(), action_sink=fail)
@@ -630,13 +643,77 @@ async def test_child_action_sink_failure_is_isolated(
 
 
 @pytest.mark.asyncio
+async def test_v4_child_action_requires_active_delivery_and_forwards_provenance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: list[ActionProvenance | None] = []
+
+    async def sink(
+        _runtime_id: str,
+        _payload: dict[str, Any],
+        provenance: ActionProvenance | None,
+    ) -> ActionSinkResult:
+        observed.append(provenance)
+        return ActionSinkResult(ok=True)
+
+    supervisor = RuntimeSupervisor(logger=FakeLogger(), action_sink=sink)
+    record = RuntimeRecord(
+        spec=RuntimeSpec(id="agent", kind="custom", agent_harness="native"),
+        token="token",
+        state=RuntimeState.READY,
+        writer=NullWriter(),  # type: ignore[arg-type]
+        protocol_version=4,
+        capabilities=frozenset({"runtime.actions.send"}),
+    )
+    trace = EventTrace(trace_id="event-1", source_runtime_id="adapter", source_event_id="event-1")
+    event_payload: dict[str, Any] = {"id": "event-1", "runtime_id": "adapter", "bot_id": "bot-1"}
+    record.active_delivery_contexts["delivery-1"] = (float("inf"), event_payload, trace)
+    responses: list[ActionResponse] = []
+
+    async def capture(_record: RuntimeRecord, message: Any) -> None:
+        assert isinstance(message, ActionResponse)
+        responses.append(message)
+
+    monkeypatch.setattr(supervisor, "_send", capture)
+    await supervisor._handle_message(
+        record,
+        ActionRequest(correlation_id="action-1", delivery_correlation_id="delivery-1", payload={}),
+    )
+    await asyncio.gather(*record.inbound_actions.values())
+
+    assert observed == [
+        ActionProvenance(
+            delivery_correlation_id="delivery-1",
+            trace=trace,
+            event_payload=event_payload,
+        )
+    ]
+    assert responses == [ActionResponse(correlation_id="action-1", ok=True)]
+
+    await supervisor._handle_message(
+        record,
+        ActionRequest(correlation_id="action-2", delivery_correlation_id="missing", payload={}),
+    )
+
+    assert responses[-1] == ActionResponse(
+        correlation_id="action-2",
+        ok=False,
+        error="action request is not bound to an active event delivery",
+    )
+
+
+@pytest.mark.asyncio
 async def test_duplicate_child_action_is_rejected_and_disconnect_cancels_sink(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     started = asyncio.Event()
     cancelled = asyncio.Event()
 
-    async def hold(_runtime_id: str, _payload: dict[str, Any]) -> ActionSinkResult:
+    async def hold(
+        _runtime_id: str,
+        _payload: dict[str, Any],
+        _provenance: ActionProvenance | None,
+    ) -> ActionSinkResult:
         started.set()
         try:
             await asyncio.Future()

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a11"
+version = "7.0.0a12"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1464,7 +1464,7 @@ requires-dist = [{ name = "liteyukibot-v7-runtime-adapter", editable = "packages
 
 [[package]]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "packages/agent" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Beta1 slice

- Bind v4 child Actions to an active kernel delivery and propagate immutable event provenance into the action boundary.
- Reject action event/runtime/bot mismatches before adapter execution; bind native Agent replies to their delivered event.
- Make protocol-neutral CallApi fail closed without exact source-event capability liteyukibot.adapter.call_api; EventBus applies the same guard to native plugin actions.
- Release root liteyukibot-v7==7.0.0a12 and Agent liteyukibot-v7-agent==0.1.0a4, with Agent requiring root >=a12.

## Verification

- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv run pytest (422 passed)
- uv run python scripts/check_release.py --tag v7.0.0a12
- uv run python scripts/check_release.py --tag agent-v0.1.0a4
- uv build and uv build --project packages/agent --out-dir dist/agent-check --clear

No configuration migration is required; deployments enabling CallApi must grant the new exact capability to the source principal.