### PR TITLE
feat(agent): scope tools to source event capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a12`. Kernel stabilization,
+The current pre-release is `liteyukibot-v7==7.0.0a13`. Kernel stabilization,
 the first bounded compatibility phase, and the first-party plugin foundation
 are complete. Runtime protocol v4 remains an alpha contract and may change
 under ADR 0011 before the first stable release.

--- a/docs/adr/0022-runtime-ipc-protocol-v4.md
+++ b/docs/adr/0022-runtime-ipc-protocol-v4.md
@@ -55,3 +55,10 @@ only accepts it while the delivery is active and passes the kernel-validated
 enforce that action event/runtime/bot routing matches the source Event before
 performing adapter-specific authorization. V3 Actions retain the existing
 unattributed shape and cannot claim this provenance.
+
+For an agent-harness Event, the kernel may additionally attach an
+`agent_tool_catalog`. It is a JSON-only, per-delivery projection of the tool
+schemas authorized for the source Event principal. The child receives no
+executable handlers or permission state. The kernel rechecks the same
+capabilities when a child submits an `agent_tool` request, so a fabricated tool
+ID cannot gain authority.

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -151,10 +151,11 @@ service is application policy for trusted plugins; it is not a sandbox
 boundary.
 
 Kernel-owned privileged capability names are defined in `liteyukibot.capabilities`.
-In beta1, a child-originated `CallApi` action requires
-`liteyukibot.adapter.call_api`, a v4 source-event provenance record, and an
-enabled permission service. `SendMessage` remains protocol-neutral and uses its
-existing event/runtime/bot routing checks.
+In beta1, every `CallApi` action requires `liteyukibot.adapter.call_api`, an
+exact source Event, and an enabled permission service. The kernel supplies the
+source Event for native handler results and v4 child provenance; a direct
+action call without one is denied. `SendMessage` remains protocol-neutral and
+uses its existing event/runtime/bot routing checks.
 
 ## Commands
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -40,7 +40,7 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a12` | `pyproject.toml` | `v7.0.0a12` |
+| `liteyukibot-v7==7.0.0a13` | `pyproject.toml` | `v7.0.0a13` |
 | `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |
@@ -51,7 +51,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-runtime-adapter==0.1.0a2` | `packages/runtime-adapter` | `runtime-adapter-v0.1.0a2` |
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
-| `liteyukibot-v7-agent==0.1.0a4` | `packages/agent` | `agent-v0.1.0a4` |
+| `liteyukibot-v7-agent==0.1.0a5` | `packages/agent` | `agent-v0.1.0a5` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
 tag that does not exactly match the selected source version and distribution.
