### PR TITLE
test(runtime): retain native agent failure diagnostics

### DIFF
--- a/packages/agent/tests/test_native_agent.py
+++ b/packages/agent/tests/test_native_agent.py
@@ -270,7 +270,6 @@ async def test_native_agent_child_round_trips_mock_provider_tool_and_source_acti
 
     server = await asyncio.start_server(provider, "127.0.0.1", 0)
     port = int(server.sockets[0].getsockname()[1])
-    action_received = asyncio.Event()
     observed_tools: list[tuple[str, str, str, Mapping[str, JsonValue]]] = []
     observed_actions: list[Mapping[str, JsonValue]] = []
 
@@ -287,7 +286,6 @@ async def test_native_agent_child_round_trips_mock_provider_tool_and_source_acti
 
     async def action_sink(_runtime_id: str, payload: dict[str, JsonValue]) -> ActionSinkResult:
         observed_actions.append(payload)
-        action_received.set()
         return ActionSinkResult(ok=True)
 
     spec = RuntimeSpec(
@@ -343,7 +341,8 @@ async def test_native_agent_child_round_trips_mock_provider_tool_and_source_acti
                 },
             )
             assert accepted == EventAccepted(correlation_id="delivery-1", status="accepted")
-            await asyncio.wait_for(action_received.wait(), timeout=12)
+            completed = await harness.wait_for_delivery_completion("delivery-1", timeout_seconds=12)
+            assert completed == EventCompleted(correlation_id="delivery-1", status="completed")
     finally:
         server.close()
         await server.wait_closed()

--- a/src/liteyukibot/runtime/supervisor.py
+++ b/src/liteyukibot/runtime/supervisor.py
@@ -48,6 +48,8 @@ from .protocol import (
 )
 
 EventSink = Callable[[str, dict[str, JsonValue]], Awaitable[str]]
+RuntimeOutputSink = Callable[[str, Literal["stdout", "stderr"], str], None]
+DeliveryCompletionSink = Callable[[str, EventCompleted], Awaitable[None]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,6 +181,8 @@ class RuntimeSupervisor:
         action_sink: ActionSink | None = None,
         agent_tool_sink: AgentToolSink | None = None,
         management_sink: ManagementSink | None = None,
+        output_sink: RuntimeOutputSink | None = None,
+        delivery_completion_sink: DeliveryCompletionSink | None = None,
         secret_values: Mapping[str, str] | None = None,
         lyip_settings: LyipSettings | None = None,
     ) -> None:
@@ -187,6 +191,8 @@ class RuntimeSupervisor:
         self.action_sink = action_sink
         self.agent_tool_sink = agent_tool_sink
         self.management_sink = management_sink
+        self.output_sink = output_sink
+        self.delivery_completion_sink = delivery_completion_sink
         self.secret_values = dict(secret_values or {})
         self._lyip_settings = lyip_settings or LyipSettings()
         self.records: dict[str, RuntimeRecord] = {}
@@ -572,6 +578,8 @@ class RuntimeSupervisor:
             status=message.status,
             detail=message.detail,
         ).info("runtime event delivery {}", message.status)
+        if self.delivery_completion_sink is not None:
+            await self.delivery_completion_sink(record.spec.id, message)
 
     async def _accept_child_event(self, record: RuntimeRecord, message: EventMessage) -> None:
         if message.correlation_id in record.inbound_events:
@@ -1196,7 +1204,12 @@ class RuntimeSupervisor:
         if inbound_management:
             await asyncio.gather(*inbound_management, return_exceptions=True)
 
-    async def _capture_output(self, record: RuntimeRecord, stream: asyncio.StreamReader, channel: str) -> None:
+    async def _capture_output(
+        self,
+        record: RuntimeRecord,
+        stream: asyncio.StreamReader,
+        channel: Literal["stdout", "stderr"],
+    ) -> None:
         logger = self.logger.bind(
             runtime=record.spec.id,
             component="runtime",
@@ -1205,6 +1218,8 @@ class RuntimeSupervisor:
         )
         while line := await stream.readline():
             text = line.decode("utf-8", errors="replace").rstrip("\r\n")
+            if self.output_sink is not None:
+                self.output_sink(record.spec.id, channel, text)
             structured = decode_child_runtime_line(text)
             if structured is not None:
                 self._emit_structured_output(logger, structured)

--- a/src/liteyukibot/testing.py
+++ b/src/liteyukibot/testing.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import tempfile
+from collections import deque
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import replace
 from pathlib import Path
@@ -28,7 +30,7 @@ from .runtime import (
     RuntimeState,
     RuntimeSupervisor,
 )
-from .runtime.protocol import JsonValue, json_mapping
+from .runtime.protocol import EventCompleted, JsonValue, json_mapping
 from .runtime.supervisor import ActionProvenance, ActionSinkResult, AgentToolSink, AgentToolSinkResult, EventSink
 from .services import ServiceKey, ServiceRegistry
 
@@ -180,11 +182,16 @@ class RuntimeTestHarness:
         self._agent_tool_sink = agent_tool_sink
         self._child_events: list[tuple[str, dict[str, JsonValue]]] = []
         self._child_actions: list[tuple[str, dict[str, JsonValue]]] = []
+        self._child_output: deque[tuple[str, str]] = deque(maxlen=100)
+        self._delivery_completions: dict[str, EventCompleted] = {}
+        self._delivery_completion_condition = asyncio.Condition()
         self._supervisor = RuntimeSupervisor(
             logger=get_logger(component="runtime-test"),
             event_sink=self._record_event,
             action_sink=self._record_action,
             agent_tool_sink=self._record_agent_tool,
+            output_sink=self._record_output,
+            delivery_completion_sink=self._record_delivery_completion,
         )
         self._supervisor.add(self.spec)
         self._started = False
@@ -215,6 +222,15 @@ class RuntimeTestHarness:
             (runtime_id, json_mapping(payload))
             for runtime_id, payload in self._child_actions
         )
+
+    @property
+    def child_output(self) -> tuple[tuple[str, str], ...]:
+        return tuple(self._child_output)
+
+    def diagnostics(self) -> str:
+        health = self._supervisor.health()[self.spec.id]
+        output = "\n".join(f"[{channel}] {line}" for channel, line in self._child_output)
+        return f"runtime health: {health}\nchild output:\n{output or '<none>'}"
 
     async def start(self) -> None:
         if self._closed:
@@ -272,6 +288,22 @@ class RuntimeTestHarness:
             timeout_seconds,
         )
 
+    async def wait_for_delivery_completion(self, correlation_id: str, *, timeout_seconds: float) -> EventCompleted:
+        if not self._started:
+            raise RuntimeError("runtime test harness is not started")
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                async with self._delivery_completion_condition:
+                    await self._delivery_completion_condition.wait_for(
+                        lambda: correlation_id in self._delivery_completions
+                    )
+                    return self._delivery_completions[correlation_id]
+        except TimeoutError as error:
+            raise TimeoutError(
+                f"runtime delivery {correlation_id} did not complete within {timeout_seconds:.1f}s\n"
+                f"{self.diagnostics()}"
+            ) from error
+
     async def _record_event(self, runtime_id: str, payload: dict[str, JsonValue]) -> str:
         self._child_events.append((runtime_id, json_mapping(payload)))
         if self._event_sink is None:
@@ -300,6 +332,14 @@ class RuntimeTestHarness:
         if self._agent_tool_sink is None:
             return AgentToolSinkResult(ok=False, error="agent tool sink is not configured")
         return await self._agent_tool_sink(runtime_id, delivery_correlation_id, payload, tool_id, arguments)
+
+    def _record_output(self, _runtime_id: str, channel: str, line: str) -> None:
+        self._child_output.append((channel, line))
+
+    async def _record_delivery_completion(self, _runtime_id: str, message: EventCompleted) -> None:
+        async with self._delivery_completion_condition:
+            self._delivery_completions[message.correlation_id] = message
+            self._delivery_completion_condition.notify_all()
 
     async def __aenter__(self) -> RuntimeTestHarness:
         await self.start()

--- a/tests/test_developer_kit.py
+++ b/tests/test_developer_kit.py
@@ -282,6 +282,8 @@ async def test_custom_runtime_example_round_trips_events_and_actions() -> None:
             correlation_id="event-delivery",
             status="accepted",
         )
+        completed = await harness.wait_for_delivery_completion("event-delivery", timeout_seconds=2)
+        assert completed.status == "completed"
         assert len(harness.child_actions) == 1
         runtime_id, payload = harness.child_actions[0]
         assert runtime_id == "example-runtime"
@@ -303,6 +305,10 @@ async def test_custom_runtime_example_round_trips_events_and_actions() -> None:
         )
         assert invalid.status == "invalid"
         assert invalid.detail is not None
+
+        with pytest.raises(TimeoutError, match="runtime health") as error:
+            await harness.wait_for_delivery_completion("missing-delivery", timeout_seconds=0.01)
+        assert "child output" in str(error.value)
 
     assert harness.state.value == RuntimeState.STOPPED.value
     await harness.stop()


### PR DESCRIPTION
## Summary
- expose bounded child output and delivery-completion observations to `RuntimeTestHarness`
- make native-agent E2E wait for full delivery completion and emit runtime diagnostics on timeout
- cover harness timeout diagnostics and completion observation

## Validation
- `uv run ruff check src/liteyukibot/runtime/supervisor.py src/liteyukibot/testing.py packages/agent/tests/test_native_agent.py tests/test_developer_kit.py`
- `uv run mypy src/liteyukibot/runtime/supervisor.py src/liteyukibot/testing.py tests/test_developer_kit.py`
- `uv run pytest -q packages/agent/tests tests/test_runtime_v7.py tests/test_developer_kit.py` (61 passed)
- 20 isolated Windows native-agent child E2E runs (20 passed)