### PR TITLE
test(runtime): verify bridge wheels against upstream

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -52,8 +52,8 @@ distribution inside the workflow.
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
 | `liteyukibot-v7-agent==0.1.0a5` | `packages/agent` | `agent-v0.1.0a5` |
-| `liteyukibot-v7-runtime-astrbot==0.1.0a5` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a5` |
-| `liteyukibot-v7-runtime-mofox==0.1.0a4` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a4` |
+| `liteyukibot-v7-runtime-astrbot==0.1.0a6` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a6` |
+| `liteyukibot-v7-runtime-mofox==0.1.0a5` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a5` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
 tag that does not exactly match the selected source version and distribution.

--- a/packages/runtime-astrbot/pyproject.toml
+++ b/packages/runtime-astrbot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a5"
+version = "0.1.0a6"
 description = "Headless AstrBot agent runtime for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "liteyukibot-v7>=7.0.0a15,<8",
-    "AstrBot>=4.27.2,<5",
+    "AstrBot==4.27.2",
 ]
 
 [project.entry-points."liteyukibot.runtimes"]

--- a/packages/runtime-mofox/pyproject.toml
+++ b/packages/runtime-mofox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-mofox"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Headless Neo-MoFox agent runtime for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/runtime-mofox/src/liteyukibot_runtime_mofox/host.py
+++ b/packages/runtime-mofox/src/liteyukibot_runtime_mofox/host.py
@@ -67,25 +67,31 @@ class MoFoxHeadlessEngine:
         self.state_directory = state_directory
         self.options = options
         self._bot: Any | None = None
+        self._previous_cwd: Path | None = None
         self._sink: ContextVar[TextSink | None] = ContextVar("liteyuki_mofox_sink", default=None)
 
     async def start(self) -> None:
         root = self.state_directory / "mofox"
         root.mkdir(parents=True, exist_ok=True)
-        os.chdir(root)
-        _enforce_headless_config(root / "config" / "core.toml")
-        _prepare_managed_plugins(root, self.options)
-        _install_upstream_namespace()
-        bot_type = import_module("src.app.runtime.bot").Bot
-        bot = bot_type(config_path="config/core.toml", plugins_dir="plugins", log_dir="logs")
-        await bot.initialize()
-        if bot.scheduler is None:
-            raise RuntimeError("Neo-MoFox headless lifecycle did not create a scheduler")
-        await bot.scheduler.start()
-        bot._running = True
-        sender_module = import_module("src.core.transport.message_send")
-        sender_module.set_message_sender(_HeadlessMessageSender(self._sink))
-        self._bot = bot
+        self._previous_cwd = Path.cwd()
+        try:
+            os.chdir(root)
+            _enforce_headless_config(root / "config" / "core.toml")
+            _prepare_managed_plugins(root, self.options)
+            _install_upstream_namespace()
+            bot_type = import_module("src.app.runtime.bot").Bot
+            bot = bot_type(config_path="config/core.toml", plugins_dir="plugins", log_dir="logs")
+            await bot.initialize()
+            if bot.scheduler is None:
+                raise RuntimeError("Neo-MoFox headless lifecycle did not create a scheduler")
+            await bot.scheduler.start()
+            bot._running = True
+            sender_module = import_module("src.core.transport.message_send")
+            sender_module.set_message_sender(_HeadlessMessageSender(self._sink))
+            self._bot = bot
+        except BaseException:
+            self._restore_working_directory()
+            raise
 
     async def process(self, event: EventEnvelope, sink: TextSink) -> None:
         bot = self._bot
@@ -103,8 +109,16 @@ class MoFoxHeadlessEngine:
 
     async def close(self) -> None:
         bot, self._bot = self._bot, None
-        if bot is not None:
-            await bot.shutdown()
+        try:
+            if bot is not None:
+                await bot.shutdown()
+        finally:
+            self._restore_working_directory()
+
+    def _restore_working_directory(self) -> None:
+        previous, self._previous_cwd = self._previous_cwd, None
+        if previous is not None:
+            os.chdir(previous)
 
 
 class MoFoxRuntimeHost:

