### PR TITLE
feat(plugins): verify generation before activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a13`. Kernel stabilization,
+The current pre-release is `liteyukibot-v7==7.0.0a14`. Kernel stabilization,
 the first bounded compatibility phase, and the first-party plugin foundation
 are complete. Runtime protocol v4 remains an alpha contract and may change
 under ADR 0011 before the first stable release.

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -95,6 +95,12 @@ for new protocol and platform adapter packages. Adapters publish a controlled
 network connections, and event/action conversion inside that child process.
 The kernel exchanges only frozen envelopes. Managed runtime generations permit
 only their selected adapter entry points; the host ships without a platform SDK.
+Before a managed generation becomes active, the kernel re-reads its immutable
+manifest and load plan, then uses that generation's isolated Python to verify
+the runtime distribution and `-m` host module can import. A failed probe removes
+only the staged generation and leaves that runtime's active and rollback
+pointers unchanged. This is an offline loadability gate, not an external
+framework, credential, or network smoke test.
 
 `liteyukibot-v7-adapter-onebot` is the first protocol package hosted there.
 Its `onebot-v11` entry point owns a bounded HTTP Post event listener and a

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -40,7 +40,7 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a13` | `pyproject.toml` | `v7.0.0a13` |
+| `liteyukibot-v7==7.0.0a14` | `pyproject.toml` | `v7.0.0a14` |
 | `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |
@@ -60,7 +60,7 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a13`;
+1. `v7.0.0a14`;
 2. `permissions-v0.2.0a1`;
 3. `commands-v0.2.0a2`;
 4. `resources-v0.1.0a2`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a13"
+version = "7.0.0a14"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/liteyukibot/plugin_install.py
+++ b/src/liteyukibot/plugin_install.py
@@ -231,6 +231,8 @@ class PluginInstallationService:
                 disabled_roots=disabled_roots,
             )
             self.generations.write(generation)
+            self.generations.read(runtime_id, generation_id)
+            self._probe_generation(generation_path, runtime)
             self.generations.activate(runtime_id, generation_id)
         except BaseException:
             shutil.rmtree(generation_path, ignore_errors=True)
@@ -328,6 +330,23 @@ class PluginInstallationService:
                 wheel_paths.append(str(staged))
             self._run(["uv", "pip", "install", "--no-index", "--no-deps", "--python", str(python), *wheel_paths])
 
+    def _probe_generation(self, generation_path: Path, runtime: RuntimePlugin) -> None:
+        """Verify the isolated runtime host imports before changing deployment state."""
+
+        module = _runtime_module(runtime)
+        python = self.generations.python_path(generation_path)
+        self._run(
+            [
+                str(python),
+                "-c",
+                "import importlib, importlib.metadata, sys; "
+                "importlib.metadata.distribution(sys.argv[1]); "
+                "importlib.import_module(sys.argv[2])",
+                runtime.distribution or "",
+                module,
+            ]
+        )
+
 
 def _resolve_bundles(index: PluginIndex, roots: tuple[str, ...]) -> tuple[PluginBundle, ...]:
     resolved: list[PluginBundle] = []
