### PR TITLE
fix(runtime): bind agent bridge actions to deliveries

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -52,6 +52,8 @@ distribution inside the workflow.
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
 | `liteyukibot-v7-agent==0.1.0a5` | `packages/agent` | `agent-v0.1.0a5` |
+| `liteyukibot-v7-runtime-astrbot==0.1.0a4` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a4` |
+| `liteyukibot-v7-runtime-mofox==0.1.0a4` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a4` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
 tag that does not exactly match the selected source version and distribution.

--- a/packages/runtime-astrbot/pyproject.toml
+++ b/packages/runtime-astrbot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Headless AstrBot agent runtime for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -9,7 +9,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a10,<8",
+    "liteyukibot-v7>=7.0.0a15,<8",
     "AstrBot>=4.27.2,<5",
 ]
 

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
@@ -233,7 +233,11 @@ class AstrBotRuntimeHost:
     ) -> None:
         async def emit(text: str) -> None:
             action = to_send_action(event, text)
-            result = await self.client.execute_action(action.action_id, action.model_dump(mode="json"))
+            result = await self.client.execute_action(
+                action.action_id,
+                action.model_dump(mode="json"),
+                delivery_correlation_id=correlation_id,
+            )
             if not result.ok:
                 raise RuntimeError(result.error or "source runtime rejected AstrBot output")
 

--- a/packages/runtime-astrbot/tests/test_translate.py
+++ b/packages/runtime-astrbot/tests/test_translate.py
@@ -56,7 +56,14 @@ class FakeClient:
     async def send(self, message: object) -> None:
         self.sent.append(message)
 
-    async def execute_action(self, _correlation_id: str, payload: dict[str, object]) -> ActionResponse:
+    async def execute_action(
+        self,
+        _correlation_id: str,
+        payload: dict[str, object],
+        *,
+        delivery_correlation_id: str | None = None,
+    ) -> ActionResponse:
+        assert delivery_correlation_id == "delivery-1"
         self.actions.append(payload)
         return ActionResponse(correlation_id="action", ok=True)
 

--- a/packages/runtime-mofox/pyproject.toml
+++ b/packages/runtime-mofox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-mofox"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Headless Neo-MoFox agent runtime for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -9,7 +9,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a10,<8",
+    "liteyukibot-v7>=7.0.0a15,<8",
     "neo-mofox @ git+https://github.com/MoFox-Studio/Neo-MoFox.git@e2ee2ff73b494428bbdfd983c7569c6f074a9c76",
 ]
 

--- a/packages/runtime-mofox/src/liteyukibot_runtime_mofox/host.py
+++ b/packages/runtime-mofox/src/liteyukibot_runtime_mofox/host.py
@@ -186,7 +186,11 @@ class MoFoxRuntimeHost:
     ) -> None:
         async def emit(text: str) -> None:
             action = to_send_action(event, text)
-            result = await self.client.execute_action(action.action_id, action.model_dump(mode="json"))
+            result = await self.client.execute_action(
+                action.action_id,
+                action.model_dump(mode="json"),
+                delivery_correlation_id=correlation_id,
+            )
             if not result.ok:
                 raise RuntimeError(result.error or "source runtime rejected MoFox output")
 

--- a/packages/runtime-mofox/tests/test_mofox_runtime.py
+++ b/packages/runtime-mofox/tests/test_mofox_runtime.py
@@ -83,7 +83,14 @@ class FakeClient:
     async def send(self, message: object) -> None:
         self.sent.append(message)
 
-    async def execute_action(self, _correlation_id: str, payload: dict[str, object]) -> ActionResponse:
+    async def execute_action(
+        self,
+        _correlation_id: str,
+        payload: dict[str, object],
+        *,
+        delivery_correlation_id: str | None = None,
+    ) -> ActionResponse:
+        assert delivery_correlation_id == "delivery-1"
         self.actions.append(payload)
         return ActionResponse(correlation_id="action", ok=True)
 

--- a/src/liteyukibot/runtime/supervisor.py
+++ b/src/liteyukibot/runtime/supervisor.py
@@ -550,6 +550,17 @@ class RuntimeSupervisor:
                 "child runtime did not declare runtime.actions.send",
             )
             return
+        if (
+            record.protocol_version == 4
+            and record.spec.agent_harness is not None
+            and request.delivery_correlation_id is None
+        ):
+            await self._reject_child_action(
+                record,
+                request,
+                "agent runtime actions require a v4 delivery correlation id",
+            )
+            return
         provenance: ActionProvenance | None = None
         if request.delivery_correlation_id is not None:
             self._clear_expired_delivery_contexts(record)

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -38,8 +38,8 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
         ("agent", "agent-v0.1.0a5"),
-        ("runtime-astrbot", "runtime-astrbot-v0.1.0a3"),
-        ("runtime-mofox", "runtime-mofox-v0.1.0a3"),
+        ("runtime-astrbot", "runtime-astrbot-v0.1.0a4"),
+        ("runtime-mofox", "runtime-mofox-v0.1.0a4"),
     ],
 )
 def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> None:

--- a/tests/test_runtime_v7.py
+++ b/tests/test_runtime_v7.py
@@ -677,6 +677,18 @@ async def test_v4_child_action_requires_active_delivery_and_forwards_provenance(
     monkeypatch.setattr(supervisor, "_send", capture)
     await supervisor._handle_message(
         record,
+        ActionRequest(correlation_id="action-unbound", payload={}),
+    )
+    assert responses == [
+        ActionResponse(
+            correlation_id="action-unbound",
+            ok=False,
+            error="agent runtime actions require a v4 delivery correlation id",
+        )
+    ]
+
+    await supervisor._handle_message(
+        record,
         ActionRequest(correlation_id="action-1", delivery_correlation_id="delivery-1", payload={}),
     )
     await asyncio.gather(*record.inbound_actions.values())
@@ -688,7 +700,7 @@ async def test_v4_child_action_requires_active_delivery_and_forwards_provenance(
             event_payload=event_payload,
         )
     ]
-    assert responses == [ActionResponse(correlation_id="action-1", ok=True)]
+    assert responses[-1] == ActionResponse(correlation_id="action-1", ok=True)
 
     await supervisor._handle_message(
         record,

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "packages/runtime-astrbot" }
 dependencies = [
     { name = "astrbot" },
@@ -1596,7 +1596,7 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-runtime-mofox"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "packages/runtime-mofox" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Beta1 slice

Close the v4 event-provenance gap for upstream Agent bridge runtimes.

## Contract

- every v4 runtime declared as an agent harness must bind child Actions to an active event delivery
- AstrBot and MoFox forward their current delivery correlation when returning output
- the supervisor derives immutable source provenance before the kernel action boundary runs
- generic and v3 runtime Action behavior remains unchanged

## Release impact

- liteyukibot-v7-runtime-astrbot advances to 0.1.0a4
- liteyukibot-v7-runtime-mofox advances to 0.1.0a4
- both require root liteyukibot-v7 >=7.0.0a15

## Verification

- full ruff and strict mypy
- full pytest: 426 passed
- all workspace wheels built
- exact AstrBot and MoFox release identities validated