### PR TITLE
fix(kernel): isolate data directory instances

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,9 +82,11 @@ liteyuki --workspace /srv/liteyuki init --non-interactive
 liteyuki --workspace /srv/liteyuki run
 ~~~
 
-`init` and `run` hold `.liteyuki/instance.lock` for the duration of the
-operation. A second process for the same workspace exits rather than replacing
-the active control descriptor. `liteyuki --version` is equivalent to
+Workspace-changing commands, including `init`, hold
+`.liteyuki/instance.lock` for the duration of the operation. A running kernel
+also holds `core.data_dir/instance.lock` for its full lifecycle. One resolved
+data directory can therefore belong to only one live kernel; concurrent bots
+must use distinct `core.data_dir` values. `liteyuki --version` is equivalent to
 `liteyuki version`.
 
 ## Instance Profiles

--- a/src/liteyukibot/cli.py
+++ b/src/liteyukibot/cli.py
@@ -592,7 +592,7 @@ def _list_runtime_plugin_generations(workspace: ConfigWorkspace, runtime_id: str
 
 def _run(settings: AppSettings, workspace: ConfigWorkspace) -> int:
     try:
-        with _exclusive_workspace(workspace):
+        with _exclusive_data_directory(settings.core.data_dir):
             asyncio.run(_run_until_signal(settings, _runtime_secrets(settings, workspace), workspace.directory))
     except KeyboardInterrupt:
         return 130
@@ -601,7 +601,7 @@ def _run(settings: AppSettings, workspace: ConfigWorkspace) -> int:
 
 @contextmanager
 def _exclusive_workspace(workspace: ConfigWorkspace) -> Iterator[None]:
-    """Prevent init or run from replacing one workspace's live control state."""
+    """Serialize operations that mutate one workspace's management state."""
 
     workspace.management_directory.mkdir(parents=True, exist_ok=True)
     lock = FileLock(workspace.management_directory / "instance.lock", timeout=0)
@@ -610,6 +610,21 @@ def _exclusive_workspace(workspace: ConfigWorkspace) -> Iterator[None]:
             yield
     except Timeout as error:
         raise RuntimeError(f"another LiteyukiBot command is active for {workspace.directory}") from error
+
+
+@contextmanager
+def _exclusive_data_directory(data_directory: Path) -> Iterator[None]:
+    """Ensure one kernel owns all state beneath a resolved data directory."""
+
+    data_directory.mkdir(parents=True, exist_ok=True)
+    lock = FileLock(data_directory / "instance.lock", timeout=0)
+    try:
+        with lock:
+            yield
+    except Timeout as error:
+        raise RuntimeError(
+            f"another LiteyukiBot instance is active for data directory {data_directory}"
+        ) from error
 
 
 async def _run_until_signal(

--- a/tests/test_cli_v7.py
+++ b/tests/test_cli_v7.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import signal
+import subprocess
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
@@ -104,16 +106,19 @@ async def test_run_until_signal_uses_windows_signal_fallback(monkeypatch: pytest
     assert assignments[-2:] == [(signal.SIGINT, previous), (signal.SIGTERM, previous)]
 
 
-def test_run_rejects_an_active_workspace_lock(
+def test_run_rejects_an_active_data_directory_lock(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     from liteyukibot.config import ConfigWorkspace
 
-    ConfigWorkspace(tmp_path).initialize()
+    workspace = ConfigWorkspace(tmp_path)
+    workspace.initialize()
+    expected_data_directory = tmp_path / "data"
+    lock_paths: list[Path] = []
 
     class LockedFileLock:
-        def __init__(self, *_args: object, **_kwargs: object) -> None:
-            pass
+        def __init__(self, path: Path, **_kwargs: object) -> None:
+            lock_paths.append(path)
 
         def __enter__(self) -> None:
             raise Timeout("instance.lock")
@@ -125,7 +130,88 @@ def test_run_rejects_an_active_workspace_lock(
     monkeypatch.setattr(cli_module, "_runtime_secrets", lambda *_args: (_ for _ in ()).throw(AssertionError()))
 
     assert cli_module.main(["--workspace", str(tmp_path), "run"]) == 2
-    assert "another LiteyukiBot command is active" in capsys.readouterr().err
+    assert lock_paths == [expected_data_directory / "instance.lock"]
+    message = f"another LiteyukiBot instance is active for data directory {expected_data_directory}"
+    assert message in capsys.readouterr().err
+
+
+def test_run_rejects_a_shared_data_directory_owned_by_another_process(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from liteyukibot.config import ConfigWorkspace
+
+    first_workspace = ConfigWorkspace(tmp_path / "first")
+    second_workspace = ConfigWorkspace(tmp_path / "second")
+    first_workspace.initialize()
+    second_workspace.initialize()
+    data_directory = tmp_path / "shared-data"
+    data_directory.mkdir()
+    helper = """
+from filelock import FileLock
+from pathlib import Path
+import sys
+import time
+
+with FileLock(Path(sys.argv[1]) / 'instance.lock', timeout=0):
+    print('locked', flush=True)
+    time.sleep(60)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", helper, str(data_directory)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline().strip() == "locked"
+        assert (
+            cli_module.main(
+                [
+                    "--workspace",
+                    str(second_workspace.directory),
+                    "--set",
+                    f"core.data_dir={data_directory}",
+                    "run",
+                ]
+            )
+            == 2
+        )
+        message = f"another LiteyukiBot instance is active for data directory {data_directory}"
+        assert message in capsys.readouterr().err
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
+
+
+def test_data_directory_locks_are_independent(tmp_path: Path) -> None:
+    first_data_directory = tmp_path / "first-data"
+    second_data_directory = tmp_path / "second-data"
+    first_data_directory.mkdir()
+    helper = """
+from filelock import FileLock
+from pathlib import Path
+import sys
+import time
+
+with FileLock(Path(sys.argv[1]) / 'instance.lock', timeout=0):
+    print('locked', flush=True)
+    time.sleep(60)
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", helper, str(first_data_directory)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline().strip() == "locked"
+        with cli_module._exclusive_data_directory(second_data_directory):
+            assert (second_data_directory / "instance.lock").is_file()
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
 
 
 def test_init_minimal_wizard_writes_locale_and_resource_index(


### PR DESCRIPTION
## Summary
- hold a run-lifecycle lock under the resolved core data directory
- reject a second kernel before it can replace the control descriptor
- retain workspace locks for workspace-local mutations and document both boundaries

## Validation
- uv run pytest tests/test_cli_v7.py
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv run pytest
- uv build --all-packages --out-dir dist/workspace --clear