--- a/packages/runtime-mofox/tests/test_mofox_runtime.py
+++ b/packages/runtime-mofox/tests/test_mofox_runtime.py
@@ -7,7 +7,12 @@ from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
 import pytest
-from liteyukibot_runtime_mofox.host import MoFoxRuntimeHost, _enforce_headless_config, _install_upstream_namespace
+from liteyukibot_runtime_mofox.host import (
+    MoFoxHeadlessEngine,
+    MoFoxRuntimeHost,
+    _enforce_headless_config,
+    _install_upstream_namespace,
+)
 from liteyukibot_runtime_mofox.translate import to_mofox_envelope, to_mofox_event_input, to_send_action
 
 from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope, Message, Segment, SendMessage
@@ -73,6 +78,17 @@ def test_mofox_reports_the_pinned_upstream_requirement_when_missing(monkeypatch:
 
     with pytest.raises(RuntimeError, match="e2ee2ff73b494428bbdfd983c7569c6f074a9c76"):
         _install_upstream_namespace()
+
+
+def test_mofox_engine_restores_working_directory() -> None:
+    engine = MoFoxHeadlessEngine(Path("state"), {})
+    original = Path.cwd()
+    engine._previous_cwd = original
+
+    engine._restore_working_directory()
+
+    assert Path.cwd() == original
+    assert engine._previous_cwd is None
 
 
 class FakeClient:

--- a/scripts/verify_astrbot_runtime_install.py
+++ b/scripts/verify_astrbot_runtime_install.py
@@ -3,16 +3,38 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import importlib.metadata
 import json
+import tempfile
 from pathlib import Path
 
 import liteyukibot_runtime_astrbot
+from liteyukibot_runtime_astrbot.host import AstrBotHeadlessEngine
 
 import liteyukibot
+from liteyukibot.logging import configure_runtime_child_logging, get_logger, shutdown_logging
 from liteyukibot.runtime import RuntimeCatalog
 
 SOURCE_ROOT = Path(__file__).resolve().parents[1]
+ASTRBOT_VERSION = "4.27.2"
+
+
+async def _verify_lifecycle() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        configure_runtime_child_logging()
+        engine = AstrBotHeadlessEngine(
+            Path(directory),
+            {},
+            get_logger(component="install-verify", runtime="astrbot"),
+        )
+        try:
+            await engine.start()
+            if not engine._schedulers:
+                raise RuntimeError("installed AstrBot runtime did not create a PipelineScheduler")
+        finally:
+            await engine.close()
+            shutdown_logging()
 
 
 def verify(expected_version: str | None = None) -> None:
@@ -26,8 +48,11 @@ def verify(expected_version: str | None = None) -> None:
         name: importlib.metadata.version(name)
         for name in ("liteyukibot-v7", "liteyukibot-v7-runtime-astrbot", "AstrBot")
     }
+    if observed["AstrBot"] != ASTRBOT_VERSION:
+        raise RuntimeError(f"expected AstrBot {ASTRBOT_VERSION}; observed {observed['AstrBot']}")
     if expected_version is not None and observed["liteyukibot-v7-runtime-astrbot"] != expected_version:
         raise RuntimeError(f"expected liteyukibot-v7-runtime-astrbot {expected_version}; observed {observed}")
+    asyncio.run(_verify_lifecycle())
     print(json.dumps(observed, sort_keys=True))
 
 

--- a/scripts/verify_mofox_runtime_install.py
+++ b/scripts/verify_mofox_runtime_install.py
@@ -3,16 +3,47 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import importlib.metadata
 import json
+import tempfile
 from pathlib import Path
 
 import liteyukibot_runtime_mofox
+from liteyukibot_runtime_mofox.host import MoFoxHeadlessEngine
 
 import liteyukibot
 from liteyukibot.runtime import RuntimeCatalog
 
 SOURCE_ROOT = Path(__file__).resolve().parents[1]