@@ -350,6 +369,19 @@ def _resolve_bundles(index: PluginIndex, roots: tuple[str, ...]) -> tuple[Plugin
     for root in roots:
         visit(root)
     return tuple(resolved)
+
+
+def _runtime_module(runtime: RuntimePlugin) -> str:
+    try:
+        marker = runtime.command.index("-m")
+        module = runtime.command[marker + 1]
+    except (ValueError, IndexError) as error:
+        raise PluginStoreError(
+            f"managed runtime kind {runtime.kind!r} command must contain a Python -m module"
+        ) from error
+    if not module or module.startswith("-"):
+        raise PluginStoreError(f"managed runtime kind {runtime.kind!r} command has an invalid Python module")
+    return module
 
 
 def _roots_requiring(index: PluginIndex, roots: tuple[str, ...], bundle_id: str) -> tuple[str, ...]:

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -132,8 +132,10 @@ def test_installer_resolves_dependencies_and_activates_only_after_materializatio
     assert result.generation.roots == ("example.root",)
     assert result.generation.source_id == "liteyukibot-v7-plugins"
     assert result.generation.resolved_bundles[-1].id == "example.root"
-    assert len(commands) == 2
+    assert len(commands) == 3
     assert commands[1][-1] == "runtime-v6==1.2.3"
+    assert commands[2][1] == "-c"
+    assert commands[2][-2:] == ["runtime-v6", "host"]
 
 
 def test_installer_stages_hash_verified_wheels_without_index_resolution(
@@ -222,6 +224,75 @@ def test_failed_environment_creation_does_not_activate_or_retain_generation(
     store = RuntimeGenerationStore(tmp_path)
     assert store.active().runtime_generations == {}
     assert not (tmp_path / ".liteyuki" / "plugins" / "runtimes" / "legacy" / "generations").exists()
+
+
+def test_failed_generation_probe_keeps_the_previous_runtime_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive, digest = _archive(tmp_path)
+    index = _index(digest)
+    monkeypatch.setattr(PluginSourceStore, "fetch", lambda _self, _source, refresh: index)
+    monkeypatch.setattr(
+        RuntimeCatalog,
+        "discover",
+        lambda _self: {
+            "v6": RuntimePlugin(
+                "v6", ("python", "-m", "host"), facet_installer=_Installer(), distribution="runtime-v6"
+            )
+        },
+    )
+    monkeypatch.setattr("liteyukibot.plugin_install.metadata.version", lambda _distribution: "1.2.3")
+
+    def run(command: list[str]) -> None:
+        if command[1] == "venv":
+            python = Path(command[-1]) / "Scripts" / "python.exe"
+            python.parent.mkdir(parents=True)
+            python.write_text("", encoding="utf-8")
+
+    service = PluginInstallationService(tmp_path, run=run)
+    monkeypatch.setattr(service.artifacts, "fetch", lambda _artifact: service.artifacts.import_file(archive, digest))
+    first = service.install("example.root", runtime_id="legacy", runtime_kind="v6")
+
+    def fail_probe(_path: Path, _runtime: RuntimePlugin) -> None:
+        raise PluginStoreError("runtime generation health probe failed")
+
+    monkeypatch.setattr(service, "_probe_generation", fail_probe)
+    with pytest.raises(PluginStoreError, match="health probe failed"):
+        service.install("example.second", runtime_id="legacy", runtime_kind="v6")
+
+    store = RuntimeGenerationStore(tmp_path)
+    assert store.active().runtime_generations == {"legacy": first.generation.id}
+    assert store.active().previous == {}
+    assert [generation.id for generation in store.list_generations("legacy")] == [first.generation.id]
+
+
+def test_installer_rejects_managed_runtime_without_a_python_module_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive, digest = _archive(tmp_path)
+    monkeypatch.setattr(PluginSourceStore, "fetch", lambda _self, _source, refresh: _index(digest))
+    monkeypatch.setattr(
+        RuntimeCatalog,
+        "discover",
+        lambda _self: {
+            "v6": RuntimePlugin("v6", ("runtime-host",), facet_installer=_Installer(), distribution="runtime-v6")
+        },
+    )
+    monkeypatch.setattr("liteyukibot.plugin_install.metadata.version", lambda _distribution: "1.2.3")
+
+    def run(command: list[str]) -> None:
+        if command[1] == "venv":
+            python = Path(command[-1]) / "Scripts" / "python.exe"
+            python.parent.mkdir(parents=True)
+            python.write_text("", encoding="utf-8")
+
+    service = PluginInstallationService(tmp_path, run=run)
+    monkeypatch.setattr(service.artifacts, "fetch", lambda _artifact: service.artifacts.import_file(archive, digest))
+
+    with pytest.raises(PluginStoreError, match="must contain a Python -m module"):
+        service.install("example.root", runtime_id="legacy", runtime_kind="v6")
+
+    assert RuntimeGenerationStore(tmp_path).active().runtime_generations == {}
 
 
 def test_installer_adds_a_root_without_dropping_the_active_generation_set(

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -25,7 +25,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a13"),
+        ("root", "v7.0.0a14"),
         ("permissions", "permissions-v0.2.0a1"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a13"
+version = "7.0.0a14"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Beta1 slice

Adds the runtime-generation health gate on top of #168.

## Behavior

- A managed generation is written, re-read through the immutable manifest/load-plan verifier, then probed with its own isolated Python before deployment activation.
- The probe requires the declared runtime distribution and the runtime command's `-m` module to import.
- Any manifest, load-plan, or probe failure removes only the staged generation. The affected runtime keeps its active and previous generation pointers; unrelated runtimes are not changed.

## Boundary

This is an offline loadability gate. It deliberately does not claim framework boot, credentials, external network, or platform transport health; those belong to the real-runtime proof slice.

## Release impact

Root pre-release advances to `liteyukibot-v7==7.0.0a14`. No runtime IPC contract changes.

## Verification

- `uv run ruff check src packages tests scripts examples`
- `uv run mypy`
- `uv run pytest` (`426 passed`)
- Root wheel build
- `scripts/check_release.py --tag v7.0.0a14`