### PR TITLE
fix(webui): reauthorize active event streams

### DIFF
--- a/packages/webui/src/liteyukibot_webui/service.py
+++ b/packages/webui/src/liteyukibot_webui/service.py
@@ -33,6 +33,7 @@ _COOKIE_NAME = "liteyuki_webui_session"
 _EVENT_TYPES = frozenset({"snapshot", "ledger_append", "operation", "heartbeat", "reset"})
 _UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 _MAX_EVENT_REPLAY = 4096
+_SSE_REAUTHORIZATION_SECONDS = 15.0
 
 
 class WebUiUnavailableError(RuntimeError):
@@ -146,7 +147,7 @@ class _SessionStore:
         self._sessions[identifier] = session
         return identifier, session
 
-    def get(self, identifier: str | None) -> _Session | None:
+    def get(self, identifier: str | None, *, touch: bool = True) -> _Session | None:
         if identifier is None:
             return None
         session = self._sessions.get(identifier)
@@ -156,7 +157,8 @@ class _SessionStore:
         if now - session.last_seen_at > self._idle_seconds or now - session.created_at > self._maximum_seconds:
             self._sessions.pop(identifier, None)
             return None
-        session.last_seen_at = now
+        if touch:
+            session.last_seen_at = now
         return session
 
     def remove(self, identifier: str | None) -> None:
@@ -243,9 +245,9 @@ def create_app(
             return _error("webui.origin_required", 403)
         return await call_next(request)
 
-    async def authenticated(request: Request, *, csrf: bool = False) -> _Session:
+    async def authenticated(request: Request, *, csrf: bool = False, touch: bool = True) -> _Session:
         identifier = request.cookies.get(_COOKIE_NAME)
-        session = sessions.get(identifier)
+        session = sessions.get(identifier, touch=touch)
         if session is None:
             raise WebUiServiceError("webui.session_required", 401)
         if csrf and not hmac.compare_digest(request.headers.get("x-csrf-token", ""), session.csrf_token):
@@ -371,6 +373,14 @@ def create_app(
         replay = await invoke(bridge.replay_events(session.principal, after_id, _MAX_EVENT_REPLAY))
 
         async def stream() -> AsyncIterable[str]:
+            next_reauthorization_at = time.monotonic() + _SSE_REAUTHORIZATION_SECONDS
+
+            async def reauthorize_if_due() -> None:
+                nonlocal next_reauthorization_at
+                if time.monotonic() >= next_reauthorization_at:
+                    await authenticated(request, touch=False)
+                    next_reauthorization_at = time.monotonic() + _SSE_REAUTHORIZATION_SECONDS
+
             if replay.reset:
                 yield _sse(WebUiEvent("reset", {"reason": "replay_unavailable"}))
                 return
@@ -378,6 +388,7 @@ def create_app(
                 yield _sse(event)
             try:
                 async for event in bridge.stream_events(session.principal, after_id):
+                    await reauthorize_if_due()
                     yield _sse(event)
             except WebUiServiceError as error:
                 yield _sse(WebUiEvent("reset", {"reason": error.code}))

--- a/packages/webui/tests/test_service.py
+++ b/packages/webui/tests/test_service.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from collections.abc import AsyncIterable
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 from liteyukibot_webui import WebUiEvent, WebUiEventReplay, WebUiPrincipal, WebUiServer, create_app
+from liteyukibot_webui import service as webui_service
 from liteyukibot_webui.service import JsonObject
 
 
@@ -63,10 +65,27 @@ class Bridge:
             yield WebUiEvent("heartbeat", {})
 
 
-def _client(tmp_path: Path) -> tuple[TestClient, Bridge]:
+def _client(
+    tmp_path: Path,
+    bridge: Bridge | None = None,
+    *,
+    session_idle_seconds: int = 1800,
+    session_max_seconds: int = 28800,
+) -> tuple[TestClient, Bridge]:
     (tmp_path / "index.html").write_text("<main>Liteyuki</main>", encoding="utf-8")
-    bridge = Bridge()
-    return TestClient(create_app(bridge, asset_directory=tmp_path), base_url="http://127.0.0.1:9321"), bridge
+    resolved_bridge = bridge or Bridge()
+    return (
+        TestClient(
+            create_app(
+                resolved_bridge,
+                asset_directory=tmp_path,
+                session_idle_seconds=session_idle_seconds,
+                session_max_seconds=session_max_seconds,
+            ),
+            base_url="http://127.0.0.1:9321",
+        ),
+        resolved_bridge,
+    )
 
 
 def _session(client: TestClient) -> str:
@@ -126,6 +145,52 @@ def test_sse_replay_and_reset_are_protocol_events(tmp_path: Path) -> None:
 
     reset = client.get("/api/v1/events", headers={"Last-Event-ID": "expired"})
     assert "event: reset\ndata: {\"reason\":\"replay_unavailable\"}" in reset.text
+
+
+def test_sse_reauthorizes_before_emitting_follow_up_events(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    class RevokedBridge(Bridge):
+        def __init__(self) -> None:
+            super().__init__()
+            self.authorized = True
+
+        async def authorize_session(self, principal: WebUiPrincipal) -> bool:
+            return self.authorized and await super().authorize_session(principal)
+
+        async def stream_events(self, _principal: WebUiPrincipal, _after_id: str | None) -> AsyncIterable[WebUiEvent]:
+            self.authorized = False
+            yield WebUiEvent("operation", {"id": "must-not-be-delivered"})
+
+    monkeypatch.setattr(webui_service, "_SSE_REAUTHORIZATION_SECONDS", 0.0)
+    client, _bridge = _client(tmp_path, RevokedBridge())
+    _session(client)
+
+    response = client.get("/api/v1/events")
+
+    assert "event: reset\ndata: {\"reason\":\"webui.session_invalid\"}" in response.text
+    assert "must-not-be-delivered" not in response.text
+
+
+def test_sse_idle_expiry_does_not_continue_stream_delivery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    class ExpiringBridge(Bridge):
+        async def stream_events(self, _principal: WebUiPrincipal, _after_id: str | None) -> AsyncIterable[WebUiEvent]:
+            clock[0] = 61.0
+            yield WebUiEvent("operation", {"id": "must-not-be-delivered"})
+
+    clock = [0.0]
+    monkeypatch.setattr("liteyukibot_webui.service.time.monotonic", lambda: clock[0])
+    monkeypatch.setattr(webui_service, "_SSE_REAUTHORIZATION_SECONDS", 0.0)
+    client, _bridge = _client(
+        tmp_path,
+        ExpiringBridge(),
+        session_idle_seconds=60,
+        session_max_seconds=300,
+    )
+    _session(client)
+
+    response = client.get("/api/v1/events")
+
+    assert "event: reset\ndata: {\"reason\":\"webui.session_required\"}" in response.text
+    assert "must-not-be-delivered" not in response.text
 
 
 def test_static_spa_fallback_is_packaged_by_the_server(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- revalidate WebUI SSE sessions before continued delivery
- keep stream checks from refreshing the session idle timer
- reset and close the stream after session expiry or capability revocation

## Validation
- `uv run ruff check packages/webui/src/liteyukibot_webui/service.py packages/webui/tests/test_service.py`
- `uv run mypy packages/webui/src/liteyukibot_webui/service.py packages/webui/tests/test_service.py`
- `uv run pytest -q packages/webui/tests tests/test_app_v7.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSE connections now periodically verify authorization, preventing continued event delivery after access is revoked.
  * Idle session expiration is respected during active SSE streams, improving session security.
  * Session checks no longer unintentionally extend idle expiration during reauthorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->