+NEO_MOFOX_COMMIT = "e2ee2ff73b494428bbdfd983c7569c6f074a9c76"
+
+
+def _verify_locked_upstream() -> str:
+    distribution = importlib.metadata.distribution("neo-mofox")
+    source = distribution.read_text("direct_url.json")
+    if source is None:
+        raise RuntimeError("neo-mofox installation does not record its locked source commit")
+    document = json.loads(source)
+    vcs = document.get("vcs_info")
+    commit = vcs.get("commit_id") if isinstance(vcs, dict) else None
+    if commit != NEO_MOFOX_COMMIT:
+        raise RuntimeError(f"expected neo-mofox commit {NEO_MOFOX_COMMIT}; observed {commit!r}")
+    return distribution.version
+
+
+async def _verify_lifecycle() -> None:
+    original_cwd = Path.cwd()
+    with tempfile.TemporaryDirectory() as directory:
+        engine = MoFoxHeadlessEngine(Path(directory), {})
+        try:
+            await engine.start()
+            if engine._bot is None or engine._bot.scheduler is None:
+                raise RuntimeError("installed MoFox runtime did not create a scheduler")
+        finally:
+            await engine.close()
+    if Path.cwd() != original_cwd:
+        raise RuntimeError("installed MoFox runtime did not restore the working directory after shutdown")
 
 
 def verify(expected_version: str | None = None) -> None:
@@ -22,16 +53,11 @@ def verify(expected_version: str | None = None) -> None:
     plugin = RuntimeCatalog().discover().get("mofox")
     if plugin is None or plugin.agent_harness != "mofox":
         raise RuntimeError("MoFox runtime entry point was not discovered")
-    observed = {
-        name: importlib.metadata.version(name)
-        for name in ("liteyukibot-v7", "liteyukibot-v7-runtime-mofox")
-    }
-    try:
-        observed["neo-mofox"] = importlib.metadata.version("neo-mofox")
-    except importlib.metadata.PackageNotFoundError:
-        pass
+    observed = {name: importlib.metadata.version(name) for name in ("liteyukibot-v7", "liteyukibot-v7-runtime-mofox")}
+    observed["neo-mofox"] = _verify_locked_upstream()
     if expected_version is not None and observed["liteyukibot-v7-runtime-mofox"] != expected_version:
         raise RuntimeError(f"expected liteyukibot-v7-runtime-mofox {expected_version}; observed {observed}")
+    asyncio.run(_verify_lifecycle())
     print(json.dumps(observed, sort_keys=True))
 
 

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -38,8 +38,8 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
         ("agent", "agent-v0.1.0a5"),
-        ("runtime-astrbot", "runtime-astrbot-v0.1.0a5"),
-        ("runtime-mofox", "runtime-mofox-v0.1.0a4"),
+        ("runtime-astrbot", "runtime-astrbot-v0.1.0a6"),
+        ("runtime-mofox", "runtime-mofox-v0.1.0a5"),
     ],
 )
 def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1581,7 +1581,7 @@ requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a5"
+version = "0.1.0a6"
 source = { editable = "packages/runtime-astrbot" }
 dependencies = [
     { name = "astrbot" },
@@ -1590,13 +1590,13 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "astrbot", specifier = ">=4.27.2,<5" },
+    { name = "astrbot", specifier = "==4.27.2" },
     { name = "liteyukibot-v7", editable = "." },
 ]
 
 [[package]]
 name = "liteyukibot-v7-runtime-mofox"
-version = "0.1.0a4"
+version = "0.1.0a5"
 source = { editable = "packages/runtime-mofox" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Beta1 slice

Validates the two agent bridge runtimes as installed wheels against their locked upstream dependencies.

- pins AstrBot to the validated `4.27.2` release and starts, verifies, and stops its real scheduler lifecycle from an isolated wheel environment;
- verifies Neo-MoFox provenance from installed `direct_url.json`, requires the pinned Git commit, and executes its real lifecycle from isolated wheels;
- restores the caller working directory after the Neo-MoFox upstream startup path changes it;
- updates bridge runtime prerelease identities to AstrBot `0.1.0a6` and MoFox `0.1.0a5`.

## Verification

- `uv run ruff check src tests scripts packages`
- `uv run mypy`
- `uv run pytest` (`430 passed`)
- `uv build --all-packages --out-dir dist/workspace --clear`
- release identity checks for `runtime-astrbot-v0.1.0a6` and `runtime-mofox-v0.1.0a5`
- isolated installed-wheel AstrBot and Neo-MoFox lifecycle verifiers