### PR TITLE
fix(astrbot): restore child logging after startup

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -52,7 +52,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
 | `liteyukibot-v7-agent==0.1.0a5` | `packages/agent` | `agent-v0.1.0a5` |
-| `liteyukibot-v7-runtime-astrbot==0.1.0a4` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a4` |
+| `liteyukibot-v7-runtime-astrbot==0.1.0a5` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a5` |
 | `liteyukibot-v7-runtime-mofox==0.1.0a4` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a4` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a

--- a/packages/runtime-astrbot/pyproject.toml
+++ b/packages/runtime-astrbot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Headless AstrBot agent runtime for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
@@ -7,11 +7,12 @@ import os
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import suppress
 from importlib import import_module
+from inspect import isawaitable
 from pathlib import Path
 from typing import Any
 
 from liteyukibot.events import EventEnvelope
-from liteyukibot.logging import configure_runtime_child_logging, get_logger
+from liteyukibot.logging import configure_runtime_child_logging, get_logger, shutdown_logging
 from liteyukibot.runtime import RuntimeClient
 from liteyukibot.runtime.projection import project_managed_plugins
 from liteyukibot.runtime.protocol import (
@@ -90,13 +91,14 @@ class AstrBotHeadlessEngine:
 
         broker = log_broker_type()
         bridge = AstrBotLogBridge(broker, self._logger)
-        bridge.start(astrbot_core.LogManager, astrbot_core.logger)
         lifecycle = lifecycle_type(broker, database_type(str(root / "astrbot.db")))
         try:
             await lifecycle.initialize()
         except BaseException:
             await bridge.close()
             raise
+        _restore_child_logging()
+        bridge.start(astrbot_core.LogManager, astrbot_core.logger)
         self._lifecycle = lifecycle
         self._schedulers = lifecycle.pipeline_scheduler_mapping
         self._log_bridge = bridge
@@ -118,8 +120,11 @@ class AstrBotHeadlessEngine:
             if lifecycle is not None:
                 await lifecycle.stop()
         finally:
-            if bridge is not None:
-                await bridge.close()
+            try:
+                if bridge is not None:
+                    await bridge.close()
+            finally:
+                await _dispose_astrbot_global_database(self._logger)
 
     def _scheduler(self) -> Any:
         requested = self.options.get("scheduler_id")
@@ -146,6 +151,26 @@ def _prepare_managed_plugins(root: Path, options: Mapping[str, object]) -> None:
         root / "managed-plugin-backups",
         mode=mode,
     )
+
+
+def _restore_child_logging() -> None:
+    """AstrBot replaces global Loguru sinks during initialization."""
+
+    shutdown_logging()
+    configure_runtime_child_logging()
+
+
+async def _dispose_astrbot_global_database(logger: Any) -> None:
+    """Release AstrBot's import-time database engine, separate from our lifecycle DB."""
+
+    try:
+        database = import_module("astrbot.core").db_helper
+        dispose = database.engine.dispose
+        result = dispose()
+        if isawaitable(result):
+            await result
+    except Exception as error:
+        logger.warning("AstrBot global database cleanup failed: {}", error)
 
 
 class AstrBotRuntimeHost:

--- a/packages/runtime-astrbot/tests/test_translate.py
+++ b/packages/runtime-astrbot/tests/test_translate.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 
 import pytest
-from liteyukibot_runtime_astrbot.host import AstrBotLogBridge, AstrBotRuntimeHost
+from liteyukibot_runtime_astrbot.host import (
+    AstrBotHeadlessEngine,
+    AstrBotLogBridge,
+    AstrBotRuntimeHost,
+    _dispose_astrbot_global_database,
+    _restore_child_logging,
+)
 from liteyukibot_runtime_astrbot.translate import to_astr_event_input, to_send_action
 
 from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope, Message, Segment, SendMessage
@@ -112,6 +119,22 @@ class FakeLogManager:
         self.calls.append((logger, broker))
 
 
+class FakeEngineLifecycle:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class RecordingCleanupLogger:
+    def __init__(self) -> None:
+        self.warnings: list[tuple[str, object]] = []
+
+    def warning(self, message: str, error: object) -> None:
+        self.warnings.append((message, error))
+
+
 @pytest.mark.asyncio
 async def test_astrbot_host_returns_pipeline_output_to_the_source_runtime() -> None:
     client = FakeClient()
@@ -145,3 +168,52 @@ async def test_astrbot_log_bridge_forwards_public_broker_records() -> None:
     assert manager.calls == [("astrbot", broker)]
     assert logger.records == [({"upstream": "astrbot", "upstream_category": "plugin"}, "WARNING", "upstream warning")]
     assert broker.unregistered is True
+
+
+def test_astrbot_restores_child_logging_after_upstream_initialization(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: list[str] = []
+    monkeypatch.setattr("liteyukibot_runtime_astrbot.host.shutdown_logging", lambda: observed.append("shutdown"))
+    monkeypatch.setattr(
+        "liteyukibot_runtime_astrbot.host.configure_runtime_child_logging",
+        lambda: observed.append("configure"),
+    )
+
+    _restore_child_logging()
+
+    assert observed == ["shutdown", "configure"]
+
+
+@pytest.mark.asyncio
+async def test_astrbot_engine_close_releases_global_database_after_lifecycle_stop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    observed: list[str] = []
+    lifecycle = FakeEngineLifecycle()
+    engine = AstrBotHeadlessEngine(tmp_path, {}, RecordingCleanupLogger())
+    engine._lifecycle = lifecycle
+    async def dispose(_logger: object) -> None:
+        observed.append("dispose")
+
+    monkeypatch.setattr("liteyukibot_runtime_astrbot.host._dispose_astrbot_global_database", dispose)
+
+    await engine.close()
+
+    assert lifecycle.stopped is True
+    assert observed == ["dispose"]
+
+
+@pytest.mark.asyncio
+async def test_astrbot_global_database_cleanup_absorbs_upstream_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    logger = RecordingCleanupLogger()
+
+    def unavailable(_name: str) -> object:
+        raise RuntimeError("not installed")
+
+    monkeypatch.setattr("liteyukibot_runtime_astrbot.host.import_module", unavailable)
+    await _dispose_astrbot_global_database(logger)
+
+    assert len(logger.warnings) == 1
+    message, error = logger.warnings[0]
+    assert message == "AstrBot global database cleanup failed: {}"
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "not installed"

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -38,7 +38,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
         ("agent", "agent-v0.1.0a5"),
-        ("runtime-astrbot", "runtime-astrbot-v0.1.0a4"),
+        ("runtime-astrbot", "runtime-astrbot-v0.1.0a5"),
         ("runtime-mofox", "runtime-mofox-v0.1.0a4"),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a4"
+version = "0.1.0a5"
 source = { editable = "packages/runtime-astrbot" }
 dependencies = [
     { name = "astrbot" },


### PR DESCRIPTION
## Beta1 slice

Repair the real AstrBot headless lifecycle discovered during locked upstream smoke testing.

## Contract

- AstrBot may replace global Loguru sinks during initialize; the bridge restores child Yukilog before forwarding broker records
- shutdown disposes AstrBot import-time global SQLite engine as well as the lifecycle database
- Windows runtime state can be released after a successful upstream stop

## Release impact

- liteyukibot-v7-runtime-astrbot advances to 0.1.0a5

## Verification

- ruff and strict mypy
- AstrBot runtime and release tests: 35 passed
- runtime wheel built
- exact release identity validated
- real locked AstrBot 4.27.2 start-to-scheduler-to-stop smoke passed without provider, platform adapter, or dashboard