### PR TITLE
test(onebot): cover HTTP error mappings

### DIFF
--- a/packages/adapter-onebot/tests/test_onebot_v11.py
+++ b/packages/adapter-onebot/tests/test_onebot_v11.py
@@ -23,9 +23,16 @@ class ApiRequest:
 
 
 class ApiStub:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        status: int = 200,
+        response: Mapping[str, Any] | None = None,
+    ) -> None:
         self.requests: asyncio.Queue[ApiRequest] = asyncio.Queue()
         self._server: asyncio.Server | None = None
+        self._status = status
+        self._response = response or {"status": "ok", "retcode": 0, "data": {"message_id": 123}}
 
     @property
     def url(self) -> str:
@@ -51,9 +58,9 @@ class ApiStub:
             if not isinstance(payload, Mapping):
                 raise ValueError("expected JSON object")
             await self.requests.put(ApiRequest(path=path, headers=headers, payload=payload))
-            response = json.dumps({"status": "ok", "retcode": 0, "data": {"message_id": 123}}).encode()
+            response = json.dumps(self._response).encode()
             writer.write(
-                b"HTTP/1.1 200 OK\r\n"
+                f"HTTP/1.1 {self._status} Stub\r\n".encode()
                 + b"Content-Type: application/json\r\n"
                 + f"Content-Length: {len(response)}\r\n".encode()
                 + b"Connection: close\r\n\r\n"
@@ -100,18 +107,20 @@ def _event(text: str = "/help") -> dict[str, Any]:
 
 async def _post_event(
     port: int,
-    event: Mapping[str, Any],
+    event: Mapping[str, Any] | bytes,
     *,
     token: str | None = "event-token",
     self_id: str = "42",
+    path: str = "/onebot/v11/http",
+    content_type: str = "application/json",
 ) -> int:
-    body = json.dumps(event).encode()
+    body = event if isinstance(event, bytes) else json.dumps(event).encode()
     reader, writer = await asyncio.open_connection("127.0.0.1", port)
     try:
         headers = [
-            "POST /onebot/v11/http HTTP/1.1",
+            f"POST {path} HTTP/1.1",
             "Host: 127.0.0.1",
-            "Content-Type: application/json",
+            f"Content-Type: {content_type}",
             f"X-Self-ID: {self_id}",
             f"Content-Length: {len(body)}",
             "Connection: close",
@@ -194,6 +203,57 @@ async def test_v11_rejects_unauthorized_and_mismatched_callbacks() -> None:
         assert await _post_event(port, _event(), self_id="41") == 400
     finally:
         await connection.close()
+
+
+@pytest.mark.asyncio
+async def test_v11_maps_invalid_callback_requests_to_http_errors() -> None:
+    connection = OneBotV11Connection(_context(_unused_port(), "http://127.0.0.1:5701"))
+
+    async def emit(_event: EventEnvelope) -> None:
+        return None
+
+    try:
+        await connection.start(emit)
+        port = int(connection._server.sockets[0].getsockname()[1])  # type: ignore[union-attr]
+        assert await _post_event(port, _event(), path="/unexpected") == 404
+        assert await _post_event(port, _event(), content_type="text/plain") == 415
+        assert await _post_event(port, b"{") == 400
+    finally:
+        await connection.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "response", "message"),
+    [
+        (200, {"status": "failed", "retcode": 100, "wording": "denied"}, "denied"),
+        (502, {"status": "ok", "retcode": 0, "data": {}}, "HTTP 502"),
+    ],
+)
+async def test_v11_maps_api_failures_to_stable_errors(
+    status: int,
+    response: Mapping[str, Any],
+    message: str,
+) -> None:
+    api = ApiStub(status=status, response=response)
+    await api.start()
+    connection = OneBotV11Connection(_context(_unused_port(), api.url))
+    try:
+        with pytest.raises(OneBotV11Error, match=message):
+            await connection.execute(
+                ActionEnvelope(
+                    runtime_id="platform",
+                    bot_id="42",
+                    action=SendMessage(
+                        conversation=ConversationRef(id="2002", type="group"),
+                        message=Message(segments=(Segment(type="text", data={"text": "hello"}),)),
+                    ),
+                )
+            )
+        assert (await asyncio.wait_for(api.requests.get(), timeout=1)).path == "/send_group_msg"
+    finally:
+        await connection.close()
+        await api.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- cover malformed OneBot v11 callbacks through the real loopback HTTP listener
- verify API retcode and HTTP transport failures become stable adapter errors

## Validation

- `uv run ruff check packages/adapter-onebot/tests/test_onebot_v11.py`
- `uv run mypy`
- `uv run pytest packages/adapter-onebot/tests/test_onebot_v11.py -q` (`7 passed`)