### PR TITLE
feat(webui): add daemon-backed Vite launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__/
 .pytest_cache/
 .ruff_cache/
+.vite/
 
 # idea
 .idea/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "ruff>=0.14,<1",
     "maturin>=1.14.1",
     "types-jsonschema>=4.26,<5",
+    "httpx2>=2.9,<3",
 ]
 release = [
     "cyclonedx-bom>=7.3.1",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,8 @@ programs with deterministic inputs and clear exit statuses.
 - `verify_*_install.py` contains the verifier invoked by an isolated install.
 - `benchmark_v7.py` records kernel performance measurements.
 - `run_tool_install_smoke.py` verifies the published CLI installation flow.
+- `run_webui_daemon.ps1` builds the SPA, stages assets, and controls an
+  isolated local daemon WebUI instance for manual integration testing.
 
 Invoke scripts through uv from the repository root:
 
@@ -17,6 +19,21 @@ Invoke scripts through uv from the repository root:
 uv run python scripts/check_release.py
 uv run python -m scripts.run_tool_install_smoke
 ```
+
+On Windows, start and open a disposable WebUI instance with:
+
+```powershell
+.\scripts\run_webui_daemon.ps1
+```
+
+Use `-Action Start`, `-Action Status`, or `-Action Stop` for lifecycle
+control. The default workspace is `tmp\webui-daemon`; pass `-SkipBuild` to
+reuse already staged assets.
+
+For Vite HMR against a real daemon, run `pnpm --dir webui run web`. It starts
+an isolated development daemon with the `webui` optional package when needed,
+proxies `/api` through Vite with the required loopback origin, and opens the
+one-use WebUI handoff in the browser.
 
 When adding a publishable package, give it an isolated install verifier and add
 the package identity to `check_release.py`, CI, and the release procedure.

--- a/scripts/run_webui_daemon.ps1
+++ b/scripts/run_webui_daemon.ps1
@@ -1,0 +1,113 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Open", "Start", "Status", "Stop")]
+    [string]$Action = "Open",
+    [string]$Workspace,
+    [ValidateRange(0, 65535)]
+    [int]$Port = 0,
+    [ValidatePattern("^[a-z0-9](?:[a-z0-9-]{0,62})$")]
+    [string]$Instance = "default",
+    [switch]$SkipBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+if ([string]::IsNullOrWhiteSpace($Workspace)) {
+    $Workspace = Join-Path $RepositoryRoot "tmp\webui-daemon"
+}
+$Workspace = [System.IO.Path]::GetFullPath($Workspace)
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Command,
+        [Parameter(Mandatory)]
+        [string[]]$Arguments
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Command failed with exit code $LASTEXITCODE"
+    }
+}
+
+function Invoke-Liteyuki {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+
+    $commandArguments = @(
+        "run", "--extra", "webui", "liteyuki", "--workspace", $Workspace, "--instance", $Instance
+    ) + $Arguments
+    Invoke-Checked -Command "uv" -Arguments $commandArguments
+}
+
+function Get-WebUiStatus {
+    $output = & uv run --extra webui liteyuki --workspace $Workspace --instance $Instance web status 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+    return ($output | Out-String | ConvertFrom-Json)
+}
+
+function Initialize-Workspace {
+    if (-not (Test-Path (Join-Path $Workspace "liteyuki.toml"))) {
+        Invoke-Liteyuki @("init", "--non-interactive", "--locale", "en-US") | Out-Host
+    }
+}
+
+function Build-WebUi {
+    if ($SkipBuild) {
+        return
+    }
+    Invoke-Checked "pnpm" @("--dir", (Join-Path $RepositoryRoot "webui"), "install", "--frozen-lockfile") | Out-Host
+    Invoke-Checked "pnpm" @("--dir", (Join-Path $RepositoryRoot "webui"), "build") | Out-Host
+    Invoke-Checked "uv" @("run", "python", "scripts/stage_webui_assets.py") | Out-Host
+}
+
+function Start-WebUi {
+    Initialize-Workspace
+    Build-WebUi
+
+    $status = Get-WebUiStatus
+    if ($null -ne $status -and $status.state -eq "running") {
+        return $status
+    }
+
+    Invoke-Liteyuki @("--set", "webui.mode=always", "--set", "webui.port=$Port", "run", "--detach") | Out-Host
+    for ($attempt = 0; $attempt -lt 30; $attempt++) {
+        Start-Sleep -Milliseconds 250
+        $status = Get-WebUiStatus
+        if ($null -ne $status -and $status.state -eq "running") {
+            return $status
+        }
+    }
+    throw "daemon started but the WebUI did not become ready; inspect '$Workspace\.liteyuki\instances\$Instance\logs\daemon.log'"
+}
+
+Push-Location $RepositoryRoot
+try {
+    switch ($Action) {
+        "Start" {
+            Start-WebUi | ConvertTo-Json -Compress
+        }
+        "Open" {
+            $status = Start-WebUi
+            $status | ConvertTo-Json -Compress
+            Invoke-Liteyuki @("web", "open")
+        }
+        "Status" {
+            $status = Get-WebUiStatus
+            if ($null -eq $status) {
+                throw "no running daemon WebUI for workspace '$Workspace' and instance '$Instance'"
+            }
+            $status | ConvertTo-Json -Compress
+        }
+        "Stop" {
+            Invoke-Liteyuki @("instance", "stop")
+        }
+    }
+}
+finally {
+    Pop-Location
+}

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,8 @@ name = "anthropic"
 version = "0.121.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
     { name = "distro" },
     { name = "docstring-parser" },
     { name = "httpx" },
@@ -192,13 +193,35 @@ wheels = [
 name = "anyio"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version < '3.15' and sys_platform == 'emscripten'",
+]
 dependencies = [
-    { name = "idna" },
-    { name = "sniffio" },
+    { name = "idna", marker = "sys_platform == 'emscripten'" },
+    { name = "sniffio", marker = "sys_platform == 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.15' and sys_platform == 'win32'",
+    "python_full_version < '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "idna", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -841,7 +864,8 @@ name = "google-genai"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
     { name = "distro" },
     { name = "google-auth", extra = ["requests"] },
     { name = "httpx" },
@@ -949,6 +973,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -975,7 +1012,8 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
     { name = "certifi" },
     { name = "httpcore" },
     { name = "idna" },
@@ -1000,6 +1038,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -1028,11 +1091,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1273,6 +1336,7 @@ yaml = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx2" },
     { name = "maturin" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1309,6 +1373,7 @@ provides-extras = ["yaml", "http", "webui"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx2", specifier = ">=2.9,<3" },
     { name = "maturin", specifier = ">=1.14.1" },
     { name = "mypy", specifier = ">=1.18,<2" },
     { name = "pytest", specifier = ">=9,<10" },
@@ -1739,7 +1804,8 @@ name = "mcp"
 version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "jsonschema" },
@@ -1913,7 +1979,8 @@ name = "nonebot2"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
     { name = "exceptiongroup" },
     { name = "loguru" },
     { name = "pydantic" },
@@ -1995,7 +2062,8 @@ name = "openai"
 version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
     { name = "distro" },
     { name = "httpx" },
     { name = "jiter" },
@@ -3120,7 +3188,8 @@ name = "sse-starlette"
 version = "3.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
     { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
@@ -3133,7 +3202,8 @@ name = "starlette"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
@@ -3197,6 +3267,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]
@@ -3343,7 +3422,8 @@ name = "watchfiles"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'emscripten'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
 wheels = [

--- a/webui/package.json
+++ b/webui/package.json
@@ -9,6 +9,8 @@
   },
   "scripts": {
     "dev": "vite",
+    "web": "node ./scripts/dev-daemon.mjs",
+    "dev:daemon": "node ./scripts/dev-daemon.mjs",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -b",

--- a/webui/scripts/dev-daemon.mjs
+++ b/webui/scripts/dev-daemon.mjs
@@ -1,0 +1,130 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import net from "node:net";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const webuiRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = resolve(webuiRoot, "..");
+const options = parseOptions(process.argv.slice(2));
+const workspace = resolve(options.workspace ?? join(repositoryRoot, "tmp", "webui-daemon"));
+const descriptor = join(workspace, ".liteyuki", "instances", options.instance, "daemon.json");
+
+await ensureDaemon();
+const handoff = await requestControl("webui.open");
+if (!handoff || typeof handoff.url !== "string") throw new Error("daemon returned an invalid WebUI handoff URL");
+
+const daemonUrl = new URL(handoff.url);
+const ticket = daemonUrl.hash;
+if (!/^#ticket=[^&]+$/.test(ticket)) throw new Error("daemon returned an invalid WebUI ticket");
+
+const viteArguments = [
+  join(webuiRoot, "node_modules", "vite", "bin", "vite.js"), "--host", "127.0.0.1", "--port", String(options.port), "--strictPort",
+];
+if (!options.noOpen) viteArguments.push("--open", `/${ticket}`);
+if (!existsSync(viteArguments[0])) throw new Error("Vite is not installed; run `pnpm --dir webui install --frozen-lockfile`");
+
+console.log(`Proxying /api to ${daemonUrl.origin}; daemon workspace: ${workspace}`);
+const vite = spawn(process.execPath, viteArguments, {
+  cwd: webuiRoot,
+  env: { ...process.env, LITEYUKI_WEBUI_PROXY_TARGET: daemonUrl.origin },
+  stdio: "inherit",
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => vite.kill(signal));
+}
+vite.once("exit", (code, signal) => process.exitCode = code ?? (signal ? 1 : 0));
+
+async function ensureDaemon() {
+  try {
+    await requestControl("status");
+    return;
+  } catch {
+    if (!existsSync(join(workspace, "liteyuki.toml"))) {
+      await run("uv", ["run", "--extra", "webui", "liteyuki", "--workspace", workspace, "init", "--non-interactive", "--locale", "en-US"]);
+    }
+    await run("uv", [
+      "run", "--extra", "webui", "liteyuki", "--workspace", workspace, "--instance", options.instance,
+      "--set", "webui.mode=always", "--set", "webui.port=0", "run", "--detach",
+    ]);
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      await delay(250);
+      try {
+        await requestControl("status");
+        return;
+      } catch {
+        // The detached daemon has not published its descriptor yet.
+      }
+    }
+    throw new Error(`daemon did not become ready; inspect ${join(workspace, ".liteyuki", "instances", options.instance, "logs", "daemon.log")}`);
+  }
+}
+
+async function requestControl(command) {
+  const value = JSON.parse(await readFile(descriptor, "utf8"));
+  if (
+    value?.protocol !== 1 || value.host !== "127.0.0.1" || !Number.isInteger(value.port)
+    || value.port < 1 || value.port > 65535 || typeof value.token !== "string" || !value.token
+  ) {
+    throw new Error(`invalid daemon descriptor: ${descriptor}`);
+  }
+  return await new Promise((resolveResponse, reject) => {
+    const socket = net.createConnection({ host: value.host, port: value.port });
+    let buffer = "";
+    const timeout = setTimeout(() => socket.destroy(new Error("daemon control request timed out")), 5000);
+    socket.setEncoding("utf8");
+    socket.once("connect", () => socket.write(`${JSON.stringify({ token: value.token, command })}\n`));
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      if (!buffer.includes("\n")) return;
+      socket.end();
+      try {
+        const response = JSON.parse(buffer);
+        if (!response?.ok) throw new Error(response?.error ?? "invalid daemon control response");
+        resolveResponse(response.result);
+      } catch (error) {
+        reject(error);
+      }
+    });
+    socket.once("error", reject);
+    socket.once("close", () => clearTimeout(timeout));
+  });
+}
+
+function run(command, arguments_) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, arguments_, { cwd: repositoryRoot, stdio: "inherit" });
+    child.once("error", reject);
+    child.once("exit", (code) => code === 0 ? resolveRun() : reject(new Error(`${command} exited with ${code}`)));
+  });
+}
+
+function parseOptions(arguments_) {
+  const options_ = { instance: "default", port: 5173, workspace: undefined, noOpen: false };
+  for (let index = 0; index < arguments_.length; index += 1) {
+    const value = arguments_[index];
+    if (value === "--workspace") options_.workspace = requiredValue(arguments_, ++index, value);
+    else if (value === "--instance") options_.instance = requiredValue(arguments_, ++index, value);
+    else if (value === "--port") options_.port = Number(requiredValue(arguments_, ++index, value));
+    else if (value === "--no-open") options_.noOpen = true;
+    else if (value === "--help") {
+      console.log("Usage: pnpm run web -- [--workspace PATH] [--instance NAME] [--port PORT] [--no-open]");
+      process.exit(0);
+    } else throw new Error(`unknown option: ${value}`);
+  }
+  if (!Number.isInteger(options_.port) || options_.port < 1 || options_.port > 65535) throw new Error("--port must be 1..65535");
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,62})$/.test(options_.instance)) throw new Error("--instance must use lower-case ASCII letters, digits, or hyphens");
+  return options_;
+}
+
+function requiredValue(arguments_, index, option) {
+  const value = arguments_[index];
+  if (!value || value.startsWith("--")) throw new Error(`${option} requires a value`);
+  return value;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
+}

--- a/webui/scripts/dev-daemon.mjs
+++ b/webui/scripts/dev-daemon.mjs
@@ -38,28 +38,42 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
 vite.once("exit", (code, signal) => process.exitCode = code ?? (signal ? 1 : 0));
 
 async function ensureDaemon() {
+  let responding = false;
   try {
-    await requestControl("status");
-    return;
+    if (await daemonIsRunning()) return;
+    responding = true;
   } catch {
-    if (!existsSync(join(workspace, "liteyuki.toml"))) {
-      await run("uv", ["run", "--extra", "webui", "liteyuki", "--workspace", workspace, "init", "--non-interactive", "--locale", "en-US"]);
-    }
-    await run("uv", [
-      "run", "--extra", "webui", "liteyuki", "--workspace", workspace, "--instance", options.instance,
-      "--set", "webui.mode=always", "--set", "webui.port=0", "run", "--detach",
-    ]);
-    for (let attempt = 0; attempt < 30; attempt += 1) {
-      await delay(250);
-      try {
-        await requestControl("status");
-        return;
-      } catch {
-        // The detached daemon has not published its descriptor yet.
-      }
-    }
-    throw new Error(`daemon did not become ready; inspect ${join(workspace, ".liteyuki", "instances", options.instance, "logs", "daemon.log")}`);
+    // A missing or stale descriptor permits launching a replacement daemon.
   }
+  if (responding && await waitForDaemonRunning()) return;
+  if (responding && existsSync(descriptor)) throw new Error("existing daemon did not reach the running state");
+
+  if (!existsSync(join(workspace, "liteyuki.toml"))) {
+    await run("uv", ["run", "--extra", "webui", "liteyuki", "--workspace", workspace, "init", "--non-interactive", "--locale", "en-US"]);
+  }
+  await run("uv", [
+    "run", "--extra", "webui", "liteyuki", "--workspace", workspace, "--instance", options.instance,
+    "--set", "webui.mode=always", "--set", "webui.port=0", "run", "--detach",
+  ]);
+  if (await waitForDaemonRunning()) return;
+  throw new Error(`daemon did not become ready; inspect ${join(workspace, ".liteyuki", "instances", options.instance, "logs", "daemon.log")}`);
+}
+
+async function daemonIsRunning() {
+  const status = await requestControl("status");
+  return status?.state === "running";
+}
+
+async function waitForDaemonRunning() {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    await delay(250);
+    try {
+      if (await daemonIsRunning()) return true;
+    } catch {
+      // The detached daemon has not published its descriptor yet.
+    }
+  }
+  return false;
 }
 
 async function requestControl(command) {

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -33,6 +33,7 @@ export function App() {
   const [workspace, setWorkspace] = useState<Workspace>(currentWorkspace);
   const [dashboard, setDashboard] = useState<Dashboard | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [sessionReady, setSessionReady] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [dismissFirstRun, setDismissFirstRun] = useState(false);
   const [operation, setOperation] = useState<WebUiOperation | null>(null);
@@ -41,6 +42,7 @@ export function App() {
     try {
       setError(null);
       await api.initialize();
+      setSessionReady(true);
       const [bootstrap, ledger, catalog, audit] = await Promise.all([api.bootstrap(), api.ledger(), api.catalog(), api.audit()]);
       setDashboard(projectDashboard(bootstrap, ledger, catalog.operations, audit.items));
     } catch (cause) {
@@ -56,9 +58,10 @@ export function App() {
     return () => window.removeEventListener("hashchange", onHash);
   }, []);
   useEffect(() => {
+    if (!sessionReady) return;
     const source = api.events((type) => { if (type !== "heartbeat") void reload(); }, () => undefined);
     return () => source.close();
-  }, [api, reload]);
+  }, [api, reload, sessionReady]);
 
   const navigate = (next: Workspace) => { window.location.hash = `#/${next}`; setWorkspace(next); setMenuOpen(false); };
   if (error) return <Unavailable error={error} retry={reload} />;

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -47,6 +47,7 @@ export function App() {
       setDashboard(projectDashboard(bootstrap, ledger, catalog.operations, audit.items));
     } catch (cause) {
       setDashboard(null);
+      setSessionReady(false);
       setError(cause instanceof Error ? cause.message : "webui.request_failed");
     }
   }, [api]);

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -25,7 +25,12 @@ export class WebUiApi {
   private initialization: Promise<void> | null = null;
 
   async initialize(): Promise<void> {
-    this.initialization ??= this.initializeSession();
+    if (this.initialization === null) {
+      this.initialization = this.initializeSession().catch((error: unknown) => {
+        this.initialization = null;
+        throw error;
+      });
+    }
     return this.initialization;
   }
 

--- a/webui/src/lib/api.ts
+++ b/webui/src/lib/api.ts
@@ -22,8 +22,14 @@ export type WebUiOperationRecord = {
 
 export class WebUiApi {
   private csrfToken: string | null = null;
+  private initialization: Promise<void> | null = null;
 
   async initialize(): Promise<void> {
+    this.initialization ??= this.initializeSession();
+    return this.initialization;
+  }
+
+  private async initializeSession(): Promise<void> {
     const match = /^#ticket=([^&]+)$/.exec(window.location.hash);
     const result = match
       ? await this.request<{ csrf_token: string }>("/session", {

--- a/webui/tests/shell.spec.ts
+++ b/webui/tests/shell.spec.ts
@@ -81,7 +81,13 @@ test("high-impact operations require an explicit target and submit typed input",
 });
 
 test("service errors render a recoverable unavailable state", async ({ page }) => {
-  await page.route("**/api/v1/**", (route) => route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: { code: "webui.bridge_unavailable" } }) }));
+  let sessionRequests = 0;
+  await page.route("**/api/v1/**", (route) => {
+    if (new URL(route.request().url()).pathname.endsWith("/session")) sessionRequests += 1;
+    return route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: { code: "webui.bridge_unavailable" } }) });
+  });
   await page.goto("/#/overview");
   await expect(page.getByText("Local service unavailable", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect.poll(() => sessionRequests).toBe(2);
 });

--- a/webui/tests/shell.spec.ts
+++ b/webui/tests/shell.spec.ts
@@ -57,12 +57,12 @@ test("workspaces project live ledger, topology, runtimes, and plugins", async ({
 });
 
 test("handoff fragment redeems its ticket before loading the local snapshot", async ({ page }) => {
-  let ticket: unknown;
+  const tickets: unknown[] = [];
   await mockDaemon(page);
-  await page.route("**/api/v1/session", async (route) => { ticket = route.request().postDataJSON(); await route.fulfill({ contentType: "application/json", body: JSON.stringify({ csrf_token: "csrf" }) }); });
+  await page.route("**/api/v1/session", async (route) => { tickets.push(route.request().postDataJSON()); await route.fulfill({ contentType: "application/json", body: JSON.stringify({ csrf_token: "csrf" }) }); });
   await page.goto("/#ticket=one-time-ticket");
   await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
-  expect(ticket).toEqual({ ticket: "one-time-ticket" });
+  expect(tickets).toEqual([{ ticket: "one-time-ticket" }]);
   await expect(page).toHaveURL(/#\/overview$/);
 });
 

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -4,6 +4,8 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
+const daemonTarget = process.env.LITEYUKI_WEBUI_PROXY_TARGET;
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
@@ -11,4 +13,17 @@ export default defineConfig({
       "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
+  server: daemonTarget
+    ? {
+      proxy: {
+        "/api": {
+          target: daemonTarget,
+          changeOrigin: true,
+          configure(proxy) {
+            proxy.on("proxyReq", (request) => request.setHeader("origin", daemonTarget));
+          },
+        },
+      },
+    }
+    : undefined,
 });


### PR DESCRIPTION
## Summary
- add `pnpm run web` for a local daemon-backed Vite/HMR session with authenticated API proxying
- add a PowerShell lifecycle helper for production-asset daemon smoke tests
- make ticket redemption idempotent under React StrictMode and delay SSE until the session exists
- add the WebUI test-client dependency explicitly and cover one-time ticket redemption

## Validation
- `uv lock --check`
- `uv run --extra webui pytest -q packages/webui/tests`
- `pnpm --dir webui typecheck`
- `pnpm --dir webui test:e2e`
- `pnpm --dir webui build`
- `uv build --project packages/webui --out-dir dist/workspace`
- `uv run python -m scripts.run_webui_install`
- real daemon -> Vite proxy -> Playwright handoff/session/SSE smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streamlined Windows tools for building, launching, monitoring, and stopping the WebUI daemon.
  * Added WebUI development commands with workspace, port, instance, browser, and build options.
  * Added configurable API proxying for local WebUI development.
* **Bug Fixes**
  * Prevented duplicate session initialization and enabled retries after failures.
  * Delayed event-stream connections until the WebUI session is ready.
  * Improved session handoff and service-error handling.
* **Documentation**
  * Added Windows usage guidance for WebUI daemon workflows and Vite hot-reload development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->