### PR TITLE
feat(permissions): record privileged policy decisions

### DIFF
--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -157,6 +157,14 @@ source Event for native handler results and v4 child provenance; a direct
 action call without one is denied. `SendMessage` remains protocol-neutral and
 uses its existing event/runtime/bot routing checks.
 
+The kernel registry currently declares the ownership and stable purpose of
+`liteyukibot.adapter.call_api`; third-party packages retain their own capability
+names. Privileged boundaries use `decide(event, capability, component=...)`
+when available. The first-party policy service retains a bounded redacted audit
+record with capability, principal tuple, component, event ID, outcome, and
+reason only. It intentionally never records message content, API parameters,
+tool arguments, or secrets.
+
 ## Commands
 
 The first-party `liteyukibot-v7-commands` package provides

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -41,7 +41,7 @@ distribution inside the workflow.
 | Package | Source | Tag |
 | --- | --- | --- |
 | `liteyukibot-v7==7.0.0a15` | `pyproject.toml` | `v7.0.0a15` |
-| `liteyukibot-v7-permissions==0.2.0a1` | `packages/permissions` | `permissions-v0.2.0a1` |
+| `liteyukibot-v7-permissions==0.2.0a2` | `packages/permissions` | `permissions-v0.2.0a2` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |
 | `liteyukibot-v7-functions==0.1.0a2` | `packages/functions` | `functions-v0.1.0a2` |
@@ -51,7 +51,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-runtime-adapter==0.1.0a2` | `packages/runtime-adapter` | `runtime-adapter-v0.1.0a2` |
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
-| `liteyukibot-v7-agent==0.1.0a5` | `packages/agent` | `agent-v0.1.0a5` |
+| `liteyukibot-v7-agent==0.1.0a6` | `packages/agent` | `agent-v0.1.0a6` |
 | `liteyukibot-v7-runtime-astrbot==0.1.0a6` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a6` |
 | `liteyukibot-v7-runtime-mofox==0.1.0a5` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a5` |
 
@@ -63,7 +63,7 @@ tag that does not exactly match the selected source version and distribution.
 Push and wait for each release before creating the next tag:
 
 1. `v7.0.0a15`;
-2. `permissions-v0.2.0a1`;
+2. `permissions-v0.2.0a2`;
 3. `commands-v0.2.0a2`;
 4. `resources-v0.1.0a2`;
 5. `functions-v0.1.0a2`;
@@ -73,7 +73,7 @@ Push and wait for each release before creating the next tag:
 9. `runtime-adapter-v0.1.0a2`.
 10. `adapter-onebot-v0.1.0a1`.
 11. `runtime-v6-v0.1.0a1`.
-12. `agent-v0.1.0a5`.
+12. `agent-v0.1.0a6`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/packages/agent/pyproject.toml
+++ b/packages/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a5"
+version = "0.1.0a6"
 description = "Native OpenAI-compatible agent harness for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/agent/src/liteyukibot_agent/__init__.py
+++ b/packages/agent/src/liteyukibot_agent/__init__.py
@@ -54,7 +54,7 @@ def runtime_plugin() -> RuntimePlugin:
 try:
     __version__ = version("liteyukibot-v7-agent")
 except PackageNotFoundError:
-    __version__ = "0.1.0a5"
+    __version__ = "0.1.0a6"
 
 plugin: PluginDefinition = create_plugin(__version__)
 

--- a/packages/agent/src/liteyukibot_agent/broker.py
+++ b/packages/agent/src/liteyukibot_agent/broker.py
@@ -49,7 +49,7 @@ class ToolBroker:
         tool = self._tools.get(tool_id)
         if tool is None:
             return AgentToolResult(ok=False, error="agent tool is not registered")
-        if not self._allowed(event, tool):
+        if not self._allowed(event, tool, audit=True):
             return AgentToolResult(ok=False, error="agent tool permission is denied")
         try:
             result = await tool.handler(event, arguments)
@@ -91,11 +91,20 @@ class ToolBroker:
             ]
         }
 
-    def _allowed(self, event: EventEnvelope, tool: AgentTool) -> bool:
-        return not tool.required_capabilities or (
-            self._permissions is not None
-            and all(self._permissions.allows(event, capability) for capability in tool.required_capabilities)
-        )
+    def _allowed(self, event: EventEnvelope, tool: AgentTool, *, audit: bool = False) -> bool:
+        if not tool.required_capabilities:
+            return True
+        if self._permissions is None:
+            return False
+        for capability in tool.required_capabilities:
+            decide = getattr(self._permissions, "decide", None)
+            if audit and callable(decide):
+                allowed = decide(event, capability, component="agent.tool")
+            else:
+                allowed = self._permissions.allows(event, capability)
+            if not allowed:
+                return False
+        return True
 
 
 def permission_checker(service: object | None) -> PermissionChecker | None:

--- a/packages/agent/tests/test_broker.py
+++ b/packages/agent/tests/test_broker.py
@@ -12,8 +12,13 @@ from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope
 class FakePermissions:
     def __init__(self, allowed: set[str]) -> None:
         self.allowed = allowed
+        self.decisions: list[tuple[str, str]] = []
 
     def allows(self, _event: EventEnvelope, capability: str) -> bool:
+        return capability in self.allowed
+
+    def decide(self, _event: EventEnvelope, capability: str, *, component: str) -> bool:
+        self.decisions.append((capability, component))
         return capability in self.allowed
 
 
@@ -71,8 +76,10 @@ async def test_broker_catalog_for_exposes_only_tools_authorized_for_the_event() 
         required_capabilities=frozenset({"admin.reset"}),
     )
     event = _event()
-    denied = ToolBroker({public.id: public, protected.id: protected}, FakePermissions(set()))
-    allowed = ToolBroker({public.id: public, protected.id: protected}, FakePermissions({"admin.reset"}))
+    denied_permissions = FakePermissions(set())
+    allowed_permissions = FakePermissions({"admin.reset"})
+    denied = ToolBroker({public.id: public, protected.id: protected}, denied_permissions)
+    allowed = ToolBroker({public.id: public, protected.id: protected}, allowed_permissions)
 
     denied_tools = denied.catalog_for(event)["tools"]
     allowed_tools = allowed.catalog_for(event)["tools"]
@@ -85,3 +92,5 @@ async def test_broker_catalog_for_exposes_only_tools_authorized_for_the_event() 
     ]
     assert (await denied.execute(event, "admin.reset", {})).error == "agent tool permission is denied"
     assert (await allowed.execute(event, "admin.reset", {})).ok is True
+    assert denied_permissions.decisions == [("admin.reset", "agent.tool")]
+    assert allowed_permissions.decisions == [("admin.reset", "agent.tool")]

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -27,3 +27,9 @@ Consumers declare `ServiceRequirement(PERMISSION_SERVICE)` and resolve a
 performs an exact, fail-closed check. `resolve(event)` returns a frozen snapshot
 for diagnostics. Every event has `public`; plugins check capabilities rather
 than deployment role names.
+
+Privileged boundaries call `decide(event, capability, component=...)` instead.
+It has the same exact policy outcome and keeps a bounded in-memory audit
+snapshot available through `audit()`. Each record contains only the capability,
+principal tuple, component, event ID, allow/deny outcome, and stable reason;
+message content, API parameters, and tool arguments are never captured.

--- a/packages/permissions/pyproject.toml
+++ b/packages/permissions/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-permissions"
-version = "0.2.0a1"
+version = "0.2.0a2"
 description = "Versioned access policy service for LiteyukiBot v7 native plugins."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/permissions/src/liteyukibot_permissions/__init__.py
+++ b/packages/permissions/src/liteyukibot_permissions/__init__.py
@@ -3,18 +3,28 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .plugin import create_plugin
-from .service import PERMISSION_SERVICE, PUBLIC, PermissionService, PermissionSnapshot, Principal
+from .service import (
+    PERMISSION_SERVICE,
+    PUBLIC,
+    PermissionAuditService,
+    PermissionDecision,
+    PermissionService,
+    PermissionSnapshot,
+    Principal,
+)
 
 try:
     __version__ = version("liteyukibot-v7-permissions")
 except PackageNotFoundError:
-    __version__ = "0.2.0a1"
+    __version__ = "0.2.0a2"
 
 plugin = create_plugin(__version__)
 
 __all__ = [
     "PERMISSION_SERVICE",
     "PUBLIC",
+    "PermissionAuditService",
+    "PermissionDecision",
     "PermissionService",
     "PermissionSnapshot",
     "Principal",

--- a/packages/permissions/src/liteyukibot_permissions/plugin.py
+++ b/packages/permissions/src/liteyukibot_permissions/plugin.py
@@ -8,7 +8,7 @@ from .service import PERMISSION_SERVICE, create_permission_service
 
 
 async def setup(context: PluginContext) -> None:
-    service = create_permission_service(context.config)
+    service = create_permission_service(context.config, logger=context.logger)
     context.services.provide(PERMISSION_SERVICE, service)
 
 

--- a/packages/permissions/src/liteyukibot_permissions/service.py
+++ b/packages/permissions/src/liteyukibot_permissions/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -61,6 +62,18 @@ class PermissionSnapshot:
         return capability in self.capabilities
 
 
+@dataclass(frozen=True, slots=True)
+class PermissionDecision:
+    """A redacted, immutable record of one privileged policy decision."""
+
+    capability: str
+    principal: Principal | None
+    component: str
+    event_id: str
+    allowed: bool
+    reason: str
+
+
 class PermissionService(Protocol):
     def principal(self, event: EventEnvelope) -> Principal | None: ...
 
@@ -69,10 +82,31 @@ class PermissionService(Protocol):
     def allows(self, event: EventEnvelope, capability: str) -> bool: ...
 
 
+class PermissionAuditService(PermissionService, Protocol):
+    def decide(self, event: EventEnvelope, capability: str, *, component: str) -> bool: ...
+
+    def audit(self, *, limit: int | None = None) -> tuple[PermissionDecision, ...]: ...
+
+
+class PermissionLogger(Protocol):
+    def bind(self, **fields: object) -> PermissionLogger: ...
+
+    def info(self, message: str, *args: object, **kwargs: object) -> None: ...
+
+
 class _ConfiguredPermissionService:
-    def __init__(self, snapshots: Mapping[Principal, PermissionSnapshot]) -> None:
+    AUDIT_CAPACITY = 256
+
+    def __init__(
+        self,
+        snapshots: Mapping[Principal, PermissionSnapshot],
+        *,
+        logger: PermissionLogger | None = None,
+    ) -> None:
         self._snapshots = dict(snapshots)
         self._anonymous = PermissionSnapshot(None, frozenset(), frozenset({PUBLIC}))
+        self._logger = logger
+        self._audit: deque[PermissionDecision] = deque(maxlen=self.AUDIT_CAPACITY)
 
     def principal(self, event: EventEnvelope) -> Principal | None:
         if event.actor is None:
@@ -98,6 +132,55 @@ class _ConfiguredPermissionService:
         if not capability or capability != capability.strip() or any(character.isspace() for character in capability):
             return False
         return self.resolve(event).allows(capability)
+
+    def decide(self, event: EventEnvelope, capability: str, *, component: str) -> bool:
+        """Evaluate and retain a redacted audit record for a privileged boundary."""
+
+        component = _validate_token("decision component", component)
+        principal = self.principal(event)
+        if not isinstance(capability, str) or not capability or capability != capability.strip() or any(
+            character.isspace() for character in capability
+        ):
+            allowed = False
+            reason = "invalid_capability"
+        else:
+            allowed = self.resolve(event).allows(capability)
+            reason = "granted" if allowed else "not_granted"
+        decision = PermissionDecision(
+            capability=capability if isinstance(capability, str) else repr(capability),
+            principal=principal,
+            component=component,
+            event_id=event.id,
+            allowed=allowed,
+            reason=reason,
+        )
+        self._audit.append(decision)
+        if self._logger is not None:
+            fields: dict[str, object] = {
+                "permission_component": component,
+                "capability": decision.capability,
+                "event_id": event.id,
+                "allowed": allowed,
+                "reason": reason,
+            }
+            if principal is not None:
+                fields.update(
+                    runtime=principal.runtime_id,
+                    bot_id=principal.bot_id,
+                    actor_id=principal.actor_id,
+                )
+            self._logger.bind(**fields).info("permission decision {}", "granted" if allowed else "denied")
+        return allowed
+
+    def audit(self, *, limit: int | None = None) -> tuple[PermissionDecision, ...]:
+        """Return newest redacted decisions, without exposing message or tool payloads."""
+
+        if limit is not None and (not isinstance(limit, int) or isinstance(limit, bool) or limit < 0):
+            raise ValueError("audit limit must be a non-negative integer")
+        decisions = tuple(self._audit)
+        if limit is None:
+            return decisions
+        return () if limit == 0 else decisions[-limit:]
 
 
 def _parse_token_sequence(value: object, *, location: str, kind: str) -> tuple[str, ...]:
@@ -203,7 +286,9 @@ def _parse_grants(
     return snapshots
 
 
-def create_permission_service(config: Mapping[str, Any]) -> PermissionService:
+def create_permission_service(
+    config: Mapping[str, Any], *, logger: PermissionLogger | None = None
+) -> PermissionAuditService:
     if not all(isinstance(key, str) for key in config):
         raise TypeError("permission config keys must be strings")
     unknown = set(config) - {"roles", "grants"}
@@ -211,12 +296,15 @@ def create_permission_service(config: Mapping[str, Any]) -> PermissionService:
         raise ValueError(f"unknown permission config keys: {', '.join(sorted(unknown))}")
     roles = _parse_roles(config.get("roles", {}))
     snapshots = _parse_grants(config.get("grants", ()), roles)
-    return _ConfiguredPermissionService(snapshots)
+    return _ConfiguredPermissionService(snapshots, logger=logger)
 
 
 __all__ = [
     "PERMISSION_SERVICE",
     "PUBLIC",
+    "PermissionDecision",
+    "PermissionAuditService",
+    "PermissionLogger",
     "PermissionService",
     "PermissionSnapshot",
     "Principal",

--- a/packages/permissions/tests/test_permissions.py
+++ b/packages/permissions/tests/test_permissions.py
@@ -7,6 +7,8 @@ import pytest
 from liteyukibot_permissions import (
     PERMISSION_SERVICE,
     PUBLIC,
+    PermissionAuditService,
+    PermissionDecision,
     PermissionService,
     PermissionSnapshot,
     Principal,
@@ -93,6 +95,41 @@ async def test_permission_service_isolates_principals_and_anonymous_events(tmp_p
         assert anonymous.capabilities == frozenset({PUBLIC})
         assert service.allows(event(actor_id=None), PUBLIC) is True
         assert service.allows(event(actor_id=None), STATUS_READ) is False
+
+
+@pytest.mark.asyncio
+async def test_permission_service_records_redacted_bounded_decisions(tmp_path: Path) -> None:
+    async with PluginTestHarness(plugin, root=tmp_path, config=permission_config()) as harness:
+        service = cast(PermissionAuditService, harness.require_service(PERMISSION_SERVICE))
+        allowed_event = event()
+        denied_event = event(actor_id="other")
+
+        assert service.decide(allowed_event, STATUS_READ, component="commands.status") is True
+        assert service.decide(denied_event, STATUS_READ, component="commands.status") is False
+        decisions = service.audit()
+
+    assert decisions == (
+        PermissionDecision(
+            capability=STATUS_READ,
+            principal=Principal("nonebot", "bot-1", "user-1"),
+            component="commands.status",
+            event_id=allowed_event.id,
+            allowed=True,
+            reason="granted",
+        ),
+        PermissionDecision(
+            capability=STATUS_READ,
+            principal=Principal("nonebot", "bot-1", "other"),
+            component="commands.status",
+            event_id=denied_event.id,
+            allowed=False,
+            reason="not_granted",
+        ),
+    )
+    assert service.audit(limit=1) == decisions[-1:]
+    assert service.audit(limit=0) == ()
+    with pytest.raises(ValueError, match="non-negative"):
+        service.audit(limit=-1)
 
 
 @pytest.mark.asyncio
@@ -237,5 +274,5 @@ def test_permission_snapshot_requires_public_capability() -> None:
 
 def test_permission_plugin_manifest_publishes_versioned_service() -> None:
     assert plugin.manifest.id == "liteyukibot.permissions"
-    assert plugin.manifest.version == "0.2.0a1"
+    assert plugin.manifest.version == "0.2.0a2"
     assert plugin.manifest.provides == (PERMISSION_SERVICE,)

--- a/scripts/verify_permissions_install.py
+++ b/scripts/verify_permissions_install.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import cast
 
 import liteyukibot_permissions
-from liteyukibot_permissions import PERMISSION_SERVICE, PermissionService
+from liteyukibot_permissions import PERMISSION_SERVICE, PermissionAuditService
 
 import liteyukibot
 from liteyukibot import PluginDefinition
@@ -70,9 +70,14 @@ async def verify(expected_version: str | None = None) -> None:
     )
     with tempfile.TemporaryDirectory() as directory:
         async with PluginTestHarness(definition, root=Path(directory), config=config) as harness:
-            service = cast(PermissionService, harness.require_service(PERMISSION_SERVICE))
+            service = cast(PermissionAuditService, harness.require_service(PERMISSION_SERVICE))
             if not service.allows(event, capability):
                 raise RuntimeError("installed permission service rejected its configured capability")
+            if not service.decide(event, capability, component="install-verify"):
+                raise RuntimeError("installed permission service denied its configured audit decision")
+            audit = service.audit(limit=1)
+            if len(audit) != 1 or audit[0].component != "install-verify" or not audit[0].allowed:
+                raise RuntimeError("installed permission service did not retain its redacted audit decision")
 
     observed = {
         "liteyukibot-v7": importlib.metadata.version("liteyukibot-v7"),

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -539,15 +539,21 @@ class LiteyukiApp:
                 error_message="adapter API action does not match its source event",
             )
         permissions = self.services.get(_PERMISSION_SERVICE)
+        decide = getattr(permissions, "decide", None)
         allows = getattr(permissions, "allows", None)
-        allowed = callable(allows) and allows(event, ADAPTER_CALL_API)
-        self.logger.bind(
-            runtime=event.runtime_id,
-            component="permissions",
-            capability=ADAPTER_CALL_API,
-            event_id=event.id,
-            allowed=allowed,
-        ).info("adapter API action permission {}", "granted" if allowed else "denied")
+        allowed = (
+            decide(event, ADAPTER_CALL_API, component="adapter.call_api")
+            if callable(decide)
+            else callable(allows) and allows(event, ADAPTER_CALL_API)
+        )
+        if not callable(decide):
+            self.logger.bind(
+                runtime=event.runtime_id,
+                component="permissions",
+                capability=ADAPTER_CALL_API,
+                event_id=event.id,
+                allowed=allowed,
+            ).info("adapter API action permission {}", "granted" if allowed else "denied")
         if allowed:
             return None
         return ActionResult(

--- a/src/liteyukibot/capabilities.py
+++ b/src/liteyukibot/capabilities.py
@@ -1,7 +1,45 @@
 """Kernel-owned capability identifiers for privileged cross-package surfaces."""
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+
 ADAPTER_CALL_API = "liteyukibot.adapter.call_api"
 PERMISSION_SERVICE_NAME = "liteyukibot.permissions"
 PERMISSION_SERVICE_MAJOR = 1
 
-__all__ = ["ADAPTER_CALL_API", "PERMISSION_SERVICE_MAJOR", "PERMISSION_SERVICE_NAME"]
+
+@dataclass(frozen=True, slots=True)
+class CapabilityDefinition:
+    """Stable metadata for a kernel-owned privileged capability."""
+
+    id: str
+    owner: str
+    summary: str
+
+
+KERNEL_CAPABILITIES = (
+    CapabilityDefinition(
+        id=ADAPTER_CALL_API,
+        owner="kernel",
+        summary="Allows a source-bound adapter API action.",
+    ),
+)
+
+_BY_ID = {capability.id: capability for capability in KERNEL_CAPABILITIES}
+
+
+def capability_definition(capability: str) -> CapabilityDefinition | None:
+    """Return metadata for a kernel-owned capability without rejecting extension tokens."""
+
+    return _BY_ID.get(capability)
+
+
+__all__ = [
+    "ADAPTER_CALL_API",
+    "CapabilityDefinition",
+    "KERNEL_CAPABILITIES",
+    "PERMISSION_SERVICE_MAJOR",
+    "PERMISSION_SERVICE_NAME",
+    "capability_definition",
+]

--- a/tests/test_app_v7.py
+++ b/tests/test_app_v7.py
@@ -75,6 +75,16 @@ class PermissionFixture:
         return self.allowed
 
 
+class PermissionAuditFixture(PermissionFixture):
+    def __init__(self, allowed: bool) -> None:
+        super().__init__(allowed)
+        self.decisions: list[tuple[EventEnvelope, str, str]] = []
+
+    def decide(self, event: EventEnvelope, capability: str, *, component: str) -> bool:
+        self.decisions.append((event, capability, component))
+        return self.allowed
+
+
 @pytest.mark.asyncio
 async def test_app_shutdown_cancels_function_background_tasks(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
@@ -430,6 +440,43 @@ async def test_app_call_api_requires_exact_event_capability_before_runtime_execu
     assert allowed.ok is True
     assert permissions.observed == [(source, "liteyukibot.adapter.call_api")]
     assert executed == [action]
+
+
+@pytest.mark.asyncio
+async def test_app_call_api_uses_permission_audit_extension_when_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = AppSettings(core=CoreSettings(data_dir=tmp_path / "data", cache_dir=tmp_path / "cache"))
+    app = LiteyukiApp(settings, logger=FakeLogger())  # type: ignore[arg-type]
+    source = EventEnvelope(
+        id="event-1",
+        runtime_id="adapter",
+        adapter="onebot-v11",
+        bot_id="bot-1",
+        type="message.group.normal",
+        conversation=ConversationRef(id="group-1", type="group"),
+        actor=ActorRef(id="user-1"),
+    )
+    action = ActionEnvelope(
+        action_id="call-1",
+        event_id=source.id,
+        runtime_id=source.runtime_id,
+        bot_id=source.bot_id,
+        action=CallApi(api="get_status"),
+    )
+    permissions = PermissionAuditFixture(allowed=False)
+    app.services.provide(ServiceKey("liteyukibot.permissions", 1), permissions, provider="test")
+
+    async def execute_unexpectedly(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("denied CallApi reached the runtime supervisor")
+
+    monkeypatch.setattr(app.runtimes, "execute_action", execute_unexpectedly)
+    result = await app.actions.execute(action, event=source)
+
+    assert result.success is False
+    assert result.error_code == "ACTION_PERMISSION_DENIED"
+    assert permissions.observed == []
+    assert permissions.decisions == [(source, "liteyukibot.adapter.call_api", "adapter.call_api")]
 
 
 @pytest.mark.asyncio

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,11 @@
+from liteyukibot.capabilities import ADAPTER_CALL_API, KERNEL_CAPABILITIES, capability_definition
+
+
+def test_kernel_capability_registry_exposes_stable_adapter_action_metadata() -> None:
+    definition = capability_definition(ADAPTER_CALL_API)
+
+    assert definition is not None
+    assert definition.id == ADAPTER_CALL_API
+    assert definition.owner == "kernel"
+    assert definition in KERNEL_CAPABILITIES
+    assert capability_definition("example.extension.capability") is None

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -26,7 +26,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
     ("name", "tag"),
     [
         ("root", "v7.0.0a15"),
-        ("permissions", "permissions-v0.2.0a1"),
+        ("permissions", "permissions-v0.2.0a2"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),
         ("functions", "functions-v0.1.0a2"),
@@ -37,7 +37,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("adapter-onebot", "adapter-onebot-v0.1.0a1"),
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
-        ("agent", "agent-v0.1.0a5"),
+        ("agent", "agent-v0.1.0a6"),
         ("runtime-astrbot", "runtime-astrbot-v0.1.0a6"),
         ("runtime-mofox", "runtime-mofox-v0.1.0a5"),
     ],

--- a/uv.lock
+++ b/uv.lock
@@ -1464,7 +1464,7 @@ requires-dist = [{ name = "liteyukibot-v7-runtime-adapter", editable = "packages
 
 [[package]]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a5"
+version = "0.1.0a6"
 source = { editable = "packages/agent" }
 dependencies = [
     { name = "liteyukibot-v7" },
@@ -1527,7 +1527,7 @@ requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-permissions"
-version = "0.2.0a1"
+version = "0.2.0a2"
 source = { editable = "packages/permissions" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Beta1 slice

Adds auditable policy decisions without changing the existing base permission-service contract.

- publishes kernel metadata for its source-bound adapter API capability;
- adds optional `PermissionAuditService` support with a bounded in-memory redacted decision snapshot;
- records Agent tool execution and `CallApi` boundary decisions while preserving older `PermissionService` implementations;
- excludes message content, API parameters, tool arguments, and secrets from audit records and structured logs;
- advances `liteyukibot-v7-permissions` to `0.2.0a2` and `liteyukibot-v7-agent` to `0.1.0a6`.

## Verification

- `uv sync --locked --all-packages --extra onebot --extra satori`
- `uv run ruff check src tests scripts packages`
- `uv run mypy`
- `uv run pytest` (`432 passed`)
- `uv build --all-packages --out-dir dist/workspace --clear`
- release identity checks for `permissions-v0.2.0a2` and `agent-v0.1.0a6`
- isolated installed-wheel verifiers for permissions and Agent