### PR TITLE
test(agent): verify installed wheel contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a14`. Kernel stabilization,
+The current pre-release is `liteyukibot-v7==7.0.0a15`. Kernel stabilization,
 the first bounded compatibility phase, and the first-party plugin foundation
 are complete. Runtime protocol v4 remains an alpha contract and may change
 under ADR 0011 before the first stable release.

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -40,7 +40,7 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a14` | `pyproject.toml` | `v7.0.0a14` |
+| `liteyukibot-v7==7.0.0a15` | `pyproject.toml` | `v7.0.0a15` |
 | `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |
@@ -60,7 +60,7 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a14`;
+1. `v7.0.0a15`;
 2. `permissions-v0.2.0a1`;
 3. `commands-v0.2.0a2`;
 4. `resources-v0.1.0a2`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a14"
+version = "7.0.0a15"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/verify_agent_install.py
+++ b/scripts/verify_agent_install.py
@@ -3,16 +3,177 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import importlib.metadata
 import json
+import tempfile
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import liteyukibot_agent
+from liteyukibot_agent.broker import ToolBroker
+from liteyukibot_agent.engine import AgentEngine, ModelReply, ToolCall
+from liteyukibot_agent.host import NativeAgentHost
+from liteyukibot_agent.store import ConversationStore
 
 import liteyukibot
+from liteyukibot.agents import AgentTool, AgentToolResult
+from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope, Message, Segment
 from liteyukibot.runtime import RuntimeCatalog
+from liteyukibot.runtime.protocol import (
+    ActionResponse,
+    AgentToolResponse,
+    EventAccepted,
+    EventCompleted,
+    EventMessage,
+    json_mapping,
+)
 
 SOURCE_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Permissions:
+    def __init__(self, allowed: set[str]) -> None:
+        self._allowed = allowed
+
+    def allows(self, _event: EventEnvelope, capability: str) -> bool:
+        return capability in self._allowed
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.sent: list[object] = []
+        self.actions: list[Mapping[str, object]] = []
+        self.tool_calls: list[tuple[str, str, Mapping[str, object]]] = []
+
+    async def send(self, message: object) -> None:
+        self.sent.append(message)
+
+    async def execute_action(
+        self,
+        _correlation_id: str,
+        payload: Mapping[str, object],
+        *,
+        delivery_correlation_id: str | None = None,
+    ) -> ActionResponse:
+        if delivery_correlation_id != "delivery-1":
+            raise RuntimeError("agent action was not bound to its source delivery")
+        self.actions.append(payload)
+        return ActionResponse(correlation_id="action", ok=True)
+
+    async def execute_agent_tool(
+        self,
+        _correlation_id: str,
+        delivery_correlation_id: str,
+        tool_id: str,
+        arguments: Mapping[str, object],
+    ) -> AgentToolResponse:
+        self.tool_calls.append((delivery_correlation_id, tool_id, arguments))
+        return AgentToolResponse(correlation_id="tool", ok=True, data={"result": "found"})
+
+
+class _Engine(AgentEngine):
+    def __init__(self) -> None:
+        self.calls = 0
+        self.tools: list[Sequence[Mapping[str, object]]] = []
+
+    async def complete(
+        self,
+        _messages: Sequence[Mapping[str, object]],
+        *,
+        tools: Sequence[Mapping[str, object]] = (),
+    ) -> ModelReply:
+        self.tools.append(tools)
+        self.calls += 1
+        if self.calls == 1:
+            return ModelReply(tool_calls=(ToolCall("call-1", "docs.search", {"query": "liteyuki"}),))
+        return ModelReply(text="found it")
+
+
+def _event() -> EventEnvelope:
+    return EventEnvelope(
+        id="event-1",
+        runtime_id="nonebot",
+        adapter="onebot.v11",
+        bot_id="bot-1",
+        type="message",
+        conversation=ConversationRef(id="group-1", type="group"),
+        actor=ActorRef(id="user-1"),
+        message=Message(segments=(Segment(type="text", data={"text": "search docs"}),)),
+    )
+
+
+async def _verify_agent_contract() -> None:
+    calls: list[Mapping[str, object]] = []
+
+    async def search(event: EventEnvelope, arguments: Mapping[str, object]) -> AgentToolResult:
+        if event.id != "event-1" or arguments != {"query": "liteyuki"}:
+            raise RuntimeError("agent tool handler received an unexpected source event")
+        calls.append(arguments)
+        return AgentToolResult(ok=True, data={"result": "found"})
+
+    tool = AgentTool(
+        id="docs.search",
+        module_id="docs",
+        title="Search docs",
+        description="Search installed documentation.",
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+        handler=search,
+        required_capabilities=frozenset({"docs.search"}),
+    )
+    event = _event()
+    denied = ToolBroker({tool.id: tool}, _Permissions(set()))
+    if denied.catalog_for(event)["tools"] != []:
+        raise RuntimeError("permissioned agent tool leaked into a denied event catalog")
+    if (await denied.execute(event, tool.id, {"query": "liteyuki"})).error != "agent tool permission is denied":
+        raise RuntimeError("permissioned agent tool execution was not denied")
+
+    broker = ToolBroker({tool.id: tool}, _Permissions({"docs.search"}))
+    catalog = broker.catalog_for(event)
+    result = await broker.execute(event, tool.id, {"query": "liteyuki"})
+    if result != AgentToolResult(ok=True, data={"result": "found"}) or calls != [{"query": "liteyuki"}]:
+        raise RuntimeError("authorized agent tool did not execute through the broker")
+
+    client = _Client()
+    engine = _Engine()
+    with tempfile.TemporaryDirectory() as directory:
+        host = NativeAgentHost(
+            client,  # type: ignore[arg-type]
+            engine,
+            ConversationStore(Path(directory) / "history.sqlite3"),
+            history_limit=10,
+            message_chunk_size=100,
+            max_concurrent_events=1,
+        )
+        await host._accept_event(
+            EventMessage(
+                correlation_id="delivery-1",
+                payload=event.model_dump(mode="json"),
+                agent_tool_catalog=json_mapping(catalog),
+            )
+        )
+        await asyncio.gather(*host._tasks)
+        await host.close()
+
+    expected_schema = {
+        "type": "function",
+        "function": {
+            "name": "docs.search",
+            "description": "Search installed documentation.",
+            "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+        },
+    }
+    if engine.tools != [(expected_schema,), (expected_schema,)]:
+        raise RuntimeError("agent harness did not pass the event-specific catalog to every model turn")
+    if client.tool_calls != [("delivery-1", "docs.search", {"query": "liteyuki"})]:
+        raise RuntimeError("agent tool request was not bound to its source delivery")
+    if client.sent != [
+        EventAccepted(correlation_id="delivery-1", status="accepted"),
+        EventCompleted(correlation_id="delivery-1", status="completed"),
+    ]:
+        raise RuntimeError("agent event did not reach the expected terminal protocol state")
+    if len(client.actions) != 1 or client.actions[0].get("runtime_id") != "nonebot":
+        raise RuntimeError("agent reply was not routed through the source runtime")
 
 
 def verify(expected_version: str | None = None) -> None:
@@ -28,6 +189,7 @@ def verify(expected_version: str | None = None) -> None:
     }
     if expected_version is not None and observed["liteyukibot-v7-agent"] != expected_version:
         raise RuntimeError(f"expected liteyukibot-v7-agent {expected_version}; observed {observed}")
+    asyncio.run(_verify_agent_contract())
     print(json.dumps(observed, sort_keys=True))
 
 

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -25,7 +25,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a14"),
+        ("root", "v7.0.0a15"),
         ("permissions", "permissions-v0.2.0a1"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a14"
+version = "7.0.0a15"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Beta1 slice

Close the native Agent installed-wheel boundary before further beta runtime work.

## Contract

- run the verifier from a temporary directory using only workspace-built root, Agent resolver, and Agent wheels
- prove denied event principals receive neither a model-visible tool schema nor an executable tool
- prove an authorized event catalog reaches each mocked model turn, and tool/action requests retain the source delivery and runtime
- no model provider, platform SDK, or external network service is contacted

## Release impact

- root pre-release advances to 7.0.0a15
- liteyukibot-v7-agent remains 0.1.0a5; its public artifact is unchanged

## Verification

- ruff check for changed verifier and release test
- full strict mypy
- full pytest: 426 passed
- all workspace wheels built
- isolated installed-Agent verifier passed
- release identity check for v7.0.0a15