### PR TITLE
fix(runtime): verify projected bridge plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   command, with redacted permission auditing and no model invocation;
 - made `liteyukibot-v7-agent` depend on the separately published command
   package so its installed plugin contract is complete.
+- fixed the AstrBot child import root so managed projected plugins are loaded,
+  and added locked-upstream plugin-reply regressions for the AstrBot and MoFox
+  bridge runtimes.
 - added `liteyukibot-v7-runtime-adapter`, a separately published Python
   platform-adapter host with managed-generation and entry-point boundaries;
 - added `liteyukibot-v7-adapter-onebot`, a pure-Python OneBot v11 HTTP Post

--- a/docs/beta1.md
+++ b/docs/beta1.md
@@ -45,7 +45,7 @@ against the released wheels.
 | Tier | Components | Beta1 commitment |
 | --- | --- | --- |
 | Supported | Native adapter host, OneBot v11 adapter, native plugins, v6 compatibility, native agent | Documented configuration plus automated end-to-end regression coverage. OneBot v11 is the only supported native platform protocol. |
-| Supported bridge | NoneBot, AstrBot, MoFox | Kernel-supervised child bridge with locked upstream dependency, lifecycle, event/action, and managed-projection evidence. LiteyukiBot does not reimplement each framework's ecosystem. |
+| Supported bridge | NoneBot, AstrBot, MoFox | Kernel-supervised child bridge with locked upstream dependency, lifecycle, event/action, and managed-projection evidence. AstrBot and MoFox regression tests load a minimal projected upstream plugin and assert its reply returns through the Liteyuki action sink. LiteyukiBot does not reimplement each framework's ecosystem. |
 | Experimental | OneBot v12, Satori, future native adapters | Separately versioned and independently tested. Their availability or absence does not alter the supported OneBot v11 path. |
 
 The current native OneBot v11 adapter owns an HTTP Post callback listener and

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -57,8 +57,8 @@ distribution inside the workflow.
 | `liteyukibot-v7-runtime-v6==0.1.0a2` | `packages/runtime-v6` | `runtime-v6-v0.1.0a2` |
 | `liteyukibot-v7-agent-resolver==0.1.0a1` | `packages/agent-resolver` | `agent-resolver-v0.1.0a1` |
 | `liteyukibot-v7-agent==0.1.0a9` | `packages/agent` | `agent-v0.1.0a9` |
-| `liteyukibot-v7-runtime-astrbot==0.1.0a6` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a6` |
-| `liteyukibot-v7-runtime-mofox==0.1.0a5` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a5` |
+| `liteyukibot-v7-runtime-astrbot==0.1.0a7` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a7` |
+| `liteyukibot-v7-runtime-mofox==0.1.0a6` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a6` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
 tag that does not exactly match the selected source version and distribution.
@@ -80,8 +80,8 @@ Push and wait for each release before creating the next tag:
 11. `runtime-v6-v0.1.0a2`.
 12. `agent-resolver-v0.1.0a1`.
 13. `agent-v0.1.0a9` (requires `commands-v0.2.0a2`).
-14. `runtime-astrbot-v0.1.0a6`.
-15. `runtime-mofox-v0.1.0a5`.
+14. `runtime-astrbot-v0.1.0a7`.
+15. `runtime-mofox-v0.1.0a6`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/packages/runtime-astrbot/pyproject.toml
+++ b/packages/runtime-astrbot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a6"
+version = "0.1.0a7"
 description = "Headless AstrBot agent runtime for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import suppress
 from importlib import import_module
@@ -77,6 +78,7 @@ class AstrBotHeadlessEngine:
         self._schedulers: Mapping[str, Any] = {}
         self._logger = logger
         self._log_bridge: AstrBotLogBridge | None = None
+        self._import_root: str | None = None
 
     async def start(self) -> None:
         root = self.state_directory / "astrbot"
@@ -84,6 +86,7 @@ class AstrBotHeadlessEngine:
         os.environ["ASTRBOT_ROOT"] = str(root)
         os.environ["ASTRBOT_RELOAD"] = "0"
         _prepare_managed_plugins(root, self.options)
+        self._install_import_root(root)
         astrbot_core = import_module("astrbot.core")
         log_broker_type = astrbot_core.LogBroker
         lifecycle_type = import_module("astrbot.core.core_lifecycle").AstrBotCoreLifecycle
@@ -96,6 +99,7 @@ class AstrBotHeadlessEngine:
             await lifecycle.initialize()
         except BaseException:
             await bridge.close()
+            self._remove_import_root()
             raise
         _restore_child_logging()
         bridge.start(astrbot_core.LogManager, astrbot_core.logger)
@@ -124,7 +128,23 @@ class AstrBotHeadlessEngine:
                 if bridge is not None:
                     await bridge.close()
             finally:
-                await _dispose_astrbot_global_database(self._logger)
+                try:
+                    await _dispose_astrbot_global_database(self._logger)
+                finally:
+                    self._remove_import_root()
+
+    def _install_import_root(self, root: Path) -> None:
+        """Expose AstrBot's ``data.plugins`` projection only in this child."""
+
+        value = str(root)
+        sys.path.insert(0, value)
+        self._import_root = value
+
+    def _remove_import_root(self) -> None:
+        value, self._import_root = self._import_root, None
+        if value is not None:
+            with suppress(ValueError):
+                sys.path.remove(value)
 
     def _scheduler(self) -> Any:
         requested = self.options.get("scheduler_id")

--- a/packages/runtime-astrbot/tests/test_translate.py
+++ b/packages/runtime-astrbot/tests/test_translate.py
@@ -55,6 +55,52 @@ def test_astrbot_translation_rejects_non_message_events() -> None:
         to_astr_event_input(event)
 
 
+def _write_bridge_plugin(root: Path) -> None:
+    plugin = root / "astrbot" / "data" / "plugins" / "liteyuki_bridge_probe"
+    plugin.mkdir(parents=True)
+    (plugin / "metadata.yaml").write_text(
+        "name: liteyuki_bridge_probe\n"
+        "description: Liteyuki bridge verification plugin\n"
+        "version: 1.0.0\n"
+        "author: LiteyukiBot\n",
+        encoding="utf-8",
+    )
+    (plugin / "main.py").write_text(
+        "from astrbot.api import star\n"
+        "from astrbot.api.event import AstrMessageEvent, MessageEventResult, filter\n\n"
+        "@star.register('liteyuki_bridge_probe', 'LiteyukiBot', 'Bridge verification', '1.0.0')\n"
+        "class Main(star.Star):\n"
+        "    @filter.command('bridge_probe')\n"
+        "    async def bridge_probe(self, event: AstrMessageEvent) -> None:\n"
+        "        event.set_result(MessageEventResult().message('astrbot bridge reply'))\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_astrbot_upstream_pipeline_routes_a_managed_plugin_reply(tmp_path: Path) -> None:
+    """Exercise the installed AstrBot scheduler, not a substitute engine."""
+
+    _write_bridge_plugin(tmp_path)
+    logger = RecordingCleanupLogger()
+    engine = AstrBotHeadlessEngine(tmp_path, {}, logger)
+    sent: list[str] = []
+
+    async def emit(text: str) -> None:
+        sent.append(text)
+
+    event = _event().model_copy(
+        update={"message": Message(segments=(Segment(type="text", data={"text": "/bridge_probe"}),))}
+    )
+    try:
+        await engine.start()
+        await engine.process(event, emit)
+    finally:
+        await engine.close()
+
+    assert sent == ["astrbot bridge reply"]
+
+
 class FakeClient:
     def __init__(self) -> None:
         self.sent: list[object] = []

--- a/packages/runtime-mofox/pyproject.toml
+++ b/packages/runtime-mofox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-mofox"
-version = "0.1.0a5"
+version = "0.1.0a6"
 description = "Headless Neo-MoFox agent runtime for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/runtime-mofox/tests/test_mofox_runtime.py
+++ b/packages/runtime-mofox/tests/test_mofox_runtime.py
@@ -91,6 +91,74 @@ def test_mofox_engine_restores_working_directory() -> None:
     assert engine._previous_cwd is None
 
 
+def _write_bridge_plugin(root: Path) -> None:
+    plugin = root / "mofox" / "plugins" / "liteyuki_bridge_probe"
+    plugin.mkdir(parents=True)
+    (plugin / "manifest.json").write_text(
+        """{
+  "name": "liteyuki_bridge_probe",
+  "version": "1.0.0",
+  "description": "Liteyuki bridge verification plugin",
+  "author": "LiteyukiBot",
+  "dependencies": {"plugins": [], "components": []},
+  "entry_point": "plugin.py",
+  "python_dependencies": []
+}
+""",
+        encoding="utf-8",
+    )
+    (plugin / "plugin.py").write_text(
+        "from src.core.components import BaseEventHandler, BasePlugin, EventType\n"
+        "from src.core.components.loader import register_plugin\n"
+        "from src.core.models.message import Message\n"
+        "from src.core.transport.message_send import get_message_sender\n"
+        "from src.kernel.event import EventDecision\n\n"
+        "class ReplyHandler(BaseEventHandler):\n"
+        "    name = 'reply'\n"
+        "    init_subscribe = [EventType.ON_MESSAGE_RECEIVED]\n\n"
+        "    async def execute(self, _event_name, params):\n"
+        "        message = params['message']\n"
+        "        if message.processed_plain_text == '/bridge_probe':\n"
+        "            await get_message_sender().send_message(Message(\n"
+        "                message_id='bridge-reply', content='mofox bridge reply',\n"
+        "                processed_plain_text='mofox bridge reply', platform=message.platform,\n"
+        "                chat_type=message.chat_type, stream_id=message.stream_id,\n"
+        "            ), adapter_signature='liteyuki:adapter:injected')\n"
+        "        return EventDecision.SUCCESS, params\n\n"
+        "@register_plugin\n"
+        "class BridgePlugin(BasePlugin):\n"
+        "    plugin_name = 'liteyuki_bridge_probe'\n"
+        "    plugin_description = 'Bridge verification'\n"
+        "    plugin_version = '1.0.0'\n\n"
+        "    def get_components(self):\n"
+        "        return [ReplyHandler]\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_mofox_upstream_receiver_routes_a_managed_plugin_reply(tmp_path: Path) -> None:
+    """Exercise the pinned Neo-MoFox receiver and plugin loader."""
+
+    _write_bridge_plugin(tmp_path)
+    engine = MoFoxHeadlessEngine(tmp_path, {})
+    sent: list[str] = []
+
+    async def emit(text: str) -> None:
+        sent.append(text)
+
+    event = _event().model_copy(
+        update={"message": Message(segments=(Segment(type="text", data={"text": "/bridge_probe"}),))}
+    )
+    try:
+        await engine.start()
+        await engine.process(event, emit)
+    finally:
+        await engine.close()
+
+    assert sent == ["mofox bridge reply"]
+
+
 class FakeClient:
     def __init__(self) -> None:
         self.sent: list[object] = []

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -39,8 +39,8 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
         ("agent", "agent-v0.1.0a9"),
-        ("runtime-astrbot", "runtime-astrbot-v0.1.0a6"),
-        ("runtime-mofox", "runtime-mofox-v0.1.0a5"),
+        ("runtime-astrbot", "runtime-astrbot-v0.1.0a7"),
+        ("runtime-mofox", "runtime-mofox-v0.1.0a6"),
     ],
 )
 def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1583,7 +1583,7 @@ requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a6"
+version = "0.1.0a7"
 source = { editable = "packages/runtime-astrbot" }
 dependencies = [
     { name = "astrbot" },
@@ -1598,7 +1598,7 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-runtime-mofox"
-version = "0.1.0a5"
+version = "0.1.0a6"
 source = { editable = "packages/runtime-mofox" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Summary
- make the AstrBot child expose its private workspace import root so projected plugins load through AstrBot's official plugin manager
- add locked-upstream AstrBot and Neo-MoFox regressions that load minimal projected plugins and route replies through the Liteyuki action sink
- release the corrected bridge packages as runtime-astrbot 0.1.0a7 and runtime-mofox 0.1.0a6

## Validation
- uv run ruff check packages/runtime-astrbot packages/runtime-mofox tests/test_release_v7.py
- uv lock --check
- uv run pytest packages/runtime-astrbot/tests packages/runtime-mofox/tests tests/test_release_v7.py -q
- git diff --check