### PR TITLE
test(benchmark): complete schema two coverage

### DIFF
--- a/.agents/skills/benchmark-tests/SKILL.md
+++ b/.agents/skills/benchmark-tests/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: benchmark-tests
+description: Maintain LiteyukiBot v7 performance benchmarks and their deterministic tests. Use for benchmark changes, performance-path changes, CI baseline artifacts, workload design, or benchmark regression review in this repository.
+---
+
+# Benchmark Tests
+
+## Workflow
+
+1. Read `scripts/benchmark_v7.py`, `tests/test_benchmark_v7.py`, and
+   `docs/performance-v7.md` before changing metric semantics.
+2. Preserve schema 2: the parent process launches independent `--sample` child
+   processes and aggregates raw samples with mean, standard deviation, minimum,
+   and maximum. Do not collect repeated samples in one interpreter.
+3. Keep the fixed event matrix: independent conversations at submission
+   concurrency 1/10/100, same-conversation FIFO, and one successful Action per
+   event. Keep function catalog setup, first call, and hot-call measurements.
+4. Add deterministic tests for workload behavior, result schema, child-process
+   invocation, aggregation compatibility, CLI validation, and platform memory
+   paths. Do not assert elapsed-time thresholds.
+5. Run `uv run pytest tests/test_benchmark_v7.py`, then the repository quality
+   commands. Generate a local artifact with:
+
+```bash
+uv run python scripts/benchmark_v7.py --samples 3 --output benchmark.json
+```
+
+## Review Rules
+
+- Treat CI artifacts as evidence for manual review, never as automatic
+  pass/fail performance gates on shared runners.
+- Compare only artifacts with the same schema, Python minor version, event
+  count, and workload configuration.
+- Preserve raw samples and dispersion. Do not update a tracked reference from
+  one run or hide an outlier in a summary-only artifact.
+- Keep schema 1 alpha references historical; schema 2 workloads are not
+  mechanically comparable to them.

--- a/.agents/skills/benchmark-tests/agents/openai.yaml
+++ b/.agents/skills/benchmark-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Benchmark Tests"
+  short_description: "Run LiteyukiBot benchmark workloads and tests."
+  default_prompt: "Use $benchmark-tests to update LiteyukiBot benchmark coverage."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
           uv run python -m scripts.run_mofox_runtime_install
       - name: Capture baseline
         working-directory: LiteyukiBot
-        run: uv run python scripts/benchmark_v7.py --output benchmark.json
+        run: uv run python scripts/benchmark_v7.py --samples 3 --output benchmark.json
       - uses: actions/upload-artifact@v7
         with:
           name: v7-baseline-${{ matrix.os }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,11 @@ package boundary, wheel, entry point, or runtime host also require its matching
 `python -m scripts.run_<package>_install` verifier. CI in
 `.github/workflows/ci.yaml` is the authoritative complete sequence.
 
+For performance-path changes, read `.agents/skills/benchmark-tests/SKILL.md`.
+It defines schema-2 benchmark workloads, isolated three-sample collection, and
+the required deterministic test coverage; benchmark artifacts require manual
+review and are not CI pass/fail gates.
+
 ## Coding Style and Contracts
 
 Use four-space indentation, type annotations, and strict mypy-compatible

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -13,3 +13,10 @@ uv run python scripts/benchmark_v7.py --output benchmark.json
 `benchmark.json` is ignored. Only update the tracked reference when its source
 environment and measurement rationale are documented in
 `docs/performance-v7.md`.
+
+Current CI output uses benchmark schema 2. It contains three independently
+started child-process samples per platform and a `summary` with arithmetic mean,
+standard deviation, minimum, and maximum. It measures independent-event
+concurrency 1/10/100, same-conversation FIFO, successful Action execution, and
+function dispatch. It remains an auditable review artifact rather than an
+automatic regression gate.

--- a/docs/performance-v7.md
+++ b/docs/performance-v7.md
@@ -50,3 +50,20 @@ captured from three clean runs per platform. A regression review is required
 when startup, latency, or RSS rises by more than 20%, or throughput falls by more
 than 20%. The comparison must use the same Python minor version, event count,
 runner architecture, and benchmark schema.
+
+## Schema 2 Workloads
+
+Current CI artifacts use schema 2. Each platform starts three separate Python
+processes and records every raw sample plus arithmetic mean, standard deviation,
+minimum, and maximum. Separate processes keep startup, tracemalloc, and peak
+RSS measurements independent.
+
+The event matrix contains independently ordered conversations submitted at
+concurrency 1, 10, and 100; a single-conversation FIFO workload; and a workload
+where every event performs one successful Action. Every workload uses 5,000
+events. Function catalog setup, first call, and hot calls remain included.
+
+Schema 1 alpha references are historical and cannot be compared mechanically to
+schema 2 because the workload set and aggregation shape changed. Schema 2
+artifacts are reviewed manually: GitHub-hosted runner variance must be examined
+through raw samples and dispersion before attributing a change to the code.

--- a/scripts/benchmark_v7.py
+++ b/scripts/benchmark_v7.py
@@ -1,4 +1,4 @@
-"""Small repeatable baseline for v7 architecture decisions."""
+"""Repeatable v7 benchmark workloads with independently sampled aggregation."""
 
 from __future__ import annotations
 
@@ -7,30 +7,52 @@ import asyncio
 import ctypes
 import importlib
 import json
+import math
 import os
 import platform
 import statistics
+import subprocess
+import sys
 import tempfile
 import time
 import tracemalloc
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from liteyukibot.app import LiteyukiApp
 from liteyukibot.config import AppSettings, CoreSettings, LoggingSettings
-from liteyukibot.events import ConversationRef, EventBus, EventEnvelope
+from liteyukibot.events import (
+    ActionEnvelope,
+    ActionResult,
+    CallApi,
+    ConversationRef,
+    EventBus,
+    EventEnvelope,
+    HandlerResult,
+)
 from liteyukibot.functions import FunctionCall, FunctionDispatcher
 from liteyukibot.resource_packs import ResourceCatalog
 
+SCHEMA_VERSION = 2
+DEFAULT_EVENT_COUNT = 5_000
+DEFAULT_FUNCTION_PACKS = 8
+DEFAULT_FUNCTIONS_PER_PACK = 16
+DEFAULT_FUNCTION_CALLS = 1_000
+DEFAULT_SAMPLES = 3
 
-async def benchmark(
+type WorkloadKind = Literal["independent", "fifo", "action"]
+
+
+async def benchmark_sample(
     event_count: int,
     *,
     function_packs: int,
     functions_per_pack: int,
     function_calls: int,
 ) -> dict[str, Any]:
+    """Collect one isolated-process sample without spawning a child process."""
+
     started = time.perf_counter()
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
@@ -41,66 +63,135 @@ async def benchmark(
             )
         )
         await app.start()
-        startup_seconds = time.perf_counter() - started
-
-        latencies: list[float] = []
-
-        async def handle(_event: EventEnvelope) -> None:
-            return None
-
-        async def timed_publish(bus: EventBus, event: EventEnvelope) -> float:
-            event_started = time.perf_counter()
-            await bus.publish(event)
-            return time.perf_counter() - event_started
-
-        async with EventBus(max_concurrent_events=100) as bus:
-            bus.subscribe(handle)
-            dispatch_started = time.perf_counter()
-            for offset in range(0, event_count, 100):
-                batch_size = min(100, event_count - offset)
-                latencies.extend(
-                    await asyncio.gather(
-                        *(
-                            timed_publish(
-                                bus,
-                                EventEnvelope(
-                                    runtime_id="benchmark",
-                                    adapter="benchmark",
-                                    bot_id="bot",
-                                    type="benchmark",
-                                    conversation=ConversationRef(
-                                        id=f"conversation-{offset + index}"
-                                    ),
-                                ),
-                            )
-                            for index in range(batch_size)
-                        )
+        startup_ms = (time.perf_counter() - started) * 1000
+        try:
+            workloads = {
+                "independent": {
+                    str(concurrency): await _benchmark_event_workload(
+                        event_count,
+                        kind="independent",
+                        submission_concurrency=concurrency,
                     )
-                )
-            dispatch_seconds = time.perf_counter() - dispatch_started
+                    for concurrency in (1, 10, 100)
+                },
+                "fifo": await _benchmark_event_workload(
+                    event_count,
+                    kind="fifo",
+                    submission_concurrency=100,
+                ),
+                "action": await _benchmark_event_workload(
+                    event_count,
+                    kind="action",
+                    submission_concurrency=100,
+                ),
+            }
+        finally:
+            await app.stop()
 
-        await app.stop()
-
-    sorted_latencies = sorted(latencies)
-    result: dict[str, Any] = {
-        "schema": 1,
+    return {
+        "schema": SCHEMA_VERSION,
         "platform": platform.platform(),
         "python": platform.python_version(),
         "event_count": event_count,
-        "startup_ms": startup_seconds * 1000,
-        "throughput_events_per_second": event_count / dispatch_seconds,
-        "event_latency_ms": {
-            "median": statistics.median(sorted_latencies) * 1000,
-            "p95": sorted_latencies[int(len(sorted_latencies) * 0.95) - 1] * 1000,
-        },
+        "startup_ms": startup_ms,
         "peak_rss_bytes": _peak_rss_bytes(),
+        "workloads": workloads,
+        "functions": await _benchmark_functions(
+            packs=function_packs,
+            functions_per_pack=functions_per_pack,
+            calls=function_calls,
+        ),
     }
-    result["functions"] = await _benchmark_functions(
-        packs=function_packs,
-        functions_per_pack=functions_per_pack,
-        calls=function_calls,
-    )
-    return result
+
+
+async def _benchmark_event_workload(
+    event_count: int,
+    *,
+    kind: WorkloadKind,
+    submission_concurrency: int,
+) -> dict[str, Any]:
+    latencies: list[float] = []
+    processed = 0
+    fifo_order: list[int] = []
+    actions_succeeded = 0
+
+    async def handle(event: EventEnvelope) -> HandlerResult | None:
+        nonlocal processed
+        processed += 1
+        if kind == "fifo":
+            fifo_order.append(int(event.id))
+        if kind == "action":
+            return HandlerResult(
+                actions=(
+                    ActionEnvelope(
+                        action_id=f"action-{event.id}",
+                        event_id=event.id,
+                        runtime_id=event.runtime_id,
+                        bot_id=event.bot_id,
+                        action=CallApi(api="benchmark"),
+                    ),
+                )
+            )
+        return None
+
+    async def execute(_event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
+        nonlocal actions_succeeded
+        actions_succeeded += 1
+        return ActionResult(action_id=action.action_id, success=True)
+
+    async def publish(bus: EventBus, index: int) -> None:
+        started = time.perf_counter()
+        conversation_id = "fifo" if kind == "fifo" else f"conversation-{index}"
+        result = await bus.publish(
+            EventEnvelope(
+                id=str(index),
+                runtime_id="benchmark",
+                adapter="benchmark",
+                bot_id="bot",
+                type="benchmark",
+                conversation=ConversationRef(id=conversation_id),
+            )
+        )
+        if result.status != "processed":
+            raise RuntimeError(f"benchmark event {index} was not processed: {result.status}")
+        if kind == "action" and len(result.action_results) != 1:
+            raise RuntimeError(f"benchmark action {index} was not executed")
+        latencies.append((time.perf_counter() - started) * 1000)
+
+    started = time.perf_counter()
+    async with EventBus(max_concurrent_events=100, action_executor=execute if kind == "action" else None) as bus:
+        bus.subscribe(handle)
+        for offset in range(0, event_count, submission_concurrency):
+            await asyncio.gather(
+                *(publish(bus, index) for index in range(offset, min(offset + submission_concurrency, event_count)))
+            )
+    elapsed_seconds = time.perf_counter() - started
+    if kind == "fifo" and fifo_order != list(range(event_count)):
+        raise RuntimeError("FIFO benchmark did not preserve event order")
+    if processed != event_count:
+        raise RuntimeError(f"benchmark handled {processed} events, expected {event_count}")
+    if kind == "action" and actions_succeeded != event_count:
+        raise RuntimeError(f"benchmark executed {actions_succeeded} actions, expected {event_count}")
+    return {
+        "kind": kind,
+        "event_count": event_count,
+        "submission_concurrency": submission_concurrency,
+        "elapsed_ms": elapsed_seconds * 1000,
+        "throughput_events_per_second": event_count / elapsed_seconds,
+        "latency_ms": _latency_summary(latencies),
+        "processed_events": processed,
+        "successful_actions": actions_succeeded,
+    }
+
+
+def _latency_summary(latencies: Sequence[float]) -> dict[str, float]:
+    if not latencies:
+        raise ValueError("latency samples must not be empty")
+    ordered = sorted(latencies)
+    return {
+        "median": statistics.median(ordered),
+        "p95": ordered[math.ceil(len(ordered) * 0.95) - 1],
+    }
 
 
 async def _benchmark_functions(*, packs: int, functions_per_pack: int, calls: int) -> dict[str, Any]:
@@ -132,7 +223,6 @@ async def _benchmark_functions(*, packs: int, functions_per_pack: int, calls: in
         first_call_peak = await _tracemalloc_peak(lambda: _dispatch_once(workspace, call))
         hot_peak = await _tracemalloc_peak(lambda: _dispatch_many(workspace, call, calls))
 
-    sorted_hot = sorted(hot_latencies)
     return {
         "available": True,
         "packs": packs,
@@ -142,11 +232,7 @@ async def _benchmark_functions(*, packs: int, functions_per_pack: int, calls: in
         "catalog_setup_tracemalloc_peak_bytes": cold_setup_peak,
         "first_call_ms": first_call_ms,
         "first_call_tracemalloc_peak_bytes": first_call_peak,
-        "hot_call_ms": {
-            "median": statistics.median(sorted_hot),
-            "p95": sorted_hot[int(len(sorted_hot) * 0.95) - 1],
-            "tracemalloc_peak_bytes": hot_peak,
-        },
+        "hot_call_ms": {**_latency_summary(hot_latencies), "tracemalloc_peak_bytes": hot_peak},
     }
 
 
@@ -194,6 +280,114 @@ def _write_function_resources(workspace: Path, packs: int, functions_per_pack: i
     (root / "index.json").write_text(json.dumps(index), encoding="utf-8")
 
 
+def aggregate_samples(samples: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if not samples:
+        raise ValueError("benchmark samples must not be empty")
+    _validate_samples(samples)
+    return {
+        "schema": SCHEMA_VERSION,
+        "sample_count": len(samples),
+        "platform": samples[0]["platform"],
+        "python": samples[0]["python"],
+        "event_count": samples[0]["event_count"],
+        "samples": list(samples),
+        "summary": _aggregate_value(
+            [
+                {
+                    "startup_ms": sample["startup_ms"],
+                    "peak_rss_bytes": sample["peak_rss_bytes"],
+                    "workloads": sample["workloads"],
+                    "functions": sample["functions"],
+                }
+                for sample in samples
+            ]
+        ),
+    }
+
+
+def _validate_samples(samples: Sequence[Mapping[str, Any]]) -> None:
+    expected = samples[0]
+    for sample in samples:
+        if sample.get("schema") != SCHEMA_VERSION:
+            raise ValueError("benchmark sample has an unsupported schema")
+        for key in ("platform", "python", "event_count"):
+            if sample.get(key) != expected.get(key):
+                raise ValueError(f"benchmark samples disagree on {key}")
+        if sample.get("workloads", {}).keys() != expected.get("workloads", {}).keys():
+            raise ValueError("benchmark samples disagree on workload groups")
+        if sample.get("functions", {}).get("available") != expected.get("functions", {}).get("available"):
+            raise ValueError("benchmark samples disagree on function executor availability")
+
+
+def _aggregate_value(values: Sequence[Any]) -> Any:
+    first = values[0]
+    if isinstance(first, bool) or first is None or isinstance(first, str):
+        if any(value != first for value in values[1:]):
+            raise ValueError("benchmark samples disagree on a non-numeric value")
+        return first
+    if isinstance(first, (int, float)):
+        numbers = [float(value) for value in values]
+        return {
+            "mean": statistics.fmean(numbers),
+            "stdev": statistics.stdev(numbers) if len(numbers) > 1 else 0.0,
+            "min": min(numbers),
+            "max": max(numbers),
+        }
+    if isinstance(first, Mapping):
+        keys = first.keys()
+        if any(not isinstance(value, Mapping) or value.keys() != keys for value in values[1:]):
+            raise ValueError("benchmark samples disagree on object keys")
+        return {key: _aggregate_value([value[key] for value in values]) for key in keys}
+    raise ValueError(f"benchmark samples contain unsupported value {type(first).__name__}")
+
+
+def run_samples(
+    *,
+    samples: int,
+    event_count: int,
+    function_packs: int,
+    functions_per_pack: int,
+    function_calls: int,
+) -> dict[str, Any]:
+    measurements = [
+        _run_child_sample(
+            event_count=event_count,
+            function_packs=function_packs,
+            functions_per_pack=functions_per_pack,
+            function_calls=function_calls,
+        )
+        for _ in range(samples)
+    ]
+    return aggregate_samples(measurements)
+
+
+def _run_child_sample(
+    *,
+    event_count: int,
+    function_packs: int,
+    functions_per_pack: int,
+    function_calls: int,
+) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--sample",
+        "--events",
+        str(event_count),
+        "--function-packs",
+        str(function_packs),
+        "--functions-per-pack",
+        str(functions_per_pack),
+        "--function-calls",
+        str(function_calls),
+    ]
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    parsed = json.loads(completed.stdout)
+    if not isinstance(parsed, dict):
+        raise ValueError("benchmark child did not produce a JSON object")
+    return cast(dict[str, Any], parsed)
+
+
 def _peak_rss_bytes() -> int:
     if os.name == "nt":
         return _windows_peak_rss()
@@ -233,25 +427,43 @@ def _windows_peak_rss() -> int:
     return int(counters.peak_working_set_size)
 
 
-def main() -> int:
+def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--events", type=int, default=5000)
-    parser.add_argument("--function-packs", type=int, default=8)
-    parser.add_argument("--functions-per-pack", type=int, default=16)
-    parser.add_argument("--function-calls", type=int, default=1000)
+    parser.add_argument("--events", type=int, default=DEFAULT_EVENT_COUNT)
+    parser.add_argument("--function-packs", type=int, default=DEFAULT_FUNCTION_PACKS)
+    parser.add_argument("--functions-per-pack", type=int, default=DEFAULT_FUNCTIONS_PER_PACK)
+    parser.add_argument("--function-calls", type=int, default=DEFAULT_FUNCTION_CALLS)
+    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    parser.add_argument("--sample", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--output", type=Path, default=Path("benchmark.json"))
-    args = parser.parse_args()
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
     if args.events < 100:
-        parser.error("--events must be at least 100")
+        _parser().error("--events must be at least 100")
     if args.function_packs < 1 or args.functions_per_pack < 1 or args.function_calls < 0:
-        parser.error("function benchmark counts must be positive, except --function-calls may be zero")
-    result = asyncio.run(
-        benchmark(
-            args.events,
-            function_packs=args.function_packs,
-            functions_per_pack=args.functions_per_pack,
-            function_calls=args.function_calls,
+        _parser().error("function benchmark counts must be positive, except --function-calls may be zero")
+    if args.samples < 1:
+        _parser().error("--samples must be at least 1")
+    if args.sample:
+        result = asyncio.run(
+            benchmark_sample(
+                args.events,
+                function_packs=args.function_packs,
+                functions_per_pack=args.functions_per_pack,
+                function_calls=args.function_calls,
+            )
         )
+        print(json.dumps(result, separators=(",", ":")))
+        return 0
+    result = run_samples(
+        samples=args.samples,
+        event_count=args.events,
+        function_packs=args.function_packs,
+        functions_per_pack=args.functions_per_pack,
+        function_calls=args.function_calls,
     )
     args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
     print(json.dumps(result, indent=2))

--- a/tests/test_benchmark_v7.py
+++ b/tests/test_benchmark_v7.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from scripts import benchmark_v7
+
+
+def _sample(*, startup_ms: float = 1.0, throughput: float = 100.0) -> dict[str, Any]:
+    return {
+        "schema": 2,
+        "platform": "test-platform",
+        "python": "3.14.0",
+        "event_count": 100,
+        "startup_ms": startup_ms,
+        "peak_rss_bytes": 1_000,
+        "workloads": {
+            "independent": {
+                "1": {
+                    "kind": "independent",
+                    "event_count": 100,
+                    "submission_concurrency": 1,
+                    "elapsed_ms": 1.0,
+                    "throughput_events_per_second": throughput,
+                    "latency_ms": {"median": 0.1, "p95": 0.2},
+                    "processed_events": 100,
+                    "successful_actions": 0,
+                }
+            },
+            "fifo": {
+                "kind": "fifo",
+                "event_count": 100,
+                "submission_concurrency": 100,
+                "elapsed_ms": 1.0,
+                "throughput_events_per_second": throughput,
+                "latency_ms": {"median": 0.1, "p95": 0.2},
+                "processed_events": 100,
+                "successful_actions": 0,
+            },
+            "action": {
+                "kind": "action",
+                "event_count": 100,
+                "submission_concurrency": 100,
+                "elapsed_ms": 1.0,
+                "throughput_events_per_second": throughput,
+                "latency_ms": {"median": 0.1, "p95": 0.2},
+                "processed_events": 100,
+                "successful_actions": 100,
+            },
+        },
+        "functions": {"available": False, "reason": "disabled"},
+    }
+
+
+def test_benchmark_sample_covers_all_event_workloads() -> None:
+    result = asyncio.run(
+        benchmark_v7.benchmark_sample(
+            100,
+            function_packs=1,
+            functions_per_pack=1,
+            function_calls=0,
+        )
+    )
+
+    assert result["schema"] == 2
+    assert result["event_count"] == 100
+    independent = result["workloads"]["independent"]
+    assert set(independent) == {"1", "10", "100"}
+    assert all(value["processed_events"] == 100 for value in independent.values())
+    assert result["workloads"]["fifo"]["processed_events"] == 100
+    assert result["workloads"]["fifo"]["successful_actions"] == 0
+    assert result["workloads"]["action"]["successful_actions"] == 100
+    assert result["functions"] == {"available": False, "reason": "disabled"}
+
+
+def test_function_benchmark_reports_missing_executor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("scripts.benchmark_v7.FunctionDispatcher.discover_executors", lambda: {})
+
+    assert asyncio.run(benchmark_v7._benchmark_functions(packs=1, functions_per_pack=1, calls=1)) == {
+        "available": False,
+        "reason": "no function executor is installed",
+    }
+
+
+def test_latency_summary_uses_ceil_rank_for_p95() -> None:
+    assert benchmark_v7._latency_summary([1.0, 2.0, 3.0, 4.0, 100.0]) == {"median": 3.0, "p95": 100.0}
+
+
+def test_aggregate_samples_retains_raw_samples_and_distribution() -> None:
+    result = benchmark_v7.aggregate_samples(
+        [
+            _sample(startup_ms=1.0, throughput=100.0),
+            _sample(startup_ms=2.0, throughput=200.0),
+            _sample(startup_ms=3.0, throughput=300.0),
+        ]
+    )
+
+    assert result["sample_count"] == 3
+    assert len(result["samples"]) == 3
+    assert result["schema"] == 2
+    assert "schema" not in result["summary"]
+    assert result["summary"]["startup_ms"] == {"mean": 2.0, "stdev": 1.0, "min": 1.0, "max": 3.0}
+    assert result["summary"]["workloads"]["action"]["throughput_events_per_second"] == {
+        "mean": 200.0,
+        "stdev": 100.0,
+        "min": 100.0,
+        "max": 300.0,
+    }
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda sample: sample.__setitem__("schema", 1),
+        lambda sample: sample.__setitem__("platform", "other"),
+        lambda sample: sample["workloads"].pop("action"),
+        lambda sample: sample.__setitem__("functions", {"available": True}),
+    ],
+)
+def test_aggregate_samples_rejects_incompatible_samples(mutate: Any) -> None:
+    first = _sample()
+    second = _sample()
+    mutate(second)
+
+    with pytest.raises(ValueError, match="benchmark sample"):
+        benchmark_v7.aggregate_samples([first, second])
+
+
+def test_run_samples_uses_one_child_process_per_sample(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout=json.dumps(_sample()))
+
+    monkeypatch.setattr("scripts.benchmark_v7.subprocess.run", fake_run)
+
+    result = benchmark_v7.run_samples(
+        samples=3,
+        event_count=100,
+        function_packs=1,
+        functions_per_pack=1,
+        function_calls=0,
+    )
+
+    assert len(calls) == 3
+    assert all("--sample" in command for command in calls)
+    assert result["sample_count"] == 3
+
+
+def test_main_writes_aggregated_output(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    output = tmp_path / "benchmark.json"
+    monkeypatch.setattr(benchmark_v7, "run_samples", lambda **_kwargs: benchmark_v7.aggregate_samples([_sample()]))
+
+    assert (
+        benchmark_v7.main(["--events", "100", "--samples", "1", "--function-calls", "0", "--output", str(output)]) == 0
+    )
+    assert json.loads(output.read_text(encoding="utf-8"))["summary"]["startup_ms"]["mean"] == 1.0
+
+
+@pytest.mark.parametrize(
+    "arguments, message",
+    [
+        (["--events", "99"], "--events must be at least 100"),
+        (["--samples", "0"], "--samples must be at least 1"),
+        (["--function-calls", "-1"], "function benchmark counts"),
+    ],
+)
+def test_main_rejects_invalid_arguments(arguments: list[str], message: str, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        benchmark_v7.main(arguments)
+
+    assert message in capsys.readouterr().err
+
+
+def test_windows_peak_rss_reports_api_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Psapi:
+        @staticmethod
+        def GetProcessMemoryInfo(*_args: object) -> int:
+            return 0
+
+    class Kernel32:
+        @staticmethod
+        def GetCurrentProcess() -> int:
+            return 1
+
+    class Windows:
+        psapi = Psapi()
+        kernel32 = Kernel32()
+
+    monkeypatch.setattr("scripts.benchmark_v7.ctypes.windll", Windows(), raising=False)
+
+    with pytest.raises(OSError, match="GetProcessMemoryInfo"):
+        benchmark_v7._windows_peak_rss()
+
+
+@pytest.mark.parametrize(
+    ("system", "raw_rss", "expected"),
+    [("Linux", 5, 5 * 1024), ("Darwin", 5, 5)],
+)
+def test_posix_peak_rss_normalizes_platform_units(
+    monkeypatch: pytest.MonkeyPatch,
+    system: str,
+    raw_rss: int,
+    expected: int,
+) -> None:
+    class Resource:
+        RUSAGE_SELF = object()
+
+        @staticmethod
+        def getrusage(_target: object) -> object:
+            return type("Usage", (), {"ru_maxrss": raw_rss})()
+
+    monkeypatch.setattr("scripts.benchmark_v7.os.name", "posix")
+    monkeypatch.setattr("scripts.benchmark_v7.platform.system", lambda: system)
+    monkeypatch.setattr("scripts.benchmark_v7.importlib.import_module", lambda _name: Resource())
+
+    assert benchmark_v7._peak_rss_bytes() == expected


### PR DESCRIPTION
Summary: upgrade the v7 benchmark to schema 2 with three isolated child-process samples, raw values plus mean/stdev/min/max aggregation, and independent/FIFO/Action workloads. Add deterministic benchmark contract coverage and the repository benchmark-tests skill. CI keeps artifacts for manual review rather than enforcing a regression gate. Validation: ruff, mypy, pytest (480 passed, 1 skipped), all-package wheel build, skill validation, and a default three-sample 5,000-event artifact. Squash merge requested.