@@ -60,7 +60,7 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a12`;
+1. `v7.0.0a13`;
 2. `permissions-v0.2.0a1`;
 3. `commands-v0.2.0a2`;
 4. `resources-v0.1.0a2`;
@@ -71,7 +71,7 @@ Push and wait for each release before creating the next tag:
 9. `runtime-adapter-v0.1.0a2`.
 10. `adapter-onebot-v0.1.0a1`.
 11. `runtime-v6-v0.1.0a1`.
-12. `agent-v0.1.0a4`.
+12. `agent-v0.1.0a5`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -3,3 +3,8 @@
 The native agent is an agent-only LiteyukiBot v7 runtime. It receives normalized
 events from source runtimes and emits ordinary actions back to those sources.
 It uses the official OpenAI Python SDK with an OpenAI-compatible endpoint.
+
+For each delivered Event, the kernel sends only the tool schemas authorized for
+that event principal. The agent runtime has no executable tool implementation;
+every tool request returns through the kernel broker, which checks the same
+capabilities again before invoking a package-provided handler.

--- a/packages/agent/pyproject.toml
+++ b/packages/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Native OpenAI-compatible agent harness for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -9,7 +9,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a12,<8",
+    "liteyukibot-v7>=7.0.0a13,<8",
     "liteyukibot-v7-agent-resolver>=0.1.0a1,<0.2",
     "openai>=2,<3",
 ]

--- a/packages/agent/src/liteyukibot_agent/__init__.py
+++ b/packages/agent/src/liteyukibot_agent/__init__.py
@@ -54,7 +54,7 @@ def runtime_plugin() -> RuntimePlugin:
 try:
     __version__ = version("liteyukibot-v7-agent")
 except PackageNotFoundError:
-    __version__ = "0.1.0a4"
+    __version__ = "0.1.0a5"
 
 plugin: PluginDefinition = create_plugin(__version__)
 

--- a/packages/agent/src/liteyukibot_agent/broker.py
+++ b/packages/agent/src/liteyukibot_agent/broker.py
@@ -49,11 +49,8 @@ class ToolBroker:
         tool = self._tools.get(tool_id)
         if tool is None:
             return AgentToolResult(ok=False, error="agent tool is not registered")
-        if tool.required_capabilities:
-            if self._permissions is None or not all(
-                self._permissions.allows(event, capability) for capability in tool.required_capabilities
-            ):
-                return AgentToolResult(ok=False, error="agent tool permission is denied")
+        if not self._allowed(event, tool):
+            return AgentToolResult(ok=False, error="agent tool permission is denied")
         try:
             result = await tool.handler(event, arguments)
         except Exception:
@@ -77,6 +74,28 @@ class ToolBroker:
                 if not tool.required_capabilities
             ]
         }
+
+    def catalog_for(self, event: EventEnvelope) -> Mapping[str, object]:
+        """Return exactly the schemas that this event principal may invoke."""
+
+        return {
+            "tools": [
+                {
+                    "id": tool.id,
+                    "title": tool.title,
+                    "description": tool.description,
+                    "input_schema": dict(tool.input_schema),
+                }
+                for tool in sorted(self._tools.values(), key=lambda candidate: candidate.id)
+                if self._allowed(event, tool)
+            ]
+        }
+
+    def _allowed(self, event: EventEnvelope, tool: AgentTool) -> bool:
+        return not tool.required_capabilities or (
+            self._permissions is not None
+            and all(self._permissions.allows(event, capability) for capability in tool.required_capabilities)
+        )
 
 
 def permission_checker(service: object | None) -> PermissionChecker | None:

--- a/packages/agent/src/liteyukibot_agent/engine.py
+++ b/packages/agent/src/liteyukibot_agent/engine.py
@@ -22,7 +22,12 @@ class ModelReply:
 
 
 class AgentEngine(Protocol):
-    async def complete(self, messages: Sequence[Mapping[str, object]]) -> ModelReply: ...
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        *,
+        tools: Sequence[Mapping[str, object]] = (),
+    ) -> ModelReply: ...
 
 
 class OpenAIChatEngine:
@@ -34,24 +39,27 @@ class OpenAIChatEngine:
         api_key: str,
         base_url: str | None,
         model: str,
-        tools: Sequence[Mapping[str, object]] = (),
     ) -> None:
         if not api_key or not model:
             raise ValueError("agent API key and model must not be empty")
         self.api_key = api_key
         self.base_url = base_url
         self.model = model
-        self.tools = tuple(tools)
 
-    async def complete(self, messages: Sequence[Mapping[str, object]]) -> ModelReply:
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        *,
+        tools: Sequence[Mapping[str, object]] = (),
+    ) -> ModelReply:
         try:
             from openai import AsyncOpenAI
         except ModuleNotFoundError as error:
             raise RuntimeError("native agent requires the openai package") from error
         client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
         request: dict[str, object] = {"model": self.model, "messages": list(messages)}
-        if self.tools:
-            request["tools"] = list(self.tools)
+        if tools:
+            request["tools"] = list(tools)
         completions: Any = client.chat.completions
         response = await completions.create(**request)
         message = response.choices[0].message

--- a/packages/agent/src/liteyukibot_agent/host.py
+++ b/packages/agent/src/liteyukibot_agent/host.py
@@ -99,7 +99,12 @@ class NativeAgentHost:
             return
         await self.client.send(EventAccepted(correlation_id=message.correlation_id, status="accepted"))
         task = asyncio.create_task(
-            self._process_event(message.correlation_id, event, message.trace),
+            self._process_event(
+                message.correlation_id,
+                event,
+                message.trace,
+                _tool_schemas(message.agent_tool_catalog),
+            ),
             name=f"agent-event:{message.correlation_id}",
         )
         self._tasks.add(task)
@@ -118,6 +123,7 @@ class NativeAgentHost:
         delivery_correlation_id: str,
         event: EventEnvelope,
         trace: EventTrace | None,
+        tools: Sequence[Mapping[str, object]],
     ) -> None:
         try:
             key = (event.runtime_id, event.bot_id, event.conversation.ordering_key)
@@ -125,7 +131,7 @@ class NativeAgentHost:
             messages: list[Mapping[str, object]] = [
                 item for item in self.store.messages(*key, limit=self.history_limit)
             ]
-            reply = await self.engine.complete(messages)
+            reply = await self.engine.complete(messages, tools=tools)
             for _index in range(4):
                 if not reply.tool_calls:
                     break
@@ -144,7 +150,7 @@ class NativeAgentHost:
                             "content": result.data if result.ok else {"error": result.error or "tool failed"},
                         }
                     )
-                reply = await self.engine.complete(messages)
+                reply = await self.engine.complete(messages, tools=tools)
             if reply.tool_calls:
                 raise RuntimeError("agent exceeded maximum tool-call rounds")
             if reply.text:
@@ -197,7 +203,6 @@ async def run() -> None:
             api_key=api_key,
             base_url=_optional_string(options, "base_url"),
             model=_required_string(options, "model"),
-            tools=_tool_schemas(options),
         )
         host = NativeAgentHost(
             client,
@@ -271,10 +276,9 @@ def _environment_secret(options: Mapping[str, object], key: str, default: str) -
     return value
 
 
-def _tool_schemas(options: Mapping[str, object]) -> tuple[Mapping[str, object], ...]:
-    catalog = options.get("agent_tool_catalog", {})
-    if not isinstance(catalog, Mapping):
-        raise ValueError("native agent option 'agent_tool_catalog' must be an object")
+def _tool_schemas(catalog: Mapping[str, object] | None) -> tuple[Mapping[str, object], ...]:
+    if catalog is None:
+        return ()
     tools = catalog.get("tools", ())
     if not isinstance(tools, Sequence) or isinstance(tools, (str, bytes)):
         raise ValueError("native agent tool catalog must contain a tools array")

--- a/packages/agent/tests/test_broker.py
+++ b/packages/agent/tests/test_broker.py
@@ -9,6 +9,14 @@ from liteyukibot.agents import AgentTool, AgentToolResult
 from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
 
 
+class FakePermissions:
+    def __init__(self, allowed: set[str]) -> None:
+        self.allowed = allowed
+
+    def allows(self, _event: EventEnvelope, capability: str) -> bool:
+        return capability in self.allowed
+
+
 def _event() -> EventEnvelope:
     return EventEnvelope(
         runtime_id="nonebot",
@@ -38,3 +46,42 @@ async def test_broker_rejects_unregistered_and_permissioned_tools_by_default() -
 
     assert (await broker.execute(_event(), "missing", {})).error == "agent tool is not registered"
     assert (await broker.execute(_event(), "admin.reset", {})).error == "agent tool permission is denied"
+
+
+@pytest.mark.asyncio
+async def test_broker_catalog_for_exposes_only_tools_authorized_for_the_event() -> None:
+    async def handler(_event: EventEnvelope, _arguments: Mapping[str, object]) -> AgentToolResult:
+        return AgentToolResult(ok=True)
+
+    public = AgentTool(
+        id="docs.search",
+        module_id="docs",
+        title="Search",
+        description="Search docs.",
+        input_schema={"type": "object", "properties": {}},
+        handler=handler,
+    )
+    protected = AgentTool(
+        id="admin.reset",
+        module_id="admin",
+        title="Reset",
+        description="Reset data.",
+        input_schema={"type": "object", "properties": {}},
+        handler=handler,
+        required_capabilities=frozenset({"admin.reset"}),
+    )
+    event = _event()
+    denied = ToolBroker({public.id: public, protected.id: protected}, FakePermissions(set()))
+    allowed = ToolBroker({public.id: public, protected.id: protected}, FakePermissions({"admin.reset"}))
+
+    denied_tools = denied.catalog_for(event)["tools"]
+    allowed_tools = allowed.catalog_for(event)["tools"]
+    assert isinstance(denied_tools, list)
+    assert isinstance(allowed_tools, list)
+    assert [item["id"] for item in denied_tools if isinstance(item, Mapping)] == ["docs.search"]
+    assert [item["id"] for item in allowed_tools if isinstance(item, Mapping)] == [
+        "admin.reset",
+        "docs.search",
+    ]
+    assert (await denied.execute(event, "admin.reset", {})).error == "agent tool permission is denied"
+    assert (await allowed.execute(event, "admin.reset", {})).ok is True

--- a/packages/agent/tests/test_native_agent.py
+++ b/packages/agent/tests/test_native_agent.py
@@ -54,14 +54,26 @@ class FakeEngine(AgentEngine):
     def __init__(self, replies: Sequence[ModelReply]) -> None:
         self._replies = iter(replies)
         self.calls: list[Sequence[Mapping[str, object]]] = []
+        self.tools: list[Sequence[Mapping[str, object]]] = []
 
-    async def complete(self, messages: Sequence[Mapping[str, object]]) -> ModelReply:
+    async def complete(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        *,
+        tools: Sequence[Mapping[str, object]] = (),
+    ) -> ModelReply:
         self.calls.append(messages)
+        self.tools.append(tools)
         return next(self._replies)
 
 
 class FailingEngine(AgentEngine):
-    async def complete(self, _messages: Sequence[Mapping[str, object]]) -> ModelReply:
+    async def complete(
+        self,
+        _messages: Sequence[Mapping[str, object]],
+        *,
+        tools: Sequence[Mapping[str, object]] = (),
+    ) -> ModelReply:
         raise RuntimeError("model unavailable")
 
 
@@ -91,7 +103,21 @@ async def test_native_agent_returns_ordered_chunks_to_source_runtime(tmp_path: P
     )
     event = _event()
 
-    await host._accept_event(EventMessage(correlation_id="delivery-1", payload=event.model_dump(mode="json")))
+    await host._accept_event(
+        EventMessage(
+            correlation_id="delivery-1",
+            payload=event.model_dump(mode="json"),
+            agent_tool_catalog={
+                "tools": [
+                    {
+                        "id": "docs.search",
+                        "description": "Search docs.",
+                        "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                    }
+                ]
+            },
+        )
+    )
     await asyncio.gather(*host._tasks)
     await host.close()
 
@@ -125,12 +151,48 @@ async def test_native_agent_binds_tool_calls_to_the_delivered_event(tmp_path: Pa
     )
     event = _event()
 
-    await host._accept_event(EventMessage(correlation_id="delivery-1", payload=event.model_dump(mode="json")))
+    await host._accept_event(
+        EventMessage(
+            correlation_id="delivery-1",
+            payload=event.model_dump(mode="json"),
+            agent_tool_catalog={
+                "tools": [
+                    {
+                        "id": "docs.search",
+                        "description": "Search docs.",
+                        "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                    }
+                ]
+            },
+        )
+    )
     await asyncio.gather(*host._tasks)
     await host.close()
 
     assert client.tool_calls == [("delivery-1", "docs.search", {"query": "liteyuki"})]
     assert len(engine.calls) == 2
+    assert engine.tools == [
+        (
+            {
+                "type": "function",
+                "function": {
+                    "name": "docs.search",
+                    "description": "Search docs.",
+                    "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                },
+            },
+        ),
+        (
+            {
+                "type": "function",
+                "function": {
+                    "name": "docs.search",
+                    "description": "Search docs.",
+                    "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                },
+            },
+        ),
+    ]
 
 
 @pytest.mark.asyncio

--- a/packages/essentials/tests/test_essentials.py
+++ b/packages/essentials/tests/test_essentials.py
@@ -258,7 +258,7 @@ async def test_three_plugin_topology_filters_help_and_correlates_status(tmp_path
     )
     recorded: list[ActionEnvelope] = []
 
-    async def record_action(action: ActionEnvelope) -> ActionResult:
+    async def record_action(_event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
         recorded.append(action)
         return ActionResult(action_id=action.action_id, success=True)
 
@@ -325,7 +325,7 @@ async def test_help_resolves_visible_hierarchical_aliases_and_renders_schema(tmp
     )
     recorded: list[ActionEnvelope] = []
 
-    async def record_action(action: ActionEnvelope) -> ActionResult:
+    async def record_action(_event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
         recorded.append(action)
         return ActionResult(action_id=action.action_id, success=True)
 

--- a/packages/profile/tests/test_profile.py
+++ b/packages/profile/tests/test_profile.py
@@ -140,7 +140,7 @@ async def test_profile_resource_commands_mutate_data_and_describe_limits(tmp_pat
     )
     actions: list[ActionEnvelope] = []
 
-    async def record(action: ActionEnvelope) -> ActionResult:
+    async def record(_event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
         actions.append(action)
         return ActionResult(action_id=action.action_id, success=True)
 
@@ -182,7 +182,7 @@ async def test_profile_language_drives_essentials_and_falls_back_after_reset(tmp
     )
     actions: list[ActionEnvelope] = []
 
-    async def record(action: ActionEnvelope) -> ActionResult:
+    async def record(_event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
         actions.append(action)
         return ActionResult(action_id=action.action_id, success=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a12"
+version = "7.0.0a13"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/verify_essentials_install.py
+++ b/scripts/verify_essentials_install.py
@@ -105,7 +105,7 @@ async def verify(expected_version: str | None = None) -> None:
         )
         actions: list[ActionEnvelope] = []
 
-        async def record(action: ActionEnvelope) -> ActionResult:
+        async def record(_event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
             actions.append(action)
             return ActionResult(action_id=action.action_id, success=True)
 

--- a/src/liteyukibot/agents.py
+++ b/src/liteyukibot/agents.py
@@ -65,11 +65,19 @@ class AgentToolCatalog(Protocol):
     def catalog(self) -> Mapping[str, object]: ...
 
 
+@runtime_checkable
+class EventAgentToolCatalog(Protocol):
+    """Expose only the tool schemas authorized for a concrete source event."""
+
+    def catalog_for(self, event: EventEnvelope) -> Mapping[str, object]: ...
+
+
 __all__ = [
     "AGENT_TOOL_BROKER_SERVICE",
     "AgentTool",
     "AgentToolBroker",
     "AgentToolCatalog",
+    "EventAgentToolCatalog",
     "AgentToolHandler",
     "AgentToolResult",
 ]

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from enum import StrEnum
 from pathlib import Path
 from time import monotonic
 from typing import Any
 
 from ._version import __version__
-from .agents import AGENT_TOOL_BROKER_SERVICE, AgentToolBroker, AgentToolCatalog, AgentToolResult
+from .agents import AGENT_TOOL_BROKER_SERVICE, AgentToolBroker, AgentToolResult, EventAgentToolCatalog
 from .capabilities import ADAPTER_CALL_API, PERMISSION_SERVICE_MAJOR, PERMISSION_SERVICE_NAME
 from .config import AppSettings, RuntimeEventRoute
 from .control import ControlServer
@@ -48,10 +48,18 @@ class AppState(StrEnum):
 class ActionService:
     """Route protocol-neutral actions to the runtime that owns the bot."""
 
-    def __init__(self, supervisor: RuntimeSupervisor) -> None:
+    def __init__(
+        self,
+        supervisor: RuntimeSupervisor,
+        action_guard: Callable[[EventEnvelope | None, ActionEnvelope], ActionResult | None],
+    ) -> None:
         self._supervisor = supervisor
+        self._action_guard = action_guard
 
-    async def execute(self, action: ActionEnvelope) -> ActionResult:
+    async def execute(self, action: ActionEnvelope, *, event: EventEnvelope | None = None) -> ActionResult:
+        guarded = self._action_guard(event, action)
+        if guarded is not None:
+            return guarded
         try:
             response = await self._supervisor.execute_action(
                 action.runtime_id,
@@ -115,15 +123,14 @@ class LiteyukiApp:
             secret_values=runtime_secrets,
         )
         self.runtimes.set_logging_settings(settings.logging)
-        self.actions = ActionService(self.runtimes)
+        self.actions = ActionService(self.runtimes, self._authorize_action)
         core = settings.core
         self.events = EventBus(
             queue_capacity=core.queue_capacity,
             enqueue_timeout=core.enqueue_timeout_seconds,
             handler_timeout=core.handler_timeout_seconds,
             max_concurrent_events=core.max_concurrent_events,
-            action_executor=self.actions.execute,
-            action_guard=self._authorize_action,
+            action_executor=self._execute_event_action,
             logger=self.logger,
         )
         self.plugins = PluginManager(
@@ -266,11 +273,6 @@ class LiteyukiApp:
                 if not isinstance(broker, AgentToolBroker):
                     raise RuntimeError("agent tool broker service has an invalid implementation")
                 self.runtimes.set_agent_tool_sink(self._execute_agent_tool)
-                if isinstance(broker, AgentToolCatalog):
-                    catalog = broker.catalog()
-                    for runtime_id, record in self.runtimes.records.items():
-                        if record.spec.agent_harness is not None:
-                            self.runtimes.merge_options(runtime_id, {"agent_tool_catalog": catalog})
 
             await self.runtimes.start()
             self._runtimes_started = True
@@ -512,14 +514,7 @@ class LiteyukiApp:
                 ok=False,
                 error="child-originated action cannot target its source runtime",
             )
-        guarded = self._authorize_action(source_event if provenance is not None else None, action)
-        if guarded is not None:
-            return ActionSinkResult(
-                ok=guarded.success,
-                data=guarded.model_dump(mode="json"),
-                error=guarded.error_message,
-            )
-        result = await self.actions.execute(action)
+        result = await self.actions.execute(action, event=source_event if provenance is not None else None)
         return ActionSinkResult(
             ok=result.success,
             data=result.model_dump(mode="json"),
@@ -561,6 +556,9 @@ class LiteyukiApp:
             error_code="ACTION_PERMISSION_DENIED",
             error_message="adapter API action permission is denied",
         )
+
+    async def _execute_event_action(self, event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
+        return await self.actions.execute(action, event=event)
 
     def _event_routes(self, settings: AppSettings) -> tuple[RuntimeEventRoute, ...]:
         routes = list(settings.runtime_event_routes)
@@ -676,11 +674,27 @@ class LiteyukiApp:
             raise ExceptionGroup("runtime event delivery failed", errors)
 
     async def _deliver_runtime_event(self, runtime_id: str, event: EventEnvelope) -> None:
-        result = await self.runtimes.dispatch_event(
-            runtime_id,
-            event.id,
-            event.model_dump(mode="json"),
-        )
+        catalog: Mapping[str, Any] | None = None
+        record = self.runtimes.records[runtime_id]
+        if record.spec.agent_harness is not None:
+            broker = self.services.get(AGENT_TOOL_BROKER_SERVICE)
+            if broker is not None:
+                if not isinstance(broker, EventAgentToolCatalog):
+                    raise RuntimeError("agent tool broker cannot produce event-scoped catalogs")
+                catalog = broker.catalog_for(event)
+        if catalog is None:
+            result = await self.runtimes.dispatch_event(
+                runtime_id,
+                event.id,
+                event.model_dump(mode="json"),
+            )
+        else:
+            result = await self.runtimes.dispatch_event(
+                runtime_id,
+                event.id,
+                event.model_dump(mode="json"),
+                agent_tool_catalog=catalog,
+            )
         if result.status != "accepted":
             detail = f": {result.detail}" if result.detail else ""
             raise RuntimeError(f"runtime {runtime_id} rejected event {event.id} as {result.status}{detail}")

--- a/src/liteyukibot/events/bus.py
+++ b/src/liteyukibot/events/bus.py
@@ -13,7 +13,7 @@ from yukilog import Logger, get_logger
 from .models import ActionEnvelope, ActionResult, DispatchResult, EventEnvelope, HandlerFailure, HandlerResult
 
 type EventHandler = Callable[[EventEnvelope], Awaitable[HandlerResult | None] | HandlerResult | None]
-type ActionExecutor = Callable[[ActionEnvelope], Awaitable[ActionResult] | ActionResult]
+type ActionExecutor = Callable[[EventEnvelope, ActionEnvelope], Awaitable[ActionResult] | ActionResult]
 type ActionGuard = Callable[[EventEnvelope, ActionEnvelope], Awaitable[ActionResult | None] | ActionResult | None]
 
 @dataclass(frozen=True, slots=True)
@@ -292,7 +292,7 @@ class EventBus:
                 error_message="the event bus has no action executor",
             )
         try:
-            result: Any = self._action_executor(action)
+            result: Any = self._action_executor(event, action)
             if inspect.isawaitable(result):
                 result = await result
             if not isinstance(result, ActionResult):

--- a/src/liteyukibot/plugins.py
+++ b/src/liteyukibot/plugins.py
@@ -15,7 +15,7 @@ from typing import Any, Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from .events import ActionEnvelope, ActionResult, EventBus
+from .events import ActionEnvelope, ActionResult, EventBus, EventEnvelope
 from .exceptions import PluginError, ServiceError
 from .init_specs import PluginInitSpec
 from .resource_packs import ResourcePackDeclaration
@@ -46,7 +46,7 @@ class LoggerLike(Protocol):
 
 
 class ActionServiceLike(Protocol):
-    async def execute(self, action: ActionEnvelope) -> ActionResult: ...
+    async def execute(self, action: ActionEnvelope, *, event: EventEnvelope | None = None) -> ActionResult: ...
 
 
 def _log_task_failure(logger: LoggerLike, name: str, error: BaseException) -> None:

--- a/src/liteyukibot/runtime/protocol.py
+++ b/src/liteyukibot/runtime/protocol.py
@@ -72,6 +72,7 @@ class EventMessage(WireModel):
     correlation_id: str
     payload: dict[str, JsonValue]
     trace: EventTrace | None = None
+    agent_tool_catalog: dict[str, JsonValue] | None = None
 
 
 class EventAccepted(WireModel):

--- a/src/liteyukibot/runtime/supervisor.py
+++ b/src/liteyukibot/runtime/supervisor.py
@@ -782,6 +782,8 @@ class RuntimeSupervisor:
         correlation_id: str,
         payload: Mapping[str, Any],
         timeout_seconds: float = 30.0,
+        *,
+        agent_tool_catalog: Mapping[str, Any] | None = None,
     ) -> EventAccepted:
         if timeout_seconds <= 0:
             raise ValueError("runtime event timeout must be positive")
@@ -790,6 +792,8 @@ class RuntimeSupervisor:
             raise RuntimeError(f"runtime {runtime_id} is not ready")
         if record.protocol_version not in (2, 3, 4):
             raise RuntimeError(f"runtime {runtime_id} did not negotiate protocol v2, v3, or v4")
+        if agent_tool_catalog is not None and record.protocol_version != 4:
+            raise RuntimeError(f"runtime {runtime_id} must negotiate protocol v4 for an agent tool catalog")
         if "runtime.events.receive" not in record.capabilities:
             raise RuntimeError(f"runtime {runtime_id} does not accept core events")
         if correlation_id in record.pending_events:
@@ -808,6 +812,7 @@ class RuntimeSupervisor:
                     correlation_id=correlation_id,
                     payload=record.pending_event_payloads[correlation_id],
                     trace=trace if record.protocol_version == 4 else None,
+                    agent_tool_catalog=json_mapping(agent_tool_catalog) if agent_tool_catalog is not None else None,
                 ),
             )
             async with asyncio.timeout(timeout_seconds):

--- a/src/liteyukibot/testing.py
+++ b/src/liteyukibot/testing.py
@@ -36,11 +36,13 @@ class _RecordingActionService:
         self._executor = executor
         self.recorded: list[ActionEnvelope] = []
 
-    async def execute(self, action: ActionEnvelope) -> ActionResult:
+    async def execute(self, action: ActionEnvelope, *, event: EventEnvelope | None = None) -> ActionResult:
         self.recorded.append(action)
         if self._executor is None:
             return ActionResult(action_id=action.action_id, success=True)
-        result = self._executor(action)
+        if event is None:
+            return ActionResult(action_id=action.action_id, success=True)
+        result = self._executor(event, action)
         if inspect.isawaitable(result):
             result = await result
         if not isinstance(result, ActionResult):
@@ -69,7 +71,7 @@ class PluginTestHarness:
             self._services.provide(key, value, provider="liteyukibot.testing")
         self._actions = _RecordingActionService(action_executor)
         self._events = EventBus(
-            action_executor=self._actions.execute,
+            action_executor=lambda event, action: self._actions.execute(action, event=event),
             logger=get_logger(component="plugin-test"),
         )
         self._manager = PluginManager(

--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -282,7 +282,7 @@ async def test_app_routes_child_action_to_distinct_adapter_runtime(
     )
     observed: list[ActionEnvelope] = []
 
-    async def execute(envelope: ActionEnvelope) -> ActionResult:
+    async def execute(envelope: ActionEnvelope, *, event: EventEnvelope | None = None) -> ActionResult:
         observed.append(envelope)
         return ActionResult(
             action_id=envelope.action_id,
@@ -405,11 +405,18 @@ async def test_app_call_api_requires_exact_event_capability_before_runtime_execu
     )
     executed: list[ActionEnvelope] = []
 
-    async def execute(envelope: ActionEnvelope) -> ActionResult:
+    async def execute_action(
+        _runtime_id: str,
+        _correlation_id: str,
+        payload: dict[str, Any],
+        timeout_seconds: float = 30.0,
+    ) -> object:
+        assert timeout_seconds == 30.0
+        envelope = ActionEnvelope.model_validate(payload)
         executed.append(envelope)
-        return ActionResult(action_id=envelope.action_id, success=True)
+        return type("Response", (), {"ok": True, "data": None, "error": None})()
 
-    monkeypatch.setattr(app.actions, "execute", execute)
+    monkeypatch.setattr(app.runtimes, "execute_action", execute_action)
     denied = await app._execute_runtime_action("agent", action.model_dump(mode="json"), provenance)
 
     assert denied.ok is False
@@ -423,6 +430,31 @@ async def test_app_call_api_requires_exact_event_capability_before_runtime_execu
     assert allowed.ok is True
     assert permissions.observed == [(source, "liteyukibot.adapter.call_api")]
     assert executed == [action]
+
+
+@pytest.mark.asyncio
+async def test_app_action_service_refuses_call_api_without_a_source_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = AppSettings(core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"))
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+    action = ActionEnvelope(
+        action_id="call-1",
+        runtime_id="adapter",
+        bot_id="bot-1",
+        action=CallApi(api="get_status"),
+    )
+
+    async def execute_unexpectedly(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("unauthorized CallApi reached the runtime supervisor")
+
+    monkeypatch.setattr(app.runtimes, "execute_action", execute_unexpectedly)
+
+    result = await app.actions.execute(action)
+
+    assert result.success is False
+    assert result.error_code == "ACTION_PERMISSION_DENIED"
+    assert result.error_message == "adapter API action requires a source event"
 
 
 def _message_event() -> EventEnvelope:

--- a/tests/test_events_v7.py
+++ b/tests/test_events_v7.py
@@ -99,7 +99,7 @@ def test_handler_order_stop_propagation_and_action_execution() -> None:
             action=CallApi(api="test"),
         )
 
-        async def execute(envelope: ActionEnvelope) -> ActionResult:
+        async def execute(_event: EventEnvelope, envelope: ActionEnvelope) -> ActionResult:
             executed.append(envelope.action_id)
             return ActionResult(action_id=envelope.action_id, success=True, data={"ok": True})
 

--- a/tests/test_protocol_v7.py
+++ b/tests/test_protocol_v7.py
@@ -50,6 +50,15 @@ async def test_protocol_round_trip_preserves_message_shape() -> None:
             source_runtime_id="nonebot",
             source_event_id="event-1",
         ),
+        agent_tool_catalog={
+            "tools": [
+                {
+                    "id": "docs.search",
+                    "description": "Search the docs.",
+                    "input_schema": {"type": "object"},
+                }
+            ]
+        },
     )
     writer = MemoryWriter()
 

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -25,7 +25,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a12"),
+        ("root", "v7.0.0a13"),
         ("permissions", "permissions-v0.2.0a1"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),
@@ -37,7 +37,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("adapter-onebot", "adapter-onebot-v0.1.0a1"),
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
-        ("agent", "agent-v0.1.0a4"),
+        ("agent", "agent-v0.1.0a5"),
         ("runtime-astrbot", "runtime-astrbot-v0.1.0a3"),
         ("runtime-mofox", "runtime-mofox-v0.1.0a3"),
     ],

--- a/tests/test_runtime_v7.py
+++ b/tests/test_runtime_v7.py
@@ -947,6 +947,15 @@ async def test_v4_event_delivery_carries_trace_and_records_terminal_outcome(
         "agent",
         "delivery-1",
         {"id": "event-1", "runtime_id": "nonebot", "message": "hello"},
+        agent_tool_catalog={
+            "tools": [
+                {
+                    "id": "docs.search",
+                    "description": "Search the docs.",
+                    "input_schema": {"type": "object"},
+                }
+            ]
+        },
     )
 
     assert result.status == "accepted"
@@ -959,6 +968,15 @@ async def test_v4_event_delivery_carries_trace_and_records_terminal_outcome(
                 source_runtime_id="nonebot",
                 source_event_id="event-1",
             ),
+            agent_tool_catalog={
+                "tools": [
+                    {
+                        "id": "docs.search",
+                        "description": "Search the docs.",
+                        "input_schema": {"type": "object"},
+                    }
+                ]
+            },
         )
     ]
     assert "delivery-1" in record.active_delivery_contexts
@@ -999,6 +1017,13 @@ async def test_v3_event_delivery_does_not_serialize_v4_trace(monkeypatch: pytest
     await supervisor.dispatch_event("legacy", "delivery-1", {"id": "event-1", "runtime_id": "nonebot"})
 
     assert outbound[0].trace is None
+    with pytest.raises(RuntimeError, match="must negotiate protocol v4"):
+        await supervisor.dispatch_event(
+            "legacy",
+            "delivery-2",
+            {"id": "event-2", "runtime_id": "nonebot"},
+            agent_tool_catalog={"tools": []},
+        )
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a12"
+version = "7.0.0a13"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1464,7 +1464,7 @@ requires-dist = [{ name = "liteyukibot-v7-runtime-adapter", editable = "packages
 
 [[package]]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a4"
+version = "0.1.0a5"
 source = { editable = "packages/agent" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Beta1 slice

Completes the event-scoped Agent capability boundary on top of #167.

## Contract changes

- Adds optional v4 `EventMessage.agent_tool_catalog`; kernel derives schemas from the source event principal and sends only JSON metadata to Agent children.
- Agent tools are visible only when authorized and are rechecked by the kernel broker at execution time.
- Routes all `CallApi` execution through `ActionService` with an exact source event. Native event handlers and v4 child actions retain their source context; direct calls without one are denied. `SendMessage` remains unaffected.

## Release impact

- Root pre-release: `7.0.0a13`.
- Native Agent pre-release: `0.1.0a5`, requiring root `>=7.0.0a13,<8`.
- No protocol generation bump: the new v4 field is optional and only supplied to the native Agent runtime.

## Verification

- `uv run ruff check src packages tests scripts examples`
- `uv run mypy`
- `uv run pytest` (`424 passed`)
- Root and Agent wheel builds
- `scripts/check_release.py --tag v7.0.0a13`
- `scripts/check_release.py --tag agent-v0.1.0a5`