### PR TITLE
test(agent): cover child runtime provider flow

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -40,7 +40,7 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a15` | `pyproject.toml` | `v7.0.0a15` |
+| `liteyukibot-v7==7.0.0a16` | `pyproject.toml` | `v7.0.0a16` |
 | `liteyukibot-v7-permissions==0.2.0a2` | `packages/permissions` | `permissions-v0.2.0a2` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |
@@ -62,7 +62,7 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a15`;
+1. `v7.0.0a16`;
 2. `permissions-v0.2.0a2`;
 3. `commands-v0.2.0a2`;
 4. `resources-v0.1.0a2`;

--- a/packages/agent/tests/test_native_agent.py
+++ b/packages/agent/tests/test_native_agent.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
@@ -11,12 +13,14 @@ from liteyukibot_agent.host import NativeAgentHost, _environment_secret
 from liteyukibot_agent.store import ConversationStore
 
 from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope, Message, Segment
+from liteyukibot.runtime import ActionSinkResult, AgentToolSinkResult, RuntimeSpec
 from liteyukibot.runtime.protocol import (
     ActionResponse,
     AgentToolResponse,
     EventAccepted,
     EventCompleted,
     EventMessage,
+    JsonValue,
 )
 
 
@@ -100,6 +104,33 @@ def _event() -> EventEnvelope:
         actor=ActorRef(id="user-1"),
         message=Message(segments=(Segment(type="text", data={"text": "hello"}),)),
     )
+
+
+async def _read_http_request(reader: asyncio.StreamReader) -> tuple[str, dict[str, object]]:
+    header = await reader.readuntil(b"\r\n\r\n")
+    lines = header.decode("ascii").split("\r\n")
+    content_length = next(
+        int(line.split(":", 1)[1].strip())
+        for line in lines
+        if line.lower().startswith("content-length:")
+    )
+    return lines[0], json.loads((await reader.readexactly(content_length)).decode("utf-8"))
+
+
+async def _write_completion(
+    writer: asyncio.StreamWriter,
+    message: dict[str, object],
+) -> None:
+    payload = json.dumps({"choices": [{"message": message}]}).encode("utf-8")
+    writer.write(
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Type: application/json\r\n"
+        + f"Content-Length: {len(payload)}\r\nConnection: close\r\n\r\n".encode("ascii")
+        + payload
+    )
+    await writer.drain()
+    writer.close()
+    await writer.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -205,6 +236,118 @@ async def test_native_agent_binds_tool_calls_to_the_delivered_event(tmp_path: Pa
             },
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_native_agent_child_round_trips_mock_provider_tool_and_source_action(tmp_path: Path) -> None:
+    requests: list[dict[str, object]] = []
+    responses: Sequence[dict[str, object]] = (
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "docs.search", "arguments": '{"query":"liteyuki"}'},
+                }
+            ],
+        },
+        {"role": "assistant", "content": "found it", "tool_calls": []},
+    )
+    response_iterator = iter(responses)
+
+    async def provider(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        request_line, request = await _read_http_request(reader)
+        assert request_line == "POST /v1/chat/completions HTTP/1.1"
+        requests.append(request)
+        await _write_completion(writer, next(response_iterator))
+
+    server = await asyncio.start_server(provider, "127.0.0.1", 0)
+    port = int(server.sockets[0].getsockname()[1])
+    action_received = asyncio.Event()
+    observed_tools: list[tuple[str, str, str, Mapping[str, JsonValue]]] = []
+    observed_actions: list[Mapping[str, JsonValue]] = []
+
+    async def tool_sink(
+        runtime_id: str,
+        delivery_id: str,
+        payload: dict[str, JsonValue],
+        tool_id: str,
+        arguments: dict[str, JsonValue],
+    ) -> AgentToolSinkResult:
+        observed_tools.append((runtime_id, delivery_id, str(payload["id"]), arguments))
+        assert tool_id == "docs.search"
+        return AgentToolSinkResult(ok=True, data={"result": "found"})
+
+    async def action_sink(_runtime_id: str, payload: dict[str, JsonValue]) -> ActionSinkResult:
+        observed_actions.append(payload)
+        action_received.set()
+        return ActionSinkResult(ok=True)
+
+    spec = RuntimeSpec(
+        id="agent",
+        kind="agent",
+        command=(sys.executable, "-m", "liteyukibot_agent"),
+        env={
+            "LITEYUKI_AGENT_API_KEY": "test-key",
+            "HTTP_PROXY": "",
+            "HTTPS_PROXY": "",
+            "ALL_PROXY": "",
+            "NO_PROXY": "127.0.0.1,localhost",
+            "http_proxy": "",
+            "https_proxy": "",
+            "all_proxy": "",
+            "no_proxy": "127.0.0.1,localhost",
+        },
+        options={
+            "model": "mock-model",
+            "base_url": f"http://127.0.0.1:{port}/v1",
+            "history_limit": 10,
+            "message_chunk_size": 100,
+            "max_concurrent_events": 1,
+            "model_timeout_seconds": 10,
+            "event_timeout_seconds": 15,
+        },
+        heartbeat_interval=0.05,
+        stale_after=1,
+        ready_timeout=5,
+        shutdown_timeout=2,
+        agent_harness="native",
+    )
+    from liteyukibot.testing import RuntimeTestHarness
+
+    harness = RuntimeTestHarness(
+        spec,
+        action_sink=action_sink,
+        agent_tool_sink=tool_sink,
+    )
+    try:
+        async with harness:
+            accepted = await harness.dispatch_event(
+                _event().model_dump(mode="json"),
+                correlation_id="delivery-1",
+                agent_tool_catalog={
+                    "tools": [
+                        {
+                            "id": "docs.search",
+                            "description": "Search docs.",
+                            "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                        }
+                    ]
+                },
+            )
+            assert accepted == EventAccepted(correlation_id="delivery-1", status="accepted")
+            await asyncio.wait_for(action_received.wait(), timeout=12)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert observed_tools == [("agent", "delivery-1", "event-1", {"query": "liteyuki"})]
+    assert observed_actions[0]["runtime_id"] == "nonebot"
+    assert len(requests) == 2
+    assert requests[0]["model"] == "mock-model"
+    assert requests[0]["tools"] != []
 
 
 @pytest.mark.asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a15"
+version = "7.0.0a16"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/run_developer_kit_install.py
+++ b/scripts/run_developer_kit_install.py
@@ -12,6 +12,10 @@ from scripts.run_isolated_install import _clean_environment
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _build_dir() -> Path:
+    return Path(os.environ.get("LITEYUKI_BUILD_DIR", ROOT / "dist")).resolve()
+
+
 def _one_wheel(directory: Path, distribution: str) -> Path:
     matches = tuple(directory.glob(f"{distribution}-*-py3-none-any.whl"))
     if len(matches) != 1:
@@ -25,10 +29,11 @@ def main() -> int:
     uv = shutil.which("uv")
     if uv is None:
         raise RuntimeError("uv executable was not found")
+    build_dir = _build_dir()
     wheels = (
-        _one_wheel(ROOT / "dist", "liteyukibot_v7"),
-        _one_wheel(ROOT / "dist" / "examples", "liteyukibot_example_plugin"),
-        _one_wheel(ROOT / "dist" / "examples", "liteyukibot_example_runtime"),
+        _one_wheel(build_dir, "liteyukibot_v7"),
+        _one_wheel(build_dir / "examples", "liteyukibot_example_plugin"),
+        _one_wheel(build_dir / "examples", "liteyukibot_example_runtime"),
     )
     command = [uv, "run", "--no-project", "--python", "3.14"]
     for wheel in wheels:

--- a/src/liteyukibot/testing.py
+++ b/src/liteyukibot/testing.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import inspect
+import tempfile
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -27,7 +29,7 @@ from .runtime import (
     RuntimeSupervisor,
 )
 from .runtime.protocol import JsonValue, json_mapping
-from .runtime.supervisor import ActionProvenance, ActionSinkResult, EventSink
+from .runtime.supervisor import ActionProvenance, ActionSinkResult, AgentToolSink, AgentToolSinkResult, EventSink
 from .services import ServiceKey, ServiceRegistry
 
 
@@ -164,20 +166,27 @@ class RuntimeTestHarness:
         *,
         event_sink: EventSink | None = None,
         action_sink: Callable[[str, dict[str, JsonValue]], Awaitable[ActionSinkResult]] | None = None,
+        agent_tool_sink: AgentToolSink | None = None,
     ) -> None:
         if spec.command is None or not spec.command:
             raise ValueError("runtime test harness requires an explicit child command")
-        self.spec = spec
+        self._state_directory = tempfile.TemporaryDirectory(prefix="liteyuki-runtime-test-")
+        self.spec = replace(
+            spec,
+            env={**spec.env, "LITEYUKI_RUNTIME_STATE_DIR": self._state_directory.name},
+        )
         self._event_sink = event_sink
         self._action_sink = action_sink
+        self._agent_tool_sink = agent_tool_sink
         self._child_events: list[tuple[str, dict[str, JsonValue]]] = []
         self._child_actions: list[tuple[str, dict[str, JsonValue]]] = []
         self._supervisor = RuntimeSupervisor(
             logger=get_logger(component="runtime-test"),
             event_sink=self._record_event,
             action_sink=self._record_action,
+            agent_tool_sink=self._record_agent_tool,
         )
-        self._supervisor.add(spec)
+        self._supervisor.add(self.spec)
         self._started = False
         self._closed = False
 
@@ -216,6 +225,7 @@ class RuntimeTestHarness:
             await self._supervisor.start()
         except BaseException:
             self._closed = True
+            self._state_directory.cleanup()
             raise
         self._started = True
 
@@ -226,6 +236,7 @@ class RuntimeTestHarness:
         if self._started:
             self._started = False
             await self._supervisor.stop()
+        self._state_directory.cleanup()
 
     async def dispatch_event(
         self,
@@ -233,6 +244,7 @@ class RuntimeTestHarness:
         *,
         correlation_id: str | None = None,
         timeout_seconds: float = 5.0,
+        agent_tool_catalog: Mapping[str, Any] | None = None,
     ) -> EventAccepted:
         if not self._started:
             raise RuntimeError("runtime test harness is not started")
@@ -241,6 +253,7 @@ class RuntimeTestHarness:
             correlation_id or str(uuid4()),
             payload,
             timeout_seconds,
+            agent_tool_catalog=agent_tool_catalog,
         )
 
     async def execute_action(
@@ -275,6 +288,18 @@ class RuntimeTestHarness:
         if self._action_sink is None:
             return ActionSinkResult(ok=True, data={"recorded": True})
         return await self._action_sink(runtime_id, payload)
+
+    async def _record_agent_tool(
+        self,
+        runtime_id: str,
+        delivery_correlation_id: str,
+        payload: dict[str, JsonValue],
+        tool_id: str,
+        arguments: dict[str, JsonValue],
+    ) -> AgentToolSinkResult:
+        if self._agent_tool_sink is None:
+            return AgentToolSinkResult(ok=False, error="agent tool sink is not configured")
+        return await self._agent_tool_sink(runtime_id, delivery_correlation_id, payload, tool_id, arguments)
 
     async def __aenter__(self) -> RuntimeTestHarness:
         await self.start()

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -11,6 +11,7 @@ from scripts.check_release import (
     read_release_identity,
     validate_release,
 )
+from scripts.run_developer_kit_install import _build_dir
 from scripts.run_isolated_install import _clean_environment, _requirement
 
 import liteyukibot
@@ -25,7 +26,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a15"),
+        ("root", "v7.0.0a16"),
         ("permissions", "permissions-v0.2.0a2"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),
@@ -99,3 +100,12 @@ def test_isolated_install_rejects_empty_and_directory_requirements(tmp_path: Pat
         _requirement("")
     with pytest.raises(ValueError, match="must be a file"):
         _requirement(str(tmp_path))
+
+
+def test_developer_kit_install_uses_an_explicit_build_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("LITEYUKI_BUILD_DIR", str(tmp_path))
+
+    assert _build_dir() == tmp_path.resolve()

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a15"
+version = "7.0.0a16"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- exercise the real `liteyukibot_agent` child process through the RuntimeSupervisor
- use a local OpenAI-compatible mock provider to prove event, delivery-bound tool, and source-runtime action routing
- isolate test runtime state from developer state and permit developer-kit wheel verification from an explicit build directory
- advance the root pre-release identity to `7.0.0a16`

## Validation

- `uv run ruff check src tests scripts packages`
- `uv run mypy`
- `uv run pytest` (`439 passed`)
- workspace and isolated wheel builds
- isolated developer-kit and Agent wheel verification