### PR TITLE
release: prepare v7.0.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 7.0.0b1 - 2026-08-12
 
 - introduced runtime IPC protocol v5 with a kernel-originated, capability-gated
   control request for source-scoped native Agent history deletion;

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ LiteyukiBot v6 plugins run in supervised child runtimes.
 The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
 line for v6 and is not merged wholesale into v7.
 
-The current source pre-release identity is `liteyukibot-v7==7.0.0a17`. Kernel stabilization,
-the first bounded compatibility phase, and the first-party plugin foundation
-are complete. Runtime protocol v5 remains an alpha contract and may change
-under ADR 0011 before the first stable release.
+The current Beta1 identity is `liteyukibot-v7==7.0.0b1`. Kernel stabilization,
+the bounded compatibility phase, and the first-party plugin foundation are
+complete. Runtime protocol v5 is a Beta1 contract and remains subject to
+normal pre-7.0 compatibility evolution.
 
 ## Current Foundation
 

--- a/docs/beta1.md
+++ b/docs/beta1.md
@@ -19,21 +19,21 @@ liteyuki check
 ```
 
 Install optional runtime distributions in the same isolated tool environment
-at install time. For the supported native OneBot v11 path, use the versions
-listed in the release notes:
+at install time. The Beta1 native OneBot v11 pair is
+`liteyukibot-v7-runtime-adapter==0.1.0a2` and
+`liteyukibot-v7-adapter-onebot==0.1.0a1`:
 
 ```bash
 uv tool install --python 3.14 --force \
-  --with "liteyukibot-v7-runtime-adapter==RELEASE_VERSION" \
-  --with "liteyukibot-v7-adapter-onebot==RELEASE_VERSION" \
+  --with "liteyukibot-v7-runtime-adapter==0.1.0a2" \
+  --with "liteyukibot-v7-adapter-onebot==0.1.0a1" \
   "liteyukibot-v7==7.0.0b1"
 ```
 
-`RELEASE_VERSION` is intentionally a placeholder: each separately distributed
-runtime and adapter has its own version. Do not substitute an arbitrary latest
-version. The release notes name the tested root/runtime/adapter set. Project
-maintainers may instead add the same requirements to their project with `uv
-add`, then invoke `uv run liteyuki ...`.
+Each separately distributed runtime has its own version. Do not substitute an
+arbitrary latest version; use the tested set named here or in the release
+notes. Project maintainers may instead add the same requirements to their
+project with `uv add`, then invoke `uv run liteyuki ...`.
 
 The repository CI already builds the root wheel, installs it via an isolated
 `uv tool` directory, and runs `version`, non-interactive `init`, and `check` on

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -44,7 +44,7 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0a17` | `pyproject.toml` | `v7.0.0a17` |
+| `liteyukibot-v7==7.0.0b1` | `pyproject.toml` | `v7.0.0b1` |
 | `liteyukibot-v7-permissions==0.2.0a2` | `packages/permissions` | `permissions-v0.2.0a2` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |
@@ -67,7 +67,7 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0a17`;
+1. `v7.0.0b1`;
 2. `permissions-v0.2.0a2`;
 3. `commands-v0.2.0a2`;
 4. `resources-v0.1.0a2`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0a17"
+version = "7.0.0b1"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -26,7 +26,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0a17"),
+        ("root", "v7.0.0b1"),
         ("permissions", "permissions-v0.2.0a2"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),

--- a/uv.lock
+++ b/uv.lock
@@ -1397,7 +1397,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0a17"
+version = "7.0.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Beta1 Release Slice

Prepares the merged root source for the immutable `v7.0.0b1` release tag.

## Contract And Release Impact
- promotes the root package identity from `7.0.0a17` to `7.0.0b1`
- records the tested native OneBot v11 runtime/adapter pair in the public Beta1 installation path
- updates the release identity table, tag order, changelog, and lockfile
- no runtime protocol, configuration-schema, or migration behavior changes in this PR

## Validation
- uv run python scripts/check_release.py --tag v7.0.0b1
- uv run pytest tests/test_release_v7.py -q
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv run python -m scripts.run_tool_install_smoke
- uv build --out-dir dist/beta1-root --clear
- uv lock --check
- git diff --check

The release tag and PyPI upload remain blocked until this PR is merged and its full CI matrix succeeds.