### PR TITLE
docs: refresh v7 guides and directory ownership

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,14 @@
+# GitHub Automation
+
+`workflows/` contains CI, Docker build validation, and PyPI Trusted Publishing
+workflows for the `v7` branch and package-specific immutable tags.
+
+- `ci.yaml` is the cross-platform quality and installation matrix.
+- `docker.yaml` validates the root image for relevant pull requests.
+- `publish.yml` publishes the kernel distribution from `v7.*` tags.
+- `publish-plugins.yaml` publishes first-party packages from package-specific
+  tags.
+
+Keep workflow changes synchronized with `scripts/check_release.py` and
+`docs/development/releasing.md`. Do not weaken isolated-install verification or
+replace Trusted Publishing with repository secrets.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,14 @@
+# Workflows
+
+These workflows are the executable CI and publishing contracts for v7.
+
+- `ci.yaml` runs cross-platform quality, package builds, isolated installs, and
+  the NoneBot contract.
+- `docker.yaml` builds the root image on relevant pull requests.
+- `publish.yml` releases the root package from an immutable `v7.*` tag.
+- `publish-plugins.yaml` releases first-party packages from immutable
+  package-specific tags.
+
+Keep tag patterns, trusted-publisher environments, `scripts/check_release.py`,
+and `docs/development/releasing.md` synchronized. Never add publishing tokens
+or weaken isolated wheel verification.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing To LiteyukiBot v7
+
+## Scope And Branches
+
+`main` is the LiteyukiBot v6 maintenance line. v7 work targets the `v7` branch.
+Start a feature or fix branch from an up-to-date `v7`; do not merge v6 source
+or dependencies into v7 wholesale.
+
+Keep one change focused on one kernel contract, package, runtime, test surface,
+or documentation concern. The kernel owns the portable models, runtime IPC,
+configuration, and lifecycle. Framework SDK objects stay in their separately
+published child-runtime packages.
+
+## Development Environment
+
+Use CPython 3.14 and uv:
+
+```bash
+uv sync --locked --all-packages --extra onebot --extra satori
+uv run liteyuki check
+```
+
+`uv.lock` is the repository lockfile. Update it only when dependency metadata
+changes, and keep every workspace package resolvable with the root project.
+
+## Validation
+
+Run the smallest relevant checks while editing, then the repository quality
+suite before opening a pull request:
+
+```bash
+uv run ruff check src tests scripts examples packages
+uv run mypy
+uv run pytest
+uv build
+uv build --all-packages --out-dir dist/workspace --clear
+```
+
+Changes to package metadata, entry points, release validation, runtime hosts,
+or package integration must also run the relevant `scripts/run_*_install.py`
+verifier. The complete CI sequence is defined in `.github/workflows/ci.yaml`.
+Do not commit `dist/`, caches, local workspaces, secrets, generated profiles,
+or temporary research artifacts.
+
+## Contracts And Tests
+
+Update the relevant accepted ADR, architecture guide, or package README when a
+public Event, Action, runtime IPC, configuration, service, or plugin contract
+changes. Keep protocol models JSON-safe and versioned. A child runtime must use
+the shared `RuntimeClient`, declare capabilities explicitly, and never create a
+runtime-to-runtime transport.
+
+Add or update focused tests under `tests/` or the owning `packages/*/tests/`
+directory. Test real package entry points and child-runtime behavior where a
+change crosses a process or installation boundary.
+
+## Pull Requests And Releases
+
+Open pull requests against `v7`. Keep stacks short; merge a green independent
+pull request promptly and never let a Stack grow beyond 20 layers. PR text
+should state the owned boundary, validation commands, and any configuration or
+release impact.
+
+Use squash merge after required checks and review pass, then delete the merged
+feature branch. Do not move or reuse package tags. Published distributions use
+the package-specific release process in
+[`docs/development/releasing.md`](docs/development/releasing.md).
+
+## Documentation
+
+The root README describes current user-facing installation and package usage.
+`docs/` records maintained contracts and operations. Directory README files
+describe how to develop their contents. Keep completed scratch plans in ignored
+`tmp/`; do not turn them into compatibility or release commitments.

--- a/README.md
+++ b/README.md
@@ -1,183 +1,161 @@
-# LiteyukiBot v7
+<div align="center">
 
-LiteyukiBot v7 is a protocol-neutral chatbot kernel for CPython 3.14. Native
-plugins run in the core process; separately distributed framework hosts and
-LiteyukiBot v6 plugins run in supervised child runtimes.
+[![][banner]][liteyuki-link]
+<h2><a href="https://bot.liteyuki.org"><span style="color: #a2d8f4">LiteyukiBot</span> <span style="color: #d0e9ff">v7</span></a></h2>
+<h4><span style="color: #a2d8f4">Protocol-neutral, multi-runtime chatbot kernel</span></h4>
 
-The `v7` branch is a clean rewrite. The `main` branch remains the maintenance
-line for v6 and is not merged wholesale into v7.
+[![][Liteyuki7]][liteyuki-link]
+[![][Python3.14]][python-link]
+[![][Usage]][usage-link]
+[![][Repo]][repo-link]
+[![][Github]][github-link]
 
-The current Beta1 identity is `liteyukibot-v7==7.0.0b1`. Kernel stabilization,
-the bounded compatibility phase, and the first-party plugin foundation are
-complete. Runtime protocol v5 is a Beta1 contract and remains subject to
-normal pre-7.0 compatibility evolution.
+</div>
 
-## Current Foundation
+## About
 
-- immutable TOML/JSON configuration with ordered includes, environment
-  overrides, and CLI overrides;
-- Yukilog 1.x facade backed by Loguru, including structured child logs;
-- native plugin entry points, async lifecycle hooks, private storage, managed
-  tasks, and versioned services;
-- bounded protocol-neutral event/action dispatch with per-conversation order;
-- authenticated framed JSON IPC and supervised subprocess runtimes;
-- runtime-host discovery plus a deliberately bounded v6 compatibility shim;
-- local authenticated CLI control and an optional loopback-only HTTP status API.
-- layered resource packs for language catalogs, functions, and future static
-  assets, with workspace packs overriding built-in and enabled-plugin content;
-- read-only kernel status plus separately distributable capability, command,
-  resource-management, profile, help, and protected-status plugins.
+LiteyukiBot v7 is a CPython 3.14 chatbot kernel. It owns configuration,
+native-plugin lifecycle, routing, permissions, logging, and local runtime IPC.
+Framework integrations run as separately installed supervised child runtimes;
+they exchange frozen Event and Action models with the kernel rather than SDK
+objects.
 
-## Requirements
+The default branch is the maintained LiteyukiBot v6 line. This `v7` branch is
+an independent rewrite. Its current published release is
+`liteyukibot-v7==7.0.0b1`.
 
-- CPython 3.14+
-- [uv](https://docs.astral.sh/uv/)
-- network access for uv to resolve PyPI dependencies
+## Features
 
-Yukilog 1.x is installed from PyPI; no sibling checkout is required.
-The v7 kernel distribution on PyPI is named `liteyukibot-v7` and provides the
-`liteyukibot` namespace. The separately installed v6 runtime provides the
-`liteyuki` compatibility namespace.
+- interactive or non-interactive project initialization through `liteyuki`;
+- immutable TOML/JSON configuration with includes, environment variables, CLI
+  overrides, provenance inspection, encrypted runtime secrets, and recovery
+  material for configuration upgrades;
+- native plugins with explicit entry points, lifecycle hooks, services,
+  managed tasks, private storage, resource packs, and localized text;
+- authenticated loopback IPC, child-runtime supervision, per-conversation
+  event ordering, bounded concurrency, and routed protocol-neutral actions;
+- retained and verifiable runtime plugin generations with source indexes,
+  rollback, disable/enable, and garbage collection commands;
+- first-party command, permission, resource, profile, essential-command, and
+  agent packages;
+- bounded LiteyukiBot v6 compatibility and separate NoneBot2, native OneBot
+  v11, AstrBot, and Neo-MoFox runtime packages.
 
-## Tool Installation
+## Install And Run
 
-Install the v7 CLI into uv's isolated tool environment:
+Requirements:
+
+- CPython 3.14 or later;
+- [uv][uv-link].
+
+Install the command-line tool and create a workspace:
 
 ```bash
 uv tool install --python 3.14 liteyukibot-v7
-liteyuki init
-liteyuki run
+mkdir my-bot
+liteyuki --workspace my-bot init
+liteyuki --workspace my-bot check
+liteyuki --workspace my-bot run
 ```
 
-The commands operate on the current directory by default. Use
-`liteyuki --workspace PATH ...` to select another project. `liteyukibot` and
-`ly` are equivalent executable aliases. Upgrade only the v7 tool with:
+`liteyukibot`, `liteyuki`, and `ly` are equivalent command names. Use
+`init --non-interactive --locale en-US` for automation. The generated
+`liteyuki.toml` is the workspace configuration; see
+[configuration operations](docs/configuration.md) for secrets, profiles,
+configuration precedence, and recovery procedures.
+
+To work from a checkout instead of a tool installation:
 
 ```bash
-uv tool upgrade --python 3.14 liteyukibot-v7
-```
-
-This does not replace a separately installed v6 `liteyukibot` distribution.
-
-```bash
-uv sync --locked
+uv sync --locked --all-packages
+uv run liteyuki init
 uv run liteyuki check
 uv run liteyuki run
 ```
 
-Optional kernel integrations are installed explicitly:
+## Packages
 
-```bash
-uv sync --extra yaml
-uv sync --extra http
-```
+The kernel package is `liteyukibot-v7`. Optional features are separate PyPI
+packages and must be installed into the same environment before they are
+enabled in `liteyuki.toml`.
 
-Framework hosts are independent packages. Install NoneBot2 with an adapter:
+| Package | Current responsibility |
+| --- | --- |
+| `liteyukibot-v7-permissions` | Exact-principal capability policy service. |
+| `liteyukibot-v7-commands` | Protocol-neutral command router and schemas. |
+| `liteyukibot-v7-resources` | Declarative resource and authorization boundary. |
+| `liteyukibot-v7-profile` | Persistent per-bot nickname and language profiles. |
+| `liteyukibot-v7-essentials` | Help and protected status commands. |
+| `liteyukibot-v7-functions` | v6 `.lyf`, `.lyfunction`, and `.mcfunction` executor. |
+| `liteyukibot-v7-runtime-nonebot` | Supervised NoneBot2 runtime host. |
+| `liteyukibot-v7-runtime-adapter` | Supervised Python platform-adapter host. |
+| `liteyukibot-v7-adapter-onebot` | Native OneBot v11 HTTP Post and HTTP API adapter. |
+| `liteyukibot-v7-runtime-v6` | Bounded LiteyukiBot v6 compatibility runtime. |
+| `liteyukibot-v7-agent-resolver` | Declarative agent module and tool resolver. |
+| `liteyukibot-v7-agent` | OpenAI-compatible native agent runtime. |
+| `liteyukibot-v7-runtime-astrbot` | Headless AstrBot agent runtime. |
+| `liteyukibot-v7-runtime-mofox` | Headless Neo-MoFox agent runtime. |
 
-```bash
-uv add "liteyukibot-v7-runtime-nonebot[onebot]"
-# or: uv add "liteyukibot-v7-runtime-nonebot[satori]"
-```
-
-Install the Python platform-adapter host independently. It contains no platform
-SDK; protocol and platform adapters are separately published packages:
-
-```bash
-uv add liteyukibot-v7-runtime-adapter
-uv add liteyukibot-v7-adapter-onebot
-```
-
-Install bounded v6 compatibility when legacy plugins are required:
-
-```bash
-uv add "liteyukibot-v7-runtime-v6"
-```
-
-Install the v6 resource-function executor only when workspace resource packs
-contain `.lyf`, `.lyfunction`, or `.mcfunction` files:
-
-```bash
-uv add "liteyukibot-v7-functions"
-```
-
-It preserves the v6 function language but does not grant resource files shell
-or adapter API access by itself; callers must explicitly provide those
-capabilities.
-
-Install the Essentials command layer with:
-
-```bash
-uv add "liteyukibot-v7-essentials==0.2.0a3"
-```
-
-This resolves `liteyukibot-v7-commands` and
-`liteyukibot-v7-permissions`; enable all three plugin IDs in configuration.
-
-The optional profile layer adds persistent per-bot user nickname and language
-preferences. Install `liteyukibot-v7-profile` to resolve resources, then enable
-`liteyukibot.resources` and `liteyukibot.profile` before Essentials. Profile is
-a business plugin: its SQLite database is private to the plugin, and resources
-only supplies the declaration, command, and authorization boundary.
-
-Create a project-local configuration with `uv run liteyuki init`; use
-`liteyuki.example.toml` as a configuration reference. CLI overrides must precede
-the subcommand, for example:
-
-```bash
-uv run liteyuki --config local.toml --set logging.level=DEBUG check
-```
-
-Initialization, encrypted runtime secrets, upgrade recovery, and configuration
-provenance are documented in [docs/configuration.md](docs/configuration.md).
-`liteyuki init` opens a full-screen setup wizard; use `--non-interactive` for
-automation and `--locale auto|zh-CN|en-US` to control its language.
+Read the package README in [`packages/`](packages/README.md) before enabling a
+package. The kernel does not install framework integrations implicitly.
 
 ## Docker
 
-The v7 image can be built locally with the optional YAML, HTTP, NoneBot,
-OneBot, Satori, and v6 compatibility runtime packages. It runs as a non-root user. GHCR
-publication is currently paused; the Docker workflow validates builds without
-pushing.
+Build the current image locally:
 
 ```bash
 docker build -t liteyukibot:v7-local .
 docker run --rm liteyukibot:v7-local version
 ```
 
-When `/app/liteyuki.toml` is absent, the container creates the versioned default
-template once. Mount a configuration at that path to control a deployment, and
-persist `/app/data`, `/app/cache`, and `/app/plugins`.
+The image runs as a non-root user. Mount `/app/data`, `/app/cache`, and
+`/app/plugins` for persistent state, then provide `/app/liteyuki.toml` for a
+configured deployment.
 
-## Development
+## Services And Support
 
-```bash
-uv sync --locked --all-packages
-uv run ruff check src tests scripts examples packages
-uv run mypy
-uv run pytest
-uv build
-uv build --all-packages --out-dir dist/workspace --clear
-uv build --project examples/native-plugin --out-dir dist/examples
-uv build --project examples/custom-runtime --out-dir dist/examples
-uv run python -m scripts.run_developer_kit_install
-uv run python -m scripts.run_permissions_install
-uv run python -m scripts.run_commands_install
-uv run python -m scripts.run_resources_install
-uv run python -m scripts.run_functions_install
-uv run python -m scripts.run_profile_install
-uv run python -m scripts.run_essentials_install
-uv run python -m scripts.run_nonebot_runtime_install
-uv run python -m scripts.run_adapter_runtime_install
-```
+Current installation, configuration, compatibility, and release boundaries are
+documented in this repository. Report reproducible defects or documentation
+errors through the [GitHub repository][github-link], including the installed
+package versions, operating system, Python version, and the minimal command or
+configuration that reproduces the result. Do not include vault passwords,
+tokens, or message payloads in public reports.
 
-The architecture overview is documented in `docs/architecture/v7.md`; accepted
-architecture contracts are indexed in `docs/adr/README.md`; the v6 compatibility
-boundary is documented in `docs/migration-v6.md`.
+## Documentation
 
-Release maintainers should follow `docs/development/releasing.md`.
+- [Configuration operations](docs/configuration.md)
+- [v7 architecture](docs/architecture/v7.md)
+- [Beta1 contract and support boundary](docs/beta1.md)
+- [v6 compatibility](docs/migration-v6.md)
+- [Native plugin development](docs/development/native-plugins.md)
+- [Custom runtime development](docs/development/custom-runtimes.md)
+- [Contributor guide](CONTRIBUTING.md)
+- [Release procedure](docs/development/releasing.md)
 
-Plugin and runtime authors should start with the installable examples and their
-focused guides:
+## References
 
-- `examples/native-plugin` and `docs/development/native-plugins.md`;
-- `examples/custom-runtime` and `docs/development/custom-runtimes.md`.
+- [NoneBot](https://nonebot.dev/) informs the separately packaged NoneBot
+  runtime boundary.
+- [AstrBot](https://github.com/AstrBotDevs/AstrBot) and
+  [Neo-MoFox](https://github.com/MoFox-Studio/Neo-MoFox) inform their respective
+  headless agent-runtime integrations.
+
+## Other
+
+This repository is a uv workspace containing the kernel, first-party packages,
+examples, tests, developer tools, documentation, and release workflows.
+Directory-level development guidance is provided by each directory's README.
+
+[Liteyuki7]: https://img.shields.io/badge/LiteyukiBot-7.0.0b1-blue?style=for-the-badge
+[Python3.14]: https://img.shields.io/badge/Python-3.14+-blue?style=for-the-badge
+[Usage]: https://img.shields.io/badge/Usage-CLI-blue?style=for-the-badge
+[Repo]: https://img.shields.io/badge/Distribution-PyPI-blue?style=for-the-badge
+[Github]: https://img.shields.io/badge/GitHub-Repository-blue?style=for-the-badge
+[banner]: https://socialify.git.ci/LiteyukiStudio/LiteyukiBot/image?description=1&font=Source+Code+Pro&forks=1&issues=1&name=1&owner=1&pattern=Floating+Cogs&pulls=1&stargazers=1&theme=Auto
+
+[python-link]: https://www.python.org/
+[uv-link]: https://docs.astral.sh/uv/
+[usage-link]: docs/configuration.md
+[liteyuki-link]: https://github.com/LiteyukiStudio/LiteyukiBot
+[repo-link]: https://pypi.org/project/liteyukibot-v7/
+[github-link]: https://github.com/LiteyukiStudio/LiteyukiBot

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,15 @@
+# Benchmarks
+
+`v7-alpha-reference.json` is the recorded pre-Beta performance reference for
+kernel startup, event throughput, latency, and peak RSS. It is an auditable
+baseline, not an automatic pass/fail threshold.
+
+Generate a local measurement from the repository root:
+
+```bash
+uv run python scripts/benchmark_v7.py --output benchmark.json
+```
+
+`benchmark.json` is ignored. Only update the tracked reference when its source
+environment and measurement rationale are documented in
+`docs/performance-v7.md`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,17 @@
+# Docker Support
+
+The root `Dockerfile` builds the v7 runtime image. This directory is reserved
+for Docker-specific support files when the image needs them; it currently has
+no additional build context.
+
+The image is validated by `.github/workflows/docker.yaml`. Build it locally
+from the repository root:
+
+```bash
+docker build -t liteyukibot:v7-local .
+docker run --rm liteyukibot:v7-local version
+```
+
+Do not add secrets, workspace data, profiles, or plugin bundles to image
+layers. The image runs as a non-root user and exposes `/app/data`,
+`/app/cache`, and `/app/plugins` as persistent volumes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,18 @@
+# Documentation
+
+`docs/` contains maintained v7 contracts and operational guidance. Write facts
+that match the current implementation and tested release state; do not use this
+tree for scratch plans or promises about unimplemented work.
+
+- `architecture/` describes the current system boundary and lifecycle.
+- `adr/` contains accepted architecture decisions; superseded decisions remain
+  for historical reasoning rather than being rewritten.
+- `development/` contains contributor, plugin-author, runtime-author, and
+  release-maintainer guidance.
+- `archive/` holds completed historical records that remain useful for design
+  or release archaeology.
+- top-level documents cover configuration, compatibility, performance, and the
+  current Beta1 support contract.
+
+Keep relative Markdown links valid. Contract changes need focused tests in the
+same pull request and a corresponding documentation update.

--- a/docs/adr/0011-pre-stable-protocol-policy.md
+++ b/docs/adr/0011-pre-stable-protocol-policy.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-v7 is in rapid alpha development. Treating every wire or schema correction as
+v7 is in rapid pre-stable development. Treating every wire or schema correction as
 a permanent compatibility event would create artificial protocol versions such
 as v20 or v99 before the design has reached a stable release. It would also
 force the project to maintain experiments that have not been released as stable
@@ -37,7 +37,7 @@ Protocol numbering is intentionally bounded:
   used.
 
 Retaining compatibility with v1, v2, or an earlier v3 shape is optional during
-alpha. It is kept only when its implementation and testing cost remain low and
+the pre-stable period. It is kept only when its implementation and testing cost remain low and
 it does not distort the intended architecture. Removing such compatibility is
 an ordinary reviewed change, not a major-version event.
 
@@ -53,5 +53,5 @@ generation requires a documented large redesign decision before stable v7.
 
 Accepted ADRs continue to record design intent and testable behavior, but their
 compatibility language does not override this pre-stable policy. Review still
-requires evidence and explicit documentation; instability is not permission for
-undocumented wire drift.
+requires evidence and explicit documentation; pre-stable status is not
+permission for undocumented wire drift.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,6 @@
+# Architecture Documentation
+
+This directory describes the current v7 system boundary and operational model.
+`v7.md` is the maintained kernel, plugin, runtime, event, action, and
+performance overview. Keep it synchronized with accepted ADRs and current
+implementation; do not use it as a proposal log.

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -139,12 +139,12 @@ protocol-v3 Action direction, ADR 0022 adds protocol-v4 delivery tracing, and
 ADR 0023 adds protocol-v5 kernel controls.
 ADR 0008 defines their v6 message-plugin mapping,
 ADR 0009 defines the NoneBot OneBot/Satori adapter boundary, and ADR 0010
-defines the developer conformance helpers. ADR 0011 governs rapid pre-stable
-iteration: v3 remains the direct-edit baseline, and a cross-cutting redesign
+defines the developer conformance helpers. ADR 0011 governs pre-stable
+iteration: v3 remains the direct-edit baseline, a cross-cutting redesign
 consumed v4, and the native Agent history control consumed v5. ADR 0012
 defines the process-local kernel status service without changing runtime IPC.
-No alpha protocol version may exceed v5. Existing v1/v2 support is tested but
-is not a compatibility promise before the first stable v7 release.
+No pre-stable protocol version may exceed v5. Existing v1/v2 support is tested
+but is not a compatibility promise before the first stable v7 release.
 
 ## Operations
 
@@ -174,7 +174,7 @@ and published-install matrix are documented in
 
 ## Current Release State
 
-The current source pre-release is `liteyukibot-v7==7.0.0a17`. The kernel,
+The current source pre-release is `liteyukibot-v7==7.0.0b1`. The kernel,
 bounded v6 compatibility, separately published runtime boundaries, and the
 first-party plugin foundation are complete. Resources and profile remain
 optional business plugins; their storage and migration ownership does not

--- a/docs/beta1.md
+++ b/docs/beta1.md
@@ -1,16 +1,17 @@
 # LiteyukiBot v7 Beta1 Contract
 
-Beta1 will publish `liteyukibot-v7==7.0.0b1`. It is a single-host,
+Beta1 is published as `liteyukibot-v7==7.0.0b1`. It is a single-host,
 protocol-neutral integration release: the kernel owns configuration, routing,
 permissions, deployment state, and IPC; platform/framework integrations run in
 supervised child processes and never exchange SDK objects with one another.
 
-This document is the release-facing contract. The implementation checklist,
-open decisions, PR rules, and release gates live in `tmp/beta1-roadmap.md`.
+This document is the release-facing contract. The completed implementation
+checklist and release working notes were intentionally kept outside the tracked
+documentation tree and are not part of the maintained contract.
 
 ## Installation
 
-After the Beta1 wheels are published, install a minimal local workspace with:
+Install a minimal local workspace with:
 
 ```bash
 uv tool install --python 3.14 "liteyukibot-v7==7.0.0b1"

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,9 @@
+# Development Documentation
+
+This directory contains maintained guides for plugin authors, custom-runtime
+authors, and release maintainers. Keep commands executable against the current
+workspace and describe only implemented contracts.
+
+- `native-plugins.md` describes the in-process plugin boundary.
+- `custom-runtimes.md` describes supervised child-runtime integration.
+- `releasing.md` describes immutable package publishing.

--- a/docs/development/custom-runtimes.md
+++ b/docs/development/custom-runtimes.md
@@ -84,9 +84,9 @@ are negotiated exactly rather than inferred.
 Protocol v5 additionally permits the kernel to send an explicitly defined
 control request to a child declaring `runtime.controls.execute`. It is not a
 generic RPC surface. The protocol is pre-stable: v5 is the current development
-target and may change without backwards-compatibility shims during alpha. No
-pre-stable version will exceed v5.
-Pin the LiteyukiBot alpha version used to build and test an external runtime.
+target and may change without backwards-compatibility shims before the stable
+v7 release. No pre-stable version will exceed v5. Pin the LiteyukiBot version
+used to build and test an external runtime.
 
 ## Testing
 

--- a/docs/development/native-plugins.md
+++ b/docs/development/native-plugins.md
@@ -142,7 +142,7 @@ The first-party `liteyukibot-v7-permissions` package provides
 `PermissionService` from `liteyukibot_permissions`, declare the service in
 their manifest, and call `allows(event, permission)`.
 
-The alpha implementation maps exact runtime, bot, and actor principals to
+The pre-stable implementation maps exact runtime, bot, and actor principals to
 static named roles and exact capability tokens configured under
 `plugins.config."liteyukibot.permissions"`. Every event has `public`;
 `resolve(event)` exposes a frozen diagnostic snapshot and unknown capabilities

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,20 @@
+# Examples
+
+Examples are small installable packages that exercise public extension points.
+They are not templates copied into production unchanged.
+
+- `native-plugin/` demonstrates a native plugin entry point, EventBus cleanup,
+  and protocol-neutral replies.
+- `custom-runtime/` demonstrates a protocol-v5 child runtime using the shared
+  `RuntimeClient` and the supervisor-owned lifecycle.
+
+Keep examples minimal, dependency-bounded, and aligned with the public guides
+in `docs/development/`. Build them from the repository root:
+
+```bash
+uv build --project examples/native-plugin --out-dir dist/examples
+uv build --project examples/custom-runtime --out-dir dist/examples
+```
+
+When a public extension contract changes, update the relevant example and its
+build coverage in CI.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,36 @@
+# First-Party Packages
+
+Each immediate child directory is an independently buildable uv workspace
+package. Package code owns its framework integration or business capability;
+the root `src/liteyukibot/` package remains the kernel and must not import these
+packages directly.
+
+## Package Classes
+
+- `permissions`, `commands`, `resources`, `profile`, and `essentials` are
+  native plugin/service packages.
+- `functions` is the separate executor for documented v6 resource functions.
+- `runtime-*` packages are supervised child-runtime hosts.
+- `adapter-onebot` is a platform adapter loaded by `runtime-adapter`.
+- `agent` and `agent-resolver` provide the native agent runtime and its
+  declarative resolver.
+
+## Development Rules
+
+Keep a package's public entry points, metadata, tests, README, and resource
+files together. Use a package-local `pyproject.toml` for dependencies and entry
+points. A package must depend on the published kernel contract it consumes;
+avoid imports into another first-party package unless that dependency is
+declared in its metadata.
+
+Run focused tests first, then validate the workspace:
+
+```bash
+uv run pytest packages/<package>/tests
+uv build --project packages/<package>
+uv run python -m scripts.run_<package>_install
+```
+
+The exact install-verifier names are listed under `scripts/`. Release tags and
+published versions are controlled by `scripts/check_release.py` and
+`docs/development/releasing.md`.

--- a/packages/adapter-onebot/README.md
+++ b/packages/adapter-onebot/README.md
@@ -37,3 +37,10 @@ replies, image/record/video media, and adapter-specific segments into frozen
 LiteyukiBot messages, and executes `SendMessage` plus constrained `CallApi`
 actions through the configured OneBot HTTP API root. OneBot v12 is intentionally
 not part of this release.
+
+## Development
+
+Keep OneBot HTTP parsing, identity checks, and API conversion in this package;
+the adapter host owns child lifecycle and the kernel owns portable models.
+Run `uv run pytest packages/adapter-onebot/tests` and
+`uv run python -m scripts.run_onebot_adapter_install` after changes.

--- a/packages/agent-resolver/README.md
+++ b/packages/agent-resolver/README.md
@@ -3,3 +3,10 @@
 This package resolves declarative agent-module closures and exposes a bounded,
 searchable tool tree. It intentionally does not install packages, create
 environments, execute tools, or import agent frameworks.
+
+## Development
+
+Keep resolution declarative and side-effect free. Run
+`uv run pytest packages/agent-resolver/tests` and
+`uv build --project packages/agent-resolver` after changing package metadata or
+resolver contracts.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -23,3 +23,10 @@ handled by the kernel, sends one protocol-v5 control request to the native
 Agent child, and clears only the requesting source runtime, bot, and
 conversation. It never sends a model request and the permission audit contains
 no conversation content.
+
+## Development
+
+Keep model-provider state and agent execution in this runtime package. Tool
+authorization and invocation remain kernel-brokered. Run
+`uv run pytest packages/agent/tests` and
+`uv run python -m scripts.run_agent_install` after changes.

--- a/packages/commands/README.md
+++ b/packages/commands/README.md
@@ -4,8 +4,8 @@
 service and a protocol-neutral EventBus command router.
 
 The parser recognizes configurable non-empty prefixes, command names, aliases,
-and explicit argument/option schemas. Hierarchical subcommand routing remains a
-separate alpha step.
+and explicit argument/option schemas. Hierarchical subcommand routing is
+supported through canonical command paths.
 
 ```toml
 [plugins]
@@ -44,3 +44,10 @@ def echo(invocation):
 Quoting, escaping, `--name value`, `--name=value`, short aliases, flags,
 repeatable options, `--`, and conversion failures have platform-independent
 semantics. Parsing errors expose stable codes through `CommandParseError`.
+
+## Development
+
+Keep command parsing and routing protocol-neutral. Update parser tests for all
+new syntax or error behavior, then run
+`uv run pytest packages/commands/tests` and
+`uv run python -m scripts.run_commands_install`.

--- a/packages/essentials/README.md
+++ b/packages/essentials/README.md
@@ -21,3 +21,10 @@ language = "zh-CN"
 ```
 
 Supported languages are `zh-CN` (the default) and `en`.
+
+## Development
+
+Essentials is a command-service consumer and does not add kernel behavior.
+Keep visible text in its resource catalogs. Run
+`uv run pytest packages/essentials/tests` and
+`uv run python -m scripts.run_essentials_install` after changes.

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -12,3 +12,10 @@ access to adapter APIs or the local operating-system shell.
 
 The old v6 `eval` parsing is intentionally replaced by literal parsing. Values
 that are not literals remain strings, matching normal legacy variable lookup.
+
+## Development
+
+Preserve the explicit caller-supplied capability boundary; function files must
+not gain implicit shell or adapter access. Run
+`uv run pytest packages/functions/tests` and
+`uv run python -m scripts.run_functions_install` after changes.

--- a/packages/permissions/README.md
+++ b/packages/permissions/README.md
@@ -33,3 +33,9 @@ It has the same exact policy outcome and keeps a bounded in-memory audit
 snapshot available through `audit()`. Each record contains only the capability,
 principal tuple, component, event ID, allow/deny outcome, and stable reason;
 message content, API parameters, and tool arguments are never captured.
+
+## Development
+
+Permission decisions must remain exact-principal and fail closed. Keep audit
+records redacted, then run `uv run pytest packages/permissions/tests` and
+`uv run python -m scripts.run_permissions_install` after changes.

--- a/packages/profile/README.md
+++ b/packages/profile/README.md
@@ -6,3 +6,9 @@ provides `liteyukibot.profile@1` to native plugins.
 Records are keyed by exact `(runtime_id, bot_id, actor_id)` principals. The
 initial fields are `nickname` and `language`; storage lives entirely in this
 plugin's private SQLite database.
+
+## Development
+
+Keep persistence private to this package and key records by the full principal
+tuple. Run `uv run pytest packages/profile/tests` and
+`uv run python -m scripts.run_profile_install` after changes.

--- a/packages/resources/README.md
+++ b/packages/resources/README.md
@@ -8,3 +8,9 @@ The service owns resource registration, field validation, principal targeting,
 and capability checks. Resource providers own their data and persistence. The
 first-party profile plugin uses this contract without requiring resources to
 own a database or a kernel storage service.
+
+## Development
+
+Resources own declarations and authorization conventions, not provider data.
+Run `uv run pytest packages/resources/tests` and
+`uv run python -m scripts.run_resources_install` after changes.

--- a/packages/runtime-adapter/README.md
+++ b/packages/runtime-adapter/README.md
@@ -30,3 +30,9 @@ Install `liteyukibot-v7-adapter-onebot` for the first real protocol entry
 point, `onebot-v11`. It owns its HTTP Post callback listener and HTTP API
 client, and needs no NoneBot or Node runtime. OneBot v12 and Satori remain
 separately delivered packages.
+
+## Development
+
+Keep platform SDK objects inside adapter packages and child processes. Run
+`uv run pytest packages/runtime-adapter/tests` and
+`uv run python -m scripts.run_adapter_runtime_install` after changes.

--- a/packages/runtime-astrbot/README.md
+++ b/packages/runtime-astrbot/README.md
@@ -3,3 +3,9 @@
 This AGPL-3.0-or-later package runs AstrBot as an agent-only headless runtime.
 It owns an AstrBot workspace below its assigned runtime state directory and
 does not start AstrBot platform adapters or its dashboard.
+
+## Development
+
+Keep AstrBot APIs and projected plugin loading inside this child host. Run
+`uv run pytest packages/runtime-astrbot/tests` and
+`uv run python -m scripts.run_astrbot_runtime_install` after changes.

--- a/packages/runtime-mofox/README.md
+++ b/packages/runtime-mofox/README.md
@@ -18,3 +18,10 @@ For a tool environment, install both requirements in one command:
 ```shell
 uv tool install --with "neo-mofox @ git+https://github.com/MoFox-Studio/Neo-MoFox.git@e2ee2ff73b494428bbdfd983c7569c6f074a9c76" liteyukibot-v7-runtime-mofox
 ```
+
+## Development
+
+Keep Neo-MoFox APIs and projected plugin loading inside this child host. The
+fixed upstream requirement is an explicit verifier prerequisite, not published
+wheel metadata. Run `uv run pytest packages/runtime-mofox/tests` and
+`uv run python -m scripts.run_mofox_runtime_install` after changes.

--- a/packages/runtime-nonebot/README.md
+++ b/packages/runtime-nonebot/README.md
@@ -13,3 +13,10 @@ uv add "liteyukibot-v7-runtime-nonebot[onebot]"
 The runtime converts NoneBot events and actions into LiteyukiBot's frozen
 Event/Action schemas. NoneBot plugins, adapters, drivers, and Bot objects stay
 inside this child process.
+
+## Development
+
+Keep NoneBot imports and adapter conversion in this package. Event forwarding
+must not suppress NoneBot matcher dispatch. Run
+`uv run pytest packages/runtime-nonebot/tests` and
+`uv run python -m scripts.run_nonebot_runtime_install` after changes.

--- a/packages/runtime-v6/README.md
+++ b/packages/runtime-v6/README.md
@@ -7,3 +7,9 @@ compatibility namespace only when this runtime package is installed.
 It supports the documented v6 plugin, lifecycle, message matcher, and reply
 bridge surfaces. It does not restore v6 channels, shared-memory transport,
 adapter objects, or process-manager APIs.
+
+## Development
+
+Keep legacy session and matcher compatibility process-local. Do not recreate
+shared-memory or adapter-object APIs. Run `uv run pytest packages/runtime-v6/tests`
+and `uv run python -m scripts.run_v6_runtime_install` after changes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,24 @@
+# Developer And Release Scripts
+
+Scripts in this directory are executable verification and release-support
+tools. They are not runtime imports and should remain small command-line
+programs with deterministic inputs and clear exit statuses.
+
+- `check_release.py` validates source versions, package identities, and tags.
+- `run_*_install.py` creates isolated environments and exercises installed
+  package entry points.
+- `verify_*_install.py` contains the verifier invoked by an isolated install.
+- `benchmark_v7.py` records kernel performance measurements.
+- `run_tool_install_smoke.py` verifies the published CLI installation flow.
+
+Invoke scripts through uv from the repository root:
+
+```bash
+uv run python scripts/check_release.py
+uv run python -m scripts.run_tool_install_smoke
+```
+
+When adding a publishable package, give it an isolated install verifier and add
+the package identity to `check_release.py`, CI, and the release procedure.
+Scripts must not embed credentials or modify tracked source files as a side
+effect.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,30 @@
+# Kernel Source
+
+`src/liteyukibot/` is the v7 kernel distribution. It owns portable models,
+configuration, logging integration, native-plugin lifecycle, event/action
+routing, runtime supervision, and the command-line interface.
+
+Keep framework SDK imports and adapter objects out of this tree. Add a runtime
+or platform integration under `packages/` and exchange only the frozen kernel
+models across the child-runtime boundary.
+
+## Layout
+
+- `app.py`, `events/`, `plugins.py`, `services.py`, and `tasks.py` implement
+  kernel lifecycle and plugin/event contracts.
+- `config/` owns settings, workspace initialization, inspection, and the secret
+  vault.
+- `runtime/` owns the authenticated IPC protocol, client, and supervisor.
+- `cli.py` owns the `liteyuki`, `liteyukibot`, and `ly` commands.
+- `builtin_resources/` contains kernel-owned resource-pack assets.
+
+Use the root quality commands after modifying this directory:
+
+```bash
+uv run ruff check src tests
+uv run mypy
+uv run pytest tests
+```
+
+Public contract changes require focused tests and the matching document under
+`docs/adr/`, `docs/architecture/`, or `docs/configuration.md`.

--- a/src/liteyukibot/config/README.md
+++ b/src/liteyukibot/config/README.md
@@ -1,0 +1,16 @@
+# Configuration Subsystem
+
+This package owns typed settings, ordered configuration loading, provenance,
+redaction, workspace initialization, upgrade recovery material, and encrypted
+secret-vault handling.
+
+Configuration precedence and operator behavior are specified in
+[`docs/configuration.md`](../../../docs/configuration.md). Keep schema models
+strict and diagnostics redacted. New secret values must remain out of IPC,
+logs, control responses, and exception text.
+
+Run focused coverage with:
+
+```bash
+uv run pytest tests/test_config_v7.py tests/test_config_initializer.py tests/test_config_inspection.py tests/test_config_vault.py tests/test_config_workspace.py
+```

--- a/src/liteyukibot/events/README.md
+++ b/src/liteyukibot/events/README.md
@@ -1,0 +1,13 @@
+# Event And Action Models
+
+This package owns frozen, JSON-safe portable Event and Action models and the
+bounded EventBus. It must not import framework SDK types or use adapter-specific
+objects as public values.
+
+Changes to envelope fields, validation, ordering, or action routing require the
+matching ADR and focused tests. See
+[`docs/adr/0001-event-and-action-contracts.md`](../../../docs/adr/0001-event-and-action-contracts.md).
+
+```bash
+uv run pytest tests/test_events_v7.py tests/test_app_v7.py
+```

--- a/src/liteyukibot/runtime/README.md
+++ b/src/liteyukibot/runtime/README.md
@@ -1,0 +1,13 @@
+# Runtime IPC And Supervision
+
+This package owns the authenticated loopback protocol, child-side
+`RuntimeClient`, capability negotiation, event traces, runtime projection, and
+supervisor lifecycle. It is the only kernel-side runtime transport.
+
+Do not add direct runtime-to-runtime channels. Keep framing bounded, payloads
+JSON-safe, and child capabilities explicit. Public protocol changes require
+models, compatibility tests, and an accepted ADR.
+
+```bash
+uv run pytest tests/test_protocol_v7.py tests/test_runtime_client_v7.py tests/test_runtime_v7.py tests/test_runtime_generations.py tests/test_runtime_projection.py
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,27 @@
+# Tests
+
+`tests/` covers root-kernel behavior and cross-package integration. Package
+unit and runtime-specific tests live beside their owners in
+`packages/*/tests/`.
+
+Name tests after the contract they exercise. Use temporary pytest paths for
+workspaces, state, profiles, and generated plugin bundles. Do not depend on a
+developer's `data/`, `plugins/`, `tmp/`, tool installation, credentials, or
+network account.
+
+Run a focused test while changing behavior:
+
+```bash
+uv run pytest tests/test_cli_v7.py
+uv run pytest packages/<package>/tests
+```
+
+Before a pull request, run the full suite from the repository root:
+
+```bash
+uv run pytest
+```
+
+Process, package-wheel, and published-dependency contracts are intentionally
+tested through the verifiers under `scripts/`; add one when an installation
+boundary changes.


### PR DESCRIPTION
## Summary
- refresh the v7 root README around current installation, CLI, Docker, and first-party packages
- add contributor guidance and directory-level development ownership documents
- align stale Beta1, pre-stable protocol, and package documentation with the published 7.0.0b1 state

## Validation
- focused pytest: 67 passed
- local Markdown link scan
- git diff --check