### PR TITLE
test(release): smoke uv tool installation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
           uv run pytest
           uv build
           uv build --all-packages --out-dir dist/workspace --clear
+          uv run python -m scripts.run_tool_install_smoke
           uv build --project examples/native-plugin --out-dir dist/examples
           uv build --project examples/custom-runtime --out-dir dist/examples
           uv run python -m scripts.run_developer_kit_install

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current pre-release is `liteyukibot-v7==7.0.0a15`. Kernel stabilization,
+The current source pre-release identity is `liteyukibot-v7==7.0.0a16`. Kernel stabilization,
 the first bounded compatibility phase, and the first-party plugin foundation
 are complete. Runtime protocol v4 remains an alpha contract and may change
 under ADR 0011 before the first stable release.

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -170,10 +170,13 @@ and published-install matrix are documented in
 
 ## Current Release State
 
-The current pre-release is `liteyukibot-v7==7.0.0a8`. The kernel, bounded v6
-compatibility, separately published NoneBot and v6 runtime boundaries, and first-party plugin foundation are
-complete. Resources and profile remain optional business plugins; their storage
-and migration ownership does not belong to the kernel.
+The current source pre-release is `liteyukibot-v7==7.0.0a16`. The kernel,
+bounded v6 compatibility, separately published runtime boundaries, and the
+first-party plugin foundation are complete. Resources and profile remain
+optional business plugins; their storage and migration ownership does not
+belong to the kernel. The Beta1 compatibility tiers, supported installation
+path, security boundary, and known limits are recorded in
+[`beta1.md`](../beta1.md).
 
 Current release procedure and package identities are in
 [`development/releasing.md`](../development/releasing.md). Completed alpha

