### PR TITLE
feat(agent): bound model and event execution

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -51,7 +51,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-runtime-adapter==0.1.0a2` | `packages/runtime-adapter` | `runtime-adapter-v0.1.0a2` |
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
-| `liteyukibot-v7-agent==0.1.0a6` | `packages/agent` | `agent-v0.1.0a6` |
+| `liteyukibot-v7-agent==0.1.0a7` | `packages/agent` | `agent-v0.1.0a7` |
 | `liteyukibot-v7-runtime-astrbot==0.1.0a6` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a6` |
 | `liteyukibot-v7-runtime-mofox==0.1.0a5` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a5` |
 
@@ -73,7 +73,7 @@ Push and wait for each release before creating the next tag:
 9. `runtime-adapter-v0.1.0a2`.
 10. `adapter-onebot-v0.1.0a1`.
 11. `runtime-v6-v0.1.0a1`.
-12. `agent-v0.1.0a6`.
+12. `agent-v0.1.0a7`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -8,3 +8,9 @@ For each delivered Event, the kernel sends only the tool schemas authorized for
 that event principal. The agent runtime has no executable tool implementation;
 every tool request returns through the kernel broker, which checks the same
 capabilities again before invoking a package-provided handler.
+
+The `agent` runtime options bound each delivered event: `history_limit` defaults
+to 40 messages, `max_concurrent_events` to 16, `max_tool_rounds` to 4,
+`model_timeout_seconds` to 60, and `event_timeout_seconds` to 120. A model or
+event timeout produces a failed terminal delivery without recording model input,
+tool arguments, or response content in logs.

--- a/packages/agent/pyproject.toml
+++ b/packages/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a6"
+version = "0.1.0a7"
 description = "Native OpenAI-compatible agent harness for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/agent/src/liteyukibot_agent/__init__.py
+++ b/packages/agent/src/liteyukibot_agent/__init__.py
@@ -38,6 +38,41 @@ def runtime_plugin() -> RuntimePlugin:
                     description="Optional OpenAI-compatible API endpoint.",
                 ),
                 InitFieldSpec(
+                    key="model_timeout_seconds",
+                    label="Model timeout seconds",
+                    kind=InitFieldKind.INTEGER,
+                    default=60,
+                    description="Maximum duration for one model request.",
+                ),
+                InitFieldSpec(
+                    key="event_timeout_seconds",
+                    label="Event timeout seconds",
+                    kind=InitFieldKind.INTEGER,
+                    default=120,
+                    description="Maximum total duration for one delivered event.",
+                ),
+                InitFieldSpec(
+                    key="max_tool_rounds",
+                    label="Maximum tool rounds",
+                    kind=InitFieldKind.INTEGER,
+                    default=4,
+                    description="Maximum model-to-tool iteration rounds per event.",
+                ),
+                InitFieldSpec(
+                    key="history_limit",
+                    label="History messages",
+                    kind=InitFieldKind.INTEGER,
+                    default=40,
+                    description="Maximum stored conversation messages sent to a model request.",
+                ),
+                InitFieldSpec(
+                    key="max_concurrent_events",
+                    label="Concurrent events",
+                    kind=InitFieldKind.INTEGER,
+                    default=16,
+                    description="Maximum in-flight events handled by this agent runtime.",
+                ),
+                InitFieldSpec(
                     key="api_key_secret",
                     label="API key",
                     label_key="agent.init.api_key",
@@ -54,7 +89,7 @@ def runtime_plugin() -> RuntimePlugin:
 try:
     __version__ = version("liteyukibot-v7-agent")
 except PackageNotFoundError:
-    __version__ = "0.1.0a6"
+    __version__ = "0.1.0a7"
 
 plugin: PluginDefinition = create_plugin(__version__)
 

--- a/packages/agent/src/liteyukibot_agent/host.py
+++ b/packages/agent/src/liteyukibot_agent/host.py
@@ -35,6 +35,9 @@ class NativeAgentHost:
         history_limit: int,
         message_chunk_size: int,
         max_concurrent_events: int,
+        model_timeout_seconds: float = 60.0,
+        event_timeout_seconds: float = 120.0,
+        max_tool_rounds: int = 4,
     ) -> None:
         self.client = client
         self.engine = engine
@@ -42,6 +45,9 @@ class NativeAgentHost:
         self.history_limit = history_limit
         self.message_chunk_size = message_chunk_size
         self.max_concurrent_events = max_concurrent_events
+        self.model_timeout_seconds = model_timeout_seconds
+        self.event_timeout_seconds = event_timeout_seconds
+        self.max_tool_rounds = max_tool_rounds
         self.logger = get_logger(component="agent", runtime=os.environ.get("LITEYUKI_RUNTIME_ID", "agent"))
         self._tasks: set[asyncio.Task[None]] = set()
 
@@ -126,67 +132,88 @@ class NativeAgentHost:
         tools: Sequence[Mapping[str, object]],
     ) -> None:
         try:
-            key = (event.runtime_id, event.bot_id, event.conversation.ordering_key)
-            self.store.append(*key, "user", event.message.plain_text if event.message is not None else "")
-            messages: list[Mapping[str, object]] = [
-                item for item in self.store.messages(*key, limit=self.history_limit)
-            ]
-            reply = await self.engine.complete(messages, tools=tools)
-            for _index in range(4):
-                if not reply.tool_calls:
-                    break
-                messages.append(_assistant_tool_message(reply))
-                for call in reply.tool_calls:
-                    result = await self.client.execute_agent_tool(
-                        f"tool-{uuid4()}",
-                        delivery_correlation_id,
-                        call.tool_id,
-                        call.arguments,
-                    )
-                    messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": call.id,
-                            "content": result.data if result.ok else {"error": result.error or "tool failed"},
-                        }
-                    )
-                reply = await self.engine.complete(messages, tools=tools)
-            if reply.tool_calls:
-                raise RuntimeError("agent exceeded maximum tool-call rounds")
-            if reply.text:
-                self.store.append(*key, "assistant", reply.text)
-                for chunk in _chunks(reply.text, self.message_chunk_size):
-                    action = ActionEnvelope(
-                        event_id=event.id,
-                        runtime_id=event.runtime_id,
-                        bot_id=event.bot_id,
-                        action=SendMessage(
-                            message=Message(segments=(Segment(type="text", data={"text": chunk}),)),
-                            conversation=event.conversation,
-                            reply_token=event.reply_token,
-                        ),
-                    )
-                    response = await self.client.execute_action(
-                        action.action_id,
-                        action.model_dump(mode="json"),
-                        delivery_correlation_id=delivery_correlation_id,
-                    )
-                    if not response.ok:
-                        raise RuntimeError(response.error or "source runtime rejected agent output")
+            async with asyncio.timeout(self.event_timeout_seconds):
+                await self._process_event_body(delivery_correlation_id, event, tools)
         except Exception as error:
+            detail = "agent event timed out" if isinstance(error, TimeoutError) else f"{type(error).__name__}: {error}"
             self.logger.bind(
                 correlation_id=delivery_correlation_id,
                 trace_id=trace.trace_id if trace is not None else None,
-            ).error("native agent event failed: {}", error)
+            ).error("native agent event failed: {}", detail)
             await self.client.send(
                 EventCompleted(
                     correlation_id=delivery_correlation_id,
                     status="failed",
-                    detail=f"{type(error).__name__}: {error}",
+                    detail=detail,
                 )
             )
             raise
         await self.client.send(EventCompleted(correlation_id=delivery_correlation_id, status="completed"))
+
+    async def _process_event_body(
+        self,
+        delivery_correlation_id: str,
+        event: EventEnvelope,
+        tools: Sequence[Mapping[str, object]],
+    ) -> None:
+        key = (event.runtime_id, event.bot_id, event.conversation.ordering_key)
+        self.store.append(*key, "user", event.message.plain_text if event.message is not None else "")
+        messages: list[Mapping[str, object]] = [item for item in self.store.messages(*key, limit=self.history_limit)]
+        reply = await self._complete(messages, tools)
+        for _index in range(self.max_tool_rounds):
+            if not reply.tool_calls:
+                break
+            messages.append(_assistant_tool_message(reply))
+            for call in reply.tool_calls:
+                result = await self.client.execute_agent_tool(
+                    f"tool-{uuid4()}",
+                    delivery_correlation_id,
+                    call.tool_id,
+                    call.arguments,
+                )
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call.id,
+                        "content": result.data if result.ok else {"error": result.error or "tool failed"},
+                    }
+                )
+            reply = await self._complete(messages, tools)
+        if reply.tool_calls:
+            raise RuntimeError("agent exceeded maximum tool-call rounds")
+        if reply.text:
+            self.store.append(*key, "assistant", reply.text)
+            for chunk in _chunks(reply.text, self.message_chunk_size):
+                action = ActionEnvelope(
+                    event_id=event.id,
+                    runtime_id=event.runtime_id,
+                    bot_id=event.bot_id,
+                    action=SendMessage(
+                        message=Message(segments=(Segment(type="text", data={"text": chunk}),)),
+                        conversation=event.conversation,
+                        reply_token=event.reply_token,
+                    ),
+                )
+                response = await self.client.execute_action(
+                    action.action_id,
+                    action.model_dump(mode="json"),
+                    delivery_correlation_id=delivery_correlation_id,
+                )
+                if not response.ok:
+                    raise RuntimeError(response.error or "source runtime rejected agent output")
+
+    async def _complete(
+        self,
+        messages: Sequence[Mapping[str, object]],
+        tools: Sequence[Mapping[str, object]],
+    ) -> ModelReply:
+        try:
+            return await asyncio.wait_for(
+                self.engine.complete(messages, tools=tools),
+                timeout=self.model_timeout_seconds,
+            )
+        except TimeoutError as error:
+            raise RuntimeError("agent model request timed out") from error
 
 
 async def run() -> None:
@@ -211,6 +238,9 @@ async def run() -> None:
             history_limit=_positive_int(options, "history_limit", 40),
             message_chunk_size=_positive_int(options, "message_chunk_size", 1500),
             max_concurrent_events=_positive_int(options, "max_concurrent_events", 16),
+            model_timeout_seconds=_positive_float(options, "model_timeout_seconds", 60.0),
+            event_timeout_seconds=_positive_float(options, "event_timeout_seconds", 120.0),
+            max_tool_rounds=_positive_int(options, "max_tool_rounds", 4),
         )
         await client.ready(
             ("runtime.events.receive", "runtime.events.complete", "runtime.actions.send", "agent.tools.execute")
@@ -266,6 +296,13 @@ def _positive_int(options: Mapping[str, object], key: str, default: int) -> int:
     if not isinstance(value, int) or isinstance(value, bool) or value < 1:
         raise ValueError(f"native agent option {key!r} must be a positive integer")
     return value
+
+
+def _positive_float(options: Mapping[str, object], key: str, default: float) -> float:
+    value = options.get(key, default)
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"native agent option {key!r} must be a positive number")
+    return float(value)
 
 
 def _environment_secret(options: Mapping[str, object], key: str, default: str) -> str:

--- a/packages/agent/tests/test_native_agent.py
+++ b/packages/agent/tests/test_native_agent.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from liteyukibot_agent.engine import AgentEngine, ModelReply, ToolCall
+from liteyukibot_agent import runtime_plugin
 from liteyukibot_agent.host import NativeAgentHost, _environment_secret
 from liteyukibot_agent.store import ConversationStore
 
@@ -75,6 +76,17 @@ class FailingEngine(AgentEngine):
         tools: Sequence[Mapping[str, object]] = (),
     ) -> ModelReply:
         raise RuntimeError("model unavailable")
+
+
+class BlockingEngine(AgentEngine):
+    async def complete(
+        self,
+        _messages: Sequence[Mapping[str, object]],
+        *,
+        tools: Sequence[Mapping[str, object]] = (),
+    ) -> ModelReply:
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
 
 
 def _event() -> EventEnvelope:
@@ -225,6 +237,93 @@ async def test_native_agent_reports_terminal_failure_without_leaking_the_task(tm
     ]
 
 
+@pytest.mark.asyncio
+async def test_native_agent_bounds_a_stalled_model_request_and_releases_capacity(tmp_path: Path) -> None:
+    client = FakeClient()
+    host = NativeAgentHost(
+        client,  # type: ignore[arg-type]
+        BlockingEngine(),
+        ConversationStore(tmp_path / "history.sqlite3"),
+        history_limit=10,
+        message_chunk_size=100,
+        max_concurrent_events=1,
+        model_timeout_seconds=0.01,
+        event_timeout_seconds=1,
+    )
+
+    await host._accept_event(EventMessage(correlation_id="delivery-1", payload=_event().model_dump(mode="json")))
+    results = await asyncio.gather(*tuple(host._tasks), return_exceptions=True)
+    await host.close()
+
+    assert len(results) == 1
+    assert isinstance(results[0], RuntimeError)
+    assert str(results[0]) == "agent model request timed out"
+    assert host._tasks == set()
+    assert client.sent == [
+        EventAccepted(correlation_id="delivery-1", status="accepted"),
+        EventCompleted(
+            correlation_id="delivery-1",
+            status="failed",
+            detail="RuntimeError: agent model request timed out",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_native_agent_bounds_the_entire_event_lifecycle(tmp_path: Path) -> None:
+    client = FakeClient()
+    host = NativeAgentHost(
+        client,  # type: ignore[arg-type]
+        BlockingEngine(),
+        ConversationStore(tmp_path / "history.sqlite3"),
+        history_limit=10,
+        message_chunk_size=100,
+        max_concurrent_events=1,
+        model_timeout_seconds=1,
+        event_timeout_seconds=0.01,
+    )
+
+    await host._accept_event(EventMessage(correlation_id="delivery-1", payload=_event().model_dump(mode="json")))
+    results = await asyncio.gather(*tuple(host._tasks), return_exceptions=True)
+    await host.close()
+
+    assert len(results) == 1
+    assert isinstance(results[0], TimeoutError)
+    assert host._tasks == set()
+    assert client.sent == [
+        EventAccepted(correlation_id="delivery-1", status="accepted"),
+        EventCompleted(correlation_id="delivery-1", status="failed", detail="agent event timed out"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_native_agent_uses_the_configured_tool_round_limit(tmp_path: Path) -> None:
+    client = FakeClient()
+    host = NativeAgentHost(
+        client,  # type: ignore[arg-type]
+        FakeEngine(
+            (
+                ModelReply(tool_calls=(ToolCall("call-1", "docs.search", {}),)),
+                ModelReply(tool_calls=(ToolCall("call-2", "docs.search", {}),)),
+            )
+        ),
+        ConversationStore(tmp_path / "history.sqlite3"),
+        history_limit=10,
+        message_chunk_size=100,
+        max_concurrent_events=1,
+        max_tool_rounds=1,
+    )
+
+    await host._accept_event(EventMessage(correlation_id="delivery-1", payload=_event().model_dump(mode="json")))
+    results = await asyncio.gather(*tuple(host._tasks), return_exceptions=True)
+    await host.close()
+
+    assert len(results) == 1
+    assert isinstance(results[0], RuntimeError)
+    assert str(results[0]) == "agent exceeded maximum tool-call rounds"
+    assert client.tool_calls == [("delivery-1", "docs.search", {})]
+
+
 def test_conversation_history_is_partitioned_by_runtime_bot_and_conversation(tmp_path: Path) -> None:
     store = ConversationStore(tmp_path / "history.sqlite3")
     try:
@@ -246,3 +345,15 @@ def test_native_agent_reads_api_key_only_from_its_configured_environment(
     assert _environment_secret({"api_key_env": "AGENT_TEST_KEY"}, "api_key_env", "OPENAI_API_KEY") == "secret"
     with pytest.raises(ValueError, match="not set"):
         _environment_secret({}, "api_key_env", "MISSING_AGENT_TEST_KEY")
+
+
+def test_native_agent_runtime_metadata_exposes_bounded_options() -> None:
+    plugin = runtime_plugin()
+    assert plugin.init_spec is not None
+
+    fields = {field.key: field for field in plugin.init_spec.fields}
+    assert fields["model_timeout_seconds"].default == 60
+    assert fields["event_timeout_seconds"].default == 120
+    assert fields["max_tool_rounds"].default == 4
+    assert fields["history_limit"].default == 40
+    assert fields["max_concurrent_events"].default == 16

--- a/packages/agent/tests/test_native_agent.py
+++ b/packages/agent/tests/test_native_agent.py
@@ -5,8 +5,8 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import pytest
-from liteyukibot_agent.engine import AgentEngine, ModelReply, ToolCall
 from liteyukibot_agent import runtime_plugin
+from liteyukibot_agent.engine import AgentEngine, ModelReply, ToolCall
 from liteyukibot_agent.host import NativeAgentHost, _environment_secret
 from liteyukibot_agent.store import ConversationStore
 

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -37,7 +37,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("adapter-onebot", "adapter-onebot-v0.1.0a1"),
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
-        ("agent", "agent-v0.1.0a6"),
+        ("agent", "agent-v0.1.0a7"),
         ("runtime-astrbot", "runtime-astrbot-v0.1.0a6"),
         ("runtime-mofox", "runtime-mofox-v0.1.0a5"),
     ],

--- a/uv.lock
+++ b/uv.lock
@@ -1464,7 +1464,7 @@ requires-dist = [{ name = "liteyukibot-v7-runtime-adapter", editable = "packages
 
 [[package]]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a6"
+version = "0.1.0a7"
 source = { editable = "packages/agent" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Beta1 slice

Bounds native Agent work per delivery through package-owned runtime options.

- caps each model request, the total event lifecycle, tool-loop rounds, retained history, and concurrent events;
- turns model and whole-event timeouts into stable failed terminal deliveries while releasing the event slot;
- exposes the limits to `liteyuki init` through the Agent runtime metadata;
- records no model input, tool arguments, or response content in timeout diagnostics;
- advances `liteyukibot-v7-agent` to `0.1.0a7`.

## Verification

- `uv sync --locked --all-packages --extra onebot --extra satori`
- `uv run ruff check src tests scripts packages`
- `uv run mypy`
- `uv run pytest` (`436 passed`)
- `uv build --all-packages --out-dir dist/workspace --clear`
- `uv run python scripts/check_release.py --package agent --tag agent-v0.1.0a7`
- isolated installed-wheel Agent verifier