### PR TITLE
fix(release): install MoFox upstream during publish verification

### DIFF
--- a/.github/workflows/publish-plugins.yaml
+++ b/.github/workflows/publish-plugins.yaml
@@ -73,8 +73,12 @@ jobs:
       - name: Verify plugin wheel with published dependencies
         run: |
           wheel="$(find dist/release -maxdepth 1 -name '*.whl' -print -quit)"
+          requirements=(--with "$wheel")
+          if [[ "${{ steps.release.outputs.package }}" == "runtime-mofox" ]]; then
+            requirements+=(--with "neo-mofox @ git+https://github.com/MoFox-Studio/Neo-MoFox.git@e2ee2ff73b494428bbdfd983c7569c6f074a9c76")
+          fi
           uv run --no-project --python 3.14 python scripts/run_isolated_install.py \
-            --with "$wheel" --verifier "${{ steps.release.outputs.verifier }}" -- \
+            "${requirements[@]}" --verifier "${{ steps.release.outputs.verifier }}" -- \
             --expected-version "${{ steps.release.outputs.version }}"
       - name: Publish plugin distribution
         run: uv publish dist/release/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   bridge runtimes.
 - made the locked Neo-MoFox upstream an explicit installation prerequisite,
   because PyPI rejects direct VCS dependencies in published wheel metadata.
+- made the MoFox release verifier install that fixed upstream requirement before
+  exercising the published runtime wheel.
 - added `liteyukibot-v7-runtime-adapter`, a separately published Python
   platform-adapter host with managed-generation and entry-point boundaries;
 - added `liteyukibot-v7-adapter-onebot`, a pure-Python OneBot v11 HTTP Post

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -58,7 +58,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-agent-resolver==0.1.0a1` | `packages/agent-resolver` | `agent-resolver-v0.1.0a1` |
 | `liteyukibot-v7-agent==0.1.0a9` | `packages/agent` | `agent-v0.1.0a9` |
 | `liteyukibot-v7-runtime-astrbot==0.1.0a7` | `packages/runtime-astrbot` | `runtime-astrbot-v0.1.0a7` |
-| `liteyukibot-v7-runtime-mofox==0.1.0a7` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a7` |
+| `liteyukibot-v7-runtime-mofox==0.1.0a8` | `packages/runtime-mofox` | `runtime-mofox-v0.1.0a8` |
 
 `scripts/check_release.py` owns this mapping. Both publish workflows reject a
 tag that does not exactly match the selected source version and distribution.
@@ -81,7 +81,7 @@ Push and wait for each release before creating the next tag:
 12. `agent-resolver-v0.1.0a1`.
 13. `agent-v0.1.0a9` (requires `commands-v0.2.0a2`).
 14. `runtime-astrbot-v0.1.0a7`.
-15. `runtime-mofox-v0.1.0a7`.
+15. `runtime-mofox-v0.1.0a8`.
 
 Each plugin workflow builds only its selected project, installs that wheel in a
 temporary uv environment against already published dependencies, exercises its

--- a/packages/runtime-mofox/pyproject.toml
+++ b/packages/runtime-mofox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-mofox"
-version = "0.1.0a7"
+version = "0.1.0a8"
 description = "Headless Neo-MoFox agent runtime for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -40,7 +40,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
         ("agent", "agent-v0.1.0a9"),
         ("runtime-astrbot", "runtime-astrbot-v0.1.0a7"),
-        ("runtime-mofox", "runtime-mofox-v0.1.0a7"),
+        ("runtime-mofox", "runtime-mofox-v0.1.0a8"),
     ],
 )
 def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1316,7 +1316,7 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-runtime-mofox"
-version = "0.1.0a7"
+version = "0.1.0a8"
 source = { editable = "packages/runtime-mofox" }
 dependencies = [
     { name = "liteyukibot-v7" },


### PR DESCRIPTION
## Beta1 MoFox publication repair

`runtime-mofox-v0.1.0a7` retained the correct publishable wheel metadata but its generic publish workflow did not install Neo-MoFox before running the MoFox verifier. This PR passes the same fixed upstream requirement used by the local lifecycle verifier only when the selected package is `runtime-mofox`.

The runtime is incremented to `0.1.0a8`; both prior failed tags remain immutable. Other plugin verification paths remain unchanged.

Verification:
- built `liteyukibot-v7-runtime-mofox==0.1.0a8`
- ran `scripts/run_isolated_install.py` with the built wheel plus the pinned Neo-MoFox requirement
- `pytest tests/test_release_v7.py packages/runtime-mofox/tests -q` (36 passed)
- `ruff check packages/runtime-mofox scripts tests/test_release_v7.py`
- `uv lock --check`