### PR TITLE
feat(agent): bound retained conversation history

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -51,7 +51,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-runtime-adapter==0.1.0a2` | `packages/runtime-adapter` | `runtime-adapter-v0.1.0a2` |
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
-| `liteyukibot-v7-agent==0.1.0a7` | `packages/agent` | `agent-v0.1.0a7` |
+| `liteyukibot-v7-agent==0.1.0a8` | `packages/agent` | `agent-v0.1.0a8` |
 | `liteyukibot-v7-runtime-astrbot==0.1.0a6` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a6` |
 | `liteyukibot-v7-runtime-mofox==0.1.0a5` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a5` |
 
@@ -73,7 +73,7 @@ Push and wait for each release before creating the next tag:
 9. `runtime-adapter-v0.1.0a2`.
 10. `adapter-onebot-v0.1.0a1`.
 11. `runtime-v6-v0.1.0a1`.
-12. `agent-v0.1.0a7`.
+12. `agent-v0.1.0a8`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -10,7 +10,9 @@ every tool request returns through the kernel broker, which checks the same
 capabilities again before invoking a package-provided handler.
 
 The `agent` runtime options bound each delivered event: `history_limit` defaults
-to 40 messages, `max_concurrent_events` to 16, `max_tool_rounds` to 4,
+to 40 messages and is also the maximum retained SQLite history per source
+runtime, bot, and conversation. Retention is applied on every write; changing
+the limit only affects subsequent writes. `max_concurrent_events` defaults to 16, `max_tool_rounds` to 4,
 `model_timeout_seconds` to 60, and `event_timeout_seconds` to 120. A model or
 event timeout produces a failed terminal delivery without recording model input,
 tool arguments, or response content in logs.

--- a/packages/agent/pyproject.toml
+++ b/packages/agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a7"
+version = "0.1.0a8"
 description = "Native OpenAI-compatible agent harness for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/agent/src/liteyukibot_agent/__init__.py
+++ b/packages/agent/src/liteyukibot_agent/__init__.py
@@ -89,7 +89,7 @@ def runtime_plugin() -> RuntimePlugin:
 try:
     __version__ = version("liteyukibot-v7-agent")
 except PackageNotFoundError:
-    __version__ = "0.1.0a7"
+    __version__ = "0.1.0a8"
 
 plugin: PluginDefinition = create_plugin(__version__)
 

--- a/packages/agent/src/liteyukibot_agent/host.py
+++ b/packages/agent/src/liteyukibot_agent/host.py
@@ -157,7 +157,12 @@ class NativeAgentHost:
         tools: Sequence[Mapping[str, object]],
     ) -> None:
         key = (event.runtime_id, event.bot_id, event.conversation.ordering_key)
-        self.store.append(*key, "user", event.message.plain_text if event.message is not None else "")
+        self.store.append(
+            *key,
+            "user",
+            event.message.plain_text if event.message is not None else "",
+            retain=self.history_limit,
+        )
         messages: list[Mapping[str, object]] = [item for item in self.store.messages(*key, limit=self.history_limit)]
         reply = await self._complete(messages, tools)
         for _index in range(self.max_tool_rounds):
@@ -182,7 +187,7 @@ class NativeAgentHost:
         if reply.tool_calls:
             raise RuntimeError("agent exceeded maximum tool-call rounds")
         if reply.text:
-            self.store.append(*key, "assistant", reply.text)
+            self.store.append(*key, "assistant", reply.text, retain=self.history_limit)
             for chunk in _chunks(reply.text, self.message_chunk_size):
                 action = ActionEnvelope(
                     event_id=event.id,

--- a/packages/agent/src/liteyukibot_agent/store.py
+++ b/packages/agent/src/liteyukibot_agent/store.py
@@ -1,4 +1,4 @@
-"""Small SQLite conversation history store owned by the native agent runtime."""
+"""Bounded SQLite conversation history owned by the native agent runtime."""
 
 from __future__ import annotations
 
@@ -57,7 +57,11 @@ class ConversationStore:
         conversation_id: str,
         role: str,
         content: Mapping[str, object] | str,
+        *,
+        retain: int,
     ) -> None:
+        if retain < 1:
+            raise ValueError("conversation history retention must be at least 1")
         self._connection.execute(
             """
             INSERT INTO messages (runtime_id, bot_id, conversation_id, role, content)
@@ -65,7 +69,41 @@ class ConversationStore:
             """,
             (runtime_id, bot_id, conversation_id, role, json.dumps(content, ensure_ascii=True)),
         )
+        self._connection.execute(
+            """
+            DELETE FROM messages
+            WHERE runtime_id = ? AND bot_id = ? AND conversation_id = ?
+              AND sequence NOT IN (
+                SELECT sequence FROM messages
+                WHERE runtime_id = ? AND bot_id = ? AND conversation_id = ?
+                ORDER BY sequence DESC
+                LIMIT ?
+            )
+            """,
+            (
+                runtime_id,
+                bot_id,
+                conversation_id,
+                runtime_id,
+                bot_id,
+                conversation_id,
+                retain,
+            ),
+        )
         self._connection.commit()
+
+    def clear(self, runtime_id: str, bot_id: str, conversation_id: str) -> int:
+        """Delete one source-scoped conversation and return its removed message count."""
+
+        cursor = self._connection.execute(
+            """
+            DELETE FROM messages
+            WHERE runtime_id = ? AND bot_id = ? AND conversation_id = ?
+            """,
+            (runtime_id, bot_id, conversation_id),
+        )
+        self._connection.commit()
+        return cursor.rowcount
 
     def close(self) -> None:
         self._connection.close()

--- a/packages/agent/tests/test_native_agent.py
+++ b/packages/agent/tests/test_native_agent.py
@@ -294,11 +294,11 @@ async def test_native_agent_child_round_trips_mock_provider_tool_and_source_acti
             "HTTP_PROXY": "",
             "HTTPS_PROXY": "",
             "ALL_PROXY": "",
-            "NO_PROXY": "127.0.0.1,localhost",
+            "NO_PROXY": "*",
             "http_proxy": "",
             "https_proxy": "",
             "all_proxy": "",
-            "no_proxy": "127.0.0.1,localhost",
+            "no_proxy": "*",
         },
         options={
             "model": "mock-model",
@@ -470,12 +470,34 @@ async def test_native_agent_uses_the_configured_tool_round_limit(tmp_path: Path)
 def test_conversation_history_is_partitioned_by_runtime_bot_and_conversation(tmp_path: Path) -> None:
     store = ConversationStore(tmp_path / "history.sqlite3")
     try:
-        store.append("onebot", "bot-1", "group:one", "user", "first")
-        store.append("onebot", "bot-2", "group:one", "user", "other-bot")
+        store.append("onebot", "bot-1", "group:one", "user", "first", retain=10)
+        store.append("onebot", "bot-2", "group:one", "user", "other-bot", retain=10)
 
         assert store.messages("onebot", "bot-1", "group:one", limit=10) == [
             {"role": "user", "content": "first"}
         ]
+    finally:
+        store.close()
+
+
+def test_conversation_history_is_bounded_and_can_clear_one_source_conversation(tmp_path: Path) -> None:
+    store = ConversationStore(tmp_path / "history.sqlite3")
+    try:
+        for value in ("first", "second", "third"):
+            store.append("onebot", "bot-1", "group:one", "user", value, retain=2)
+        store.append("onebot", "bot-1", "group:two", "user", "unrelated", retain=2)
+
+        assert store.messages("onebot", "bot-1", "group:one", limit=10) == [
+            {"role": "user", "content": "second"},
+            {"role": "user", "content": "third"},
+        ]
+        assert store.clear("onebot", "bot-1", "group:one") == 2
+        assert store.messages("onebot", "bot-1", "group:one", limit=10) == []
+        assert store.messages("onebot", "bot-1", "group:two", limit=10) == [
+            {"role": "user", "content": "unrelated"}
+        ]
+        with pytest.raises(ValueError, match="retention"):
+            store.append("onebot", "bot-1", "group:one", "user", "invalid", retain=0)
     finally:
         store.close()
 

--- a/scripts/verify_agent_install.py
+++ b/scripts/verify_agent_install.py
@@ -176,6 +176,28 @@ async def _verify_agent_contract() -> None:
         raise RuntimeError("agent reply was not routed through the source runtime")
 
 
+def _verify_history_retention() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        store = ConversationStore(Path(directory) / "history.sqlite3")
+        try:
+            for value in ("first", "second", "third"):
+                store.append("nonebot", "bot-1", "group:one", "user", value, retain=2)
+            store.append("nonebot", "bot-1", "group:two", "user", "unrelated", retain=2)
+            if store.messages("nonebot", "bot-1", "group:one", limit=10) != [
+                {"role": "user", "content": "second"},
+                {"role": "user", "content": "third"},
+            ]:
+                raise RuntimeError("agent history retention did not bound one conversation")
+            if store.clear("nonebot", "bot-1", "group:one") != 2:
+                raise RuntimeError("agent history clear did not report removed messages")
+            if store.messages("nonebot", "bot-1", "group:two", limit=10) != [
+                {"role": "user", "content": "unrelated"}
+            ]:
+                raise RuntimeError("agent history clear crossed source conversation boundaries")
+        finally:
+            store.close()
+
+
 def verify(expected_version: str | None = None) -> None:
     imported = (Path(liteyukibot.__file__).resolve(), Path(liteyukibot_agent.__file__).resolve())
     if any(path.is_relative_to(SOURCE_ROOT) for path in imported):
@@ -190,6 +212,7 @@ def verify(expected_version: str | None = None) -> None:
     if expected_version is not None and observed["liteyukibot-v7-agent"] != expected_version:
         raise RuntimeError(f"expected liteyukibot-v7-agent {expected_version}; observed {observed}")
     asyncio.run(_verify_agent_contract())
+    _verify_history_retention()
     print(json.dumps(observed, sort_keys=True))
 
 

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -38,7 +38,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("adapter-onebot", "adapter-onebot-v0.1.0a1"),
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
-        ("agent", "agent-v0.1.0a7"),
+        ("agent", "agent-v0.1.0a8"),
         ("runtime-astrbot", "runtime-astrbot-v0.1.0a6"),
         ("runtime-mofox", "runtime-mofox-v0.1.0a5"),
     ],

--- a/uv.lock
+++ b/uv.lock
@@ -1464,7 +1464,7 @@ requires-dist = [{ name = "liteyukibot-v7-runtime-adapter", editable = "packages
 
 [[package]]
 name = "liteyukibot-v7-agent"
-version = "0.1.0a7"
+version = "0.1.0a8"
 source = { editable = "packages/agent" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Summary

- retain at most `history_limit` SQLite messages per source runtime, bot, and conversation
- expose a source-scoped store clear primitive without adding a model or unguarded control path
- exercise retention and isolation from the installed Agent wheel
- release impact: `liteyukibot-v7-agent` advances to `0.1.0a8`

## Validation

- `uv run ruff check packages/agent scripts/verify_agent_install.py tests/test_release_v7.py`
- `uv run mypy`
- `uv run pytest packages/agent/tests tests/test_release_v7.py -q` (`38 passed`)
- workspace wheel build and `uv run python -m scripts.run_agent_install`