### PR TITLE
fix(release): require compatible Satori kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 7.0.0b2 - 2026-08-13
+
+- added `EditMessage` to the portable action model and the separately
+  published native OneBot v11/v12 and Satori adapter packages;
+- added named instance configuration, daemon-managed workers, local development
+  controls, and data-directory instance locking;
+- added the interactive management console and responsive initialization flow;
+- upgraded performance artifacts to schema 2 with three independent samples
+  and deterministic benchmark coverage;
+- require `liteyukibot-v7>=7.0.0b2` for the Satori adapter so published wheels
+  always import the portable `EditMessage` action.
+
 ## 7.0.0b1 - 2026-08-12
 
 - introduced runtime IPC protocol v5 with a kernel-originated, capability-gated

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Framework integrations run as separately installed supervised child runtimes;
 they exchange frozen Event and Action models with the kernel rather than SDK
 objects.
 
-The default branch is the maintained LiteyukiBot v6 line. This `v7` branch is
-an independent rewrite. Its current published release is
-`liteyukibot-v7==7.0.0b1`.
+The default branch is the maintained LiteyukiBot v7 line. The prior v6 line is
+preserved on the `v6` branch. Its current published release is
+`liteyukibot-v7==7.0.0b2`.
 
 ## Features
 
@@ -146,7 +146,7 @@ This repository is a uv workspace containing the kernel, first-party packages,
 examples, tests, developer tools, documentation, and release workflows.
 Directory-level development guidance is provided by each directory's README.
 
-[Liteyuki7]: https://img.shields.io/badge/LiteyukiBot-7.0.0b1-blue?style=for-the-badge
+[Liteyuki7]: https://img.shields.io/badge/LiteyukiBot-7.0.0b2-blue?style=for-the-badge
 [Python3.14]: https://img.shields.io/badge/Python-3.14+-blue?style=for-the-badge
 [Usage]: https://img.shields.io/badge/Usage-CLI-blue?style=for-the-badge
 [Repo]: https://img.shields.io/badge/Distribution-PyPI-blue?style=for-the-badge

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -177,7 +177,7 @@ and published-install matrix are documented in
 
 ## Current Release State
 
-The current source pre-release is `liteyukibot-v7==7.0.0b1`. The kernel,
+The current source pre-release is `liteyukibot-v7==7.0.0b2`. The kernel,
 bounded v6 compatibility, separately published runtime boundaries, and the
 first-party plugin foundation are complete. Resources and profile remain
 optional business plugins; their storage and migration ownership does not

--- a/docs/beta1.md
+++ b/docs/beta1.md
@@ -1,6 +1,6 @@
 # LiteyukiBot v7 Beta1 Contract
 
-Beta1 is published as `liteyukibot-v7==7.0.0b1`. It is a single-host,
+Beta1 is published as `liteyukibot-v7==7.0.0b2`. It is a single-host,
 protocol-neutral integration release: the kernel owns configuration, routing,
 permissions, deployment state, and IPC; platform/framework integrations run in
 supervised child processes and never exchange SDK objects with one another.
@@ -14,7 +14,7 @@ documentation tree and are not part of the maintained contract.
 Install a minimal local workspace with:
 
 ```bash
-uv tool install --python 3.14 "liteyukibot-v7==7.0.0b1"
+uv tool install --python 3.14 "liteyukibot-v7==7.0.0b2"
 liteyuki init
 liteyuki check
 ```
@@ -28,13 +28,22 @@ at install time. The Beta1 native OneBot v11 pair is
 uv tool install --python 3.14 --force \
   --with "liteyukibot-v7-runtime-adapter==0.1.0a2" \
   --with "liteyukibot-v7-adapter-onebot==0.1.0a1" \
-  "liteyukibot-v7==7.0.0b1"
+  "liteyukibot-v7==7.0.0b2"
 ```
 
 Each separately distributed runtime has its own version. Do not substitute an
 arbitrary latest version; use the tested set named here or in the release
 notes. Project maintainers may instead add the same requirements to their
 project with `uv add`, then invoke `uv run liteyuki ...`.
+
+The experimental external Satori v1 gateway client uses the same adapter host:
+
+```bash
+uv tool install --python 3.14 --force \
+  --with "liteyukibot-v7-runtime-adapter==0.1.0a2" \
+  --with "liteyukibot-v7-adapter-satori==0.1.0a2" \
+  "liteyukibot-v7==7.0.0b2"
+```
 
 The repository CI already builds the root wheel, installs it via an isolated
 `uv tool` directory, and runs `version`, non-interactive `init`, and `check` on

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -45,7 +45,7 @@ distribution inside the workflow.
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0b1` | `pyproject.toml` | `v7.0.0b1` |
+| `liteyukibot-v7==7.0.0b2` | `pyproject.toml` | `v7.0.0b2` |
 | `liteyukibot-v7-permissions==0.2.0a2` | `packages/permissions` | `permissions-v0.2.0a2` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |
@@ -55,7 +55,7 @@ distribution inside the workflow.
 | `liteyukibot-v7-runtime-nonebot==0.1.0a1` | `packages/runtime-nonebot` | `runtime-nonebot-v0.1.0a1` |
 | `liteyukibot-v7-runtime-adapter==0.1.0a2` | `packages/runtime-adapter` | `runtime-adapter-v0.1.0a2` |
 | `liteyukibot-v7-adapter-onebot==0.1.0a1` | `packages/adapter-onebot` | `adapter-onebot-v0.1.0a1` |
-| `liteyukibot-v7-adapter-satori==0.1.0a1` | `packages/adapter-satori` | `adapter-satori-v0.1.0a1` |
+| `liteyukibot-v7-adapter-satori==0.1.0a2` | `packages/adapter-satori` | `adapter-satori-v0.1.0a2` |
 | `liteyukibot-v7-runtime-v6==0.1.0a2` | `packages/runtime-v6` | `runtime-v6-v0.1.0a2` |
 | `liteyukibot-v7-agent-resolver==0.1.0a1` | `packages/agent-resolver` | `agent-resolver-v0.1.0a1` |
 | `liteyukibot-v7-agent==0.1.0a9` | `packages/agent` | `agent-v0.1.0a9` |
@@ -69,7 +69,7 @@ tag that does not exactly match the selected source version and distribution.
 
 Push and wait for each release before creating the next tag:
 
-1. `v7.0.0b1`;
+1. `v7.0.0b2`;
 2. `permissions-v0.2.0a2`;
 3. `commands-v0.2.0a2`;
 4. `resources-v0.1.0a2`;
@@ -79,7 +79,7 @@ Push and wait for each release before creating the next tag:
 8. `runtime-nonebot-v0.1.0a1`.
 9. `runtime-adapter-v0.1.0a2`.
 10. `adapter-onebot-v0.1.0a1`.
-11. `adapter-satori-v0.1.0a1`.
+11. `adapter-satori-v0.1.0a2`.
 12. `runtime-v6-v0.1.0a2`.
 13. `agent-resolver-v0.1.0a1`.
 14. `agent-v0.1.0a9` (requires `commands-v0.2.0a2`).

--- a/packages/adapter-satori/pyproject.toml
+++ b/packages/adapter-satori/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-adapter-satori"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Native Satori v1 adapter for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -8,6 +8,7 @@ license = "LicenseRef-LSO"
 license-files = ["LICENSE"]
 authors = [{ name = "LiteyukiStudio" }]
 dependencies = [
+    "liteyukibot-v7>=7.0.0b2,<8",
     "liteyukibot-v7-runtime-adapter>=0.1.0a2,<1",
     "websockets>=15,<16",
 ]
@@ -20,6 +21,7 @@ requires = ["uv_build>=0.11.32,<0.12"]
 build-backend = "uv_build"
 
 [tool.uv.sources]
+liteyukibot-v7 = { workspace = true }
 liteyukibot-v7-runtime-adapter = { workspace = true }
 
 [tool.uv.build-backend]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0b1"
+version = "7.0.0b2"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -26,7 +26,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0b1"),
+        ("root", "v7.0.0b2"),
         ("permissions", "permissions-v0.2.0a2"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),
@@ -36,6 +36,7 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
         ("runtime-nonebot", "runtime-nonebot-v0.1.0a1"),
         ("runtime-adapter", "runtime-adapter-v0.1.0a2"),
         ("adapter-onebot", "adapter-onebot-v0.1.0a1"),
+        ("adapter-satori", "adapter-satori-v0.1.0a2"),
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
         ("agent", "agent-v0.1.0a9"),

--- a/uv.lock
+++ b/uv.lock
@@ -1116,7 +1116,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0b1"
+version = "7.0.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1187,15 +1187,17 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-adapter-satori"
-version = "0.1.0a1"
+version = "0.1.0a2"
 source = { editable = "packages/adapter-satori" }
 dependencies = [
+    { name = "liteyukibot-v7" },
     { name = "liteyukibot-v7-runtime-adapter" },
     { name = "websockets" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "liteyukibot-v7", editable = "." },
     { name = "liteyukibot-v7-runtime-adapter", editable = "packages/runtime-adapter" },
     { name = "websockets", specifier = ">=15,<16" },
 ]


### PR DESCRIPTION
## Summary
- release the kernel as 7.0.0b2 so published adapters receive EditMessage
- release the native Satori adapter as 0.1.0a2 with an explicit kernel floor
- register both identities in release docs and regression coverage

## Root Cause
The immutable adapter-satori-v0.1.0a1 tag failed before upload because its wheel resolved the already-published 7.0.0b1 kernel, which does not export EditMessage.

## Validation
- uv lock --check
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv run pytest
- uv build --all-packages --out-dir dist/workspace --clear
- uv run python -m scripts.run_satori_adapter_install
- uv run python -m scripts.run_isolated_install --with dist/workspace/liteyukibot_v7-7.0.0b2-py3-none-any.whl --verifier scripts/verify_published_install.py -- --expected-version 7.0.0b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portable and native message-editing actions.
  * Added instance and worker management capabilities.
  * Introduced an interactive console.
  * Added experimental installation guidance for the Satori v1 gateway.

* **Documentation**
  * Updated project documentation and release references for LiteyukiBot v7.0.0b2.
  * Clarified that v6 remains available on its dedicated branch.
  * Updated performance artifact and release workflow information.

* **Chores**
  * Published LiteyukiBot v7.0.0b2 and the Satori adapter v0.1.0a2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->