--- a/docs/beta1.md
+++ b/docs/beta1.md
@@ -1,0 +1,124 @@
+# LiteyukiBot v7 Beta1 Contract
+
+Beta1 will publish `liteyukibot-v7==7.0.0b1`. It is a single-host,
+protocol-neutral integration release: the kernel owns configuration, routing,
+permissions, deployment state, and IPC; platform/framework integrations run in
+supervised child processes and never exchange SDK objects with one another.
+
+This document is the release-facing contract. The implementation checklist,
+open decisions, PR rules, and release gates live in `tmp/beta1-roadmap.md`.
+
+## Installation
+
+After the Beta1 wheels are published, install a minimal local workspace with:
+
+```bash
+uv tool install --python 3.14 "liteyukibot-v7==7.0.0b1"
+liteyuki init
+liteyuki check
+```
+
+Install optional runtime distributions in the same isolated tool environment
+at install time. For the supported native OneBot v11 path, use the versions
+listed in the release notes:
+
+```bash
+uv tool install --python 3.14 --force \
+  --with "liteyukibot-v7-runtime-adapter==RELEASE_VERSION" \
+  --with "liteyukibot-v7-adapter-onebot==RELEASE_VERSION" \
+  "liteyukibot-v7==7.0.0b1"
+```
+
+`RELEASE_VERSION` is intentionally a placeholder: each separately distributed
+runtime and adapter has its own version. Do not substitute an arbitrary latest
+version. The release notes name the tested root/runtime/adapter set. Project
+maintainers may instead add the same requirements to their project with `uv
+add`, then invoke `uv run liteyuki ...`.
+
+The repository CI already builds the root wheel, installs it via an isolated
+`uv tool` directory, and runs `version`, non-interactive `init`, and `check` on
+Windows, macOS, and Linux. The public PyPI smoke for Beta1 repeats that flow
+against the released wheels.
+
+## Compatibility Tiers
+
+| Tier | Components | Beta1 commitment |
+| --- | --- | --- |
+| Supported | Native adapter host, OneBot v11 adapter, native plugins, v6 compatibility, native agent | Documented configuration plus automated end-to-end regression coverage. OneBot v11 is the only supported native platform protocol. |
+| Supported bridge | NoneBot, AstrBot, MoFox | Kernel-supervised child bridge with locked upstream dependency, lifecycle, event/action, and managed-projection evidence. LiteyukiBot does not reimplement each framework's ecosystem. |
+| Experimental | OneBot v12, Satori, future native adapters | Separately versioned and independently tested. Their availability or absence does not alter the supported OneBot v11 path. |
+
+The current native OneBot v11 adapter owns an HTTP Post callback listener and
+HTTP API client. It accepts private and group messages, maps text, mentions,
+replies, and media into frozen envelopes, and returns `SendMessage` or guarded
+`CallApi` actions through the source runtime. Malformed callbacks, path and
+content-type failures, and API failures have stable error behavior; listener
+restart clears stale reply routes before accepting the next generation.
+
+The native agent is OpenAI-compatible but is not an unrestricted automation
+runtime. The kernel exposes only source-principal-authorized business-tool
+schemas and rechecks that capability at invocation. Agent events are bounded by
+model/event timeouts, tool rounds, concurrency, and conversation history. The
+SQLite store retains at most `history_limit` messages for each exact
+`(runtime_id, bot_id, conversation_id)` tuple on subsequent writes.
+
+## Runtime And Delivery Semantics
+
+Runtime IPC uses authenticated framed JSON over loopback. An event is accepted
+by the kernel, routed to configured children, and can result in a
+protocol-neutral action back to the source runtime. The kernel verifies the
+runtime, bot, and active event-delivery provenance before it executes a
+child-originated action.
+
+Delivery is bounded best effort, not exactly-once or durable cross-host
+messaging. A failed/overloaded child, source action failure, timeout, or restart
+is exposed as a terminal diagnostic. Runtime generation activation first checks
+the staged immutable load plan in an isolated Python environment; a failed
+health probe leaves the prior active/rollback pointers intact.
+
+## Security Boundary
+
+- Runtime secrets reside in the encrypted workspace vault and are injected only
+  into the environment variable declared by the enabled runtime; secrets do not
+  travel through IPC or diagnostic output.
+- Capability grants are exact `(runtime_id, bot_id, actor_id)` decisions and
+  fail closed for an unknown principal. Agent tool visibility and execution use
+  the same decision path.
+- `CallApi` has one guarded kernel action boundary. Direct child calls without
+  an accepted source event are rejected.
+- Native plugins are trusted in-process code. Third-party framework and
+  platform SDK state remains inside its child runtime; this is an integration
+  boundary, not a sandbox for malicious plugins.
+
+## Upgrade And Recovery
+
+`config_version = 1` remains the Beta1 configuration schema. Configurations
+with an older or missing version block startup after LiteyukiBot writes a backup
+and a current upgrade template below `.liteyuki/`; newer configurations are
+rejected without modification. Review the template, merge it manually, then
+run `liteyuki config upgrade --refresh` only to regenerate recovery material.
+
+Managed profiles and runtime generations retain a verified previous pointer.
+Use `liteyuki profile rollback` to restore the preceding profile. Package-owned
+state is never copied or migrated automatically; a package must provide an
+explicit compatible migration/backup path before that behavior becomes part of
+the Beta1 release contract.
+
+## Known Limits
+
+- There are no runtime-to-runtime sockets, distributed clustering, durable
+  delivery, or WebUI implementation in Beta1.
+- OneBot v12 and Satori are not substitutes for the supported OneBot v11 path.
+- Agent routes cannot install packages, edit configuration, execute arbitrary
+  shell commands, or use unrestricted filesystem tools.
+- Agent history has a bounded retention policy. A user-facing, capability-gated
+  clear-history control is not part of Beta1 until its authorization and audit
+  contract is released.
+
+## Release Evidence
+
+A Beta1 tag is created only after the release commit is merged, the full
+three-platform CI and Docker checks pass, all required trusted publishers are
+configured, each package wheel is installed in isolation, and the public
+released-wheel smoke passes. Package tags are immutable and published in
+dependency order; see [the release procedure](development/releasing.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ then use the selected profile Python. The previous verified profile remains
 available for one-command rollback.
 
 ~~~bash
-liteyuki profile stage --require "liteyukibot-v7==7.0.0a8"
+liteyuki profile stage --require "liteyukibot-v7==PUBLISHED_VERSION"
 liteyuki profile list
 liteyuki profile activate PROFILE_ID
 liteyuki profile rollback
@@ -73,6 +73,8 @@ liteyuki profile rollback
 
 `liteyuki.lock` records the active/previous profile and its exact installed
 distribution versions. Profiles never copy or migrate package-owned data.
+Replace `PUBLISHED_VERSION` with a version that has already been uploaded; use
+the release notes rather than a source-tree version that may not exist on PyPI.
 
 ## Precedence And Inspection
 
@@ -127,8 +129,9 @@ api_key_env configuration remains an explicit compatibility override.
 
 ## Upgrade Material
 
-config_version = 1 is the current v7 alpha schema. A root configuration with a
-missing or older version is preserved and blocks startup after generating:
+config_version = 1 is the current v7 pre-release schema and the planned Beta1
+schema. A root configuration with a missing or older version is preserved and
+blocks startup after generating:
 
 - a backup under .liteyuki/config-backups/;
 - a current template under .liteyuki/config-upgrades/;

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -26,6 +26,10 @@ Before the first plugin upload, create these Pending Publishers:
 | `liteyukibot-v7-runtime-adapter` | `pypi-runtime-adapter` |
 | `liteyukibot-v7-adapter-onebot` | `pypi-adapter-onebot` |
 | `liteyukibot-v7-runtime-v6` | `pypi-runtime-v6` |
+| `liteyukibot-v7-agent-resolver` | `pypi-agent-resolver` |
+| `liteyukibot-v7-agent` | `pypi-agent` |
+| `liteyukibot-v7-runtime-astrbot` | `pypi-astrbot-runtime` |
+| `liteyukibot-v7-runtime-mofox` | `pypi-mofox-runtime` |
 
 PyPI requires different pending project names to use distinct publisher
 identities. The workflow selects the environment from the release tag (or the
@@ -50,7 +54,8 @@ distribution inside the workflow.
 | `liteyukibot-v7-runtime-nonebot==0.1.0a1` | `packages/runtime-nonebot` | `runtime-nonebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-adapter==0.1.0a2` | `packages/runtime-adapter` | `runtime-adapter-v0.1.0a2` |
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
-| `liteyukibot-v7-runtime-v6==0.1.0a1` | `packages/runtime-v6` | `runtime-v6-v0.1.0a1` |
+| `liteyukibot-v7-runtime-v6==0.1.0a2` | `packages/runtime-v6` | `runtime-v6-v0.1.0a2` |
+| `liteyukibot-v7-agent-resolver==0.1.0a1` | `packages/agent-resolver` | `agent-resolver-v0.1.0a1` |
 | `liteyukibot-v7-agent==0.1.0a8` | `packages/agent` | `agent-v0.1.0a8` |
 | `liteyukibot-v7-runtime-astrbot==0.1.0a6` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a6` |
 | `liteyukibot-v7-runtime-mofox==0.1.0a5` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a5` |
@@ -72,8 +77,11 @@ Push and wait for each release before creating the next tag:
 8. `runtime-nonebot-v0.1.0a1`.
 9. `runtime-adapter-v0.1.0a2`.
 10. `adapter-onebot-v0.1.0a1`.
-11. `runtime-v6-v0.1.0a1`.
-12. `agent-v0.1.0a8`.
+11. `runtime-v6-v0.1.0a2`.
+12. `agent-resolver-v0.1.0a1`.
+13. `agent-v0.1.0a8`.
+14. `runtime-astrbot-v0.1.0a6`.
+15. `runtime-mofox-v0.1.0a5`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/docs/performance-v7.md
+++ b/docs/performance-v7.md
@@ -3,7 +3,7 @@
 ## Published Install Contract
 
 CI installs the newest published `liteyukibot-v7` in the
-`>=7.0.0a2,<7.0.0a4` release window from PyPI in an isolated uv environment on
+`>=7.0.0a2,<8` release window from PyPI in an isolated uv environment on
 Ubuntu, Windows, and macOS. It verifies that distribution metadata and the
 `liteyukibot` kernel namespace report the same version. The separately released
 v6 runtime has its own isolated-install verifier for the `liteyuki`
@@ -15,7 +15,7 @@ Run the same contract locally with:
 
 ```bash
 uv run --no-project --python 3.14 python scripts/run_isolated_install.py \
-  --with "liteyukibot-v7>=7.0.0a2,<7.0.0a4" \
+  --with "liteyukibot-v7>=7.0.0a2,<8" \
   --verifier scripts/verify_published_install.py
 ```
 

--- a/scripts/run_tool_install_smoke.py
+++ b/scripts/run_tool_install_smoke.py
@@ -1,0 +1,56 @@
+"""Exercise the user-facing ``uv tool install`` path from a built root wheel."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _root_wheel() -> Path:
+    wheels = tuple((ROOT / "dist" / "workspace").glob("liteyukibot_v7-*-py3-none-any.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(f"expected one root wheel in dist/workspace, found {len(wheels)}")
+    return wheels[0].resolve()
+
+
+def _run(command: list[str], *, cwd: Path, environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, env=environment, text=True, capture_output=True, check=True)
+
+
+def main() -> int:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv executable was not found")
+    with tempfile.TemporaryDirectory(prefix="liteyuki-tool-smoke-") as directory:
+        root = Path(directory)
+        tool_directory = root / "tools"
+        workspace = root / "workspace"
+        environment = os.environ.copy()
+        environment["UV_TOOL_DIR"] = str(tool_directory)
+        bin_directory = Path(_run([uv, "tool", "dir", "--bin"], cwd=root, environment=environment).stdout.strip())
+        environment["PATH"] = os.pathsep.join((str(bin_directory), environment.get("PATH", "")))
+
+        _run(
+            [uv, "tool", "install", "--python", "3.14", "--force", str(_root_wheel())],
+            cwd=root,
+            environment=environment,
+        )
+        version = _run(["liteyuki", "version"], cwd=root, environment=environment).stdout.strip()
+        if not version:
+            raise RuntimeError("installed liteyuki CLI did not report a version")
+        _run(
+            ["liteyuki", "--workspace", str(workspace), "init", "--non-interactive", "--locale", "en-US"],
+            cwd=root,
+            environment=environment,
+        )
+        _run(["liteyuki", "--workspace", str(workspace), "check"], cwd=root, environment=environment)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- install the built root wheel through an isolated `uv tool` directory
- verify the installed CLI version, non-interactive workspace initialization, and configuration validation
- run this user-facing path in the existing three-platform CI quality matrix
- refresh stale alpha release-window references in operational documentation

## Validation

- `uv build --all-packages --out-dir dist/workspace --clear`
- `uv run python -m scripts.run_tool_install_smoke`
- `uv run ruff check scripts/run_tool_install_smoke.py`
- `uv run mypy`
- `uv run pytest tests/test_cli_v7.py tests/test_release_v7.py -q` (`32 passed`)