### PR TITLE
perf(webui): optimize workspace rendering

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -17,6 +17,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "3.14.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.544.0",

--- a/webui/pnpm-lock.yaml
+++ b/webui/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@tanstack/react-virtual':
+        specifier: 3.14.9
+        version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1272,6 +1275,15 @@ packages:
     resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/react-virtual@3.14.9':
+    resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.7':
+    resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2840,6 +2852,14 @@ snapshots:
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
       vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.7
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
+  '@tanstack/virtual-core@3.17.7': {}
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/webui/src/app/App.tsx
+++ b/webui/src/app/App.tsx
@@ -1,19 +1,19 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { CircleAlert, RefreshCw } from "lucide-react";
 
-import { Sidebar, TopStatusBar, navigation } from "@/components/app-shell";
+import { Sidebar, TopStatusBar } from "@/components/app-shell";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { OperationDialog } from "@/features/operations/operation-dialog";
-import { WorkspaceView } from "@/features/workspaces/workspace-view";
-import { useLocale } from "@/i18n/locale";
-import type { WebUiOperation } from "@/models/api";
+import { useLocale, useLocaleActions } from "@/i18n/locale";
 import { projectDashboard, type Dashboard } from "@/models/dashboard";
 import { isWorkspace, type Workspace } from "@/models/workspace";
 import { WebUiApi } from "@/services/webui-api";
+
+const workspaceViewModule = import("@/features/workspaces/workspace-view");
+const WorkspaceView = lazy(() => workspaceViewModule.then(({ WorkspaceView: View }) => ({ default: View })));
 
 function currentWorkspace(): Workspace {
   const value = window.location.hash.replace(/^#\//, "");
@@ -21,21 +21,20 @@ function currentWorkspace(): Workspace {
 }
 
 export function App() {
-  const { locale, presentation, applyPresentation, t } = useLocale();
+  const { applyPresentation, getLocale } = useLocaleActions();
   const api = useMemo(() => new WebUiApi(), []);
   const [workspace, setWorkspace] = useState<Workspace>(currentWorkspace);
   const [dashboard, setDashboard] = useState<Dashboard | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [sessionReady, setSessionReady] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [operation, setOperation] = useState<WebUiOperation | null>(null);
 
-  const reload = useCallback(async () => {
+  const reload = useCallback(async (requestedLocale?: string) => {
     try {
       setError(null);
       await api.initialize();
       setSessionReady(true);
-      const [bootstrap, ledger, catalog, audit, resolvedPresentation] = await Promise.all([api.bootstrap(), api.ledger(), api.catalog(), api.audit(), api.presentation(locale)]);
+      const [bootstrap, ledger, catalog, audit, resolvedPresentation] = await Promise.all([api.bootstrap(), api.ledger(), api.catalog(), api.audit(), api.presentation(requestedLocale ?? getLocale())]);
       applyPresentation(resolvedPresentation);
       setDashboard(projectDashboard(bootstrap, ledger, catalog.operations, audit.items));
     } catch (cause) {
@@ -43,9 +42,8 @@ export function App() {
       setSessionReady(false);
       setError(cause instanceof Error ? cause.message : "webui.request_failed");
     }
-  }, [api, applyPresentation, locale]);
+  }, [api, applyPresentation, getLocale]);
 
-  useEffect(() => { void reload(); }, [reload]);
   useEffect(() => {
     const onHash = () => setWorkspace(currentWorkspace());
     window.addEventListener("hashchange", onHash);
@@ -57,12 +55,16 @@ export function App() {
     return () => source.close();
   }, [api, reload, sessionReady]);
 
-  const navigate = (next: Workspace) => { window.location.hash = `#/${next}`; setWorkspace(next); setMenuOpen(false); };
-  if (error) return <Unavailable error={error} retry={reload} />;
-  if (!dashboard) return <Loading />;
+  const navigate = useCallback((next: Workspace) => { window.location.hash = `#/${next}`; setWorkspace(next); setMenuOpen(false); }, []);
+  const openNavigation = useCallback(() => setMenuOpen(true), []);
+  const refresh = useCallback(() => void reload(), [reload]);
+  return <><PresentationSynchronizer reload={reload} />{error ? <Unavailable error={error} retry={reload} /> : !dashboard ? <Loading /> : <TooltipProvider><div className="grid min-h-screen bg-background lg:grid-cols-[236px_minmax(0,1fr)]"><Sidebar active={workspace} dashboard={dashboard} navigate={navigate} /><Sheet open={menuOpen} onOpenChange={setMenuOpen}><SheetContent side="left" className="w-72 p-0"><SheetHeader className="sr-only"><SheetTitle>Navigation</SheetTitle></SheetHeader><Sidebar active={workspace} dashboard={dashboard} drawer navigate={navigate} /></SheetContent></Sheet><div className="min-w-0"><TopStatusBar dashboard={dashboard} workspace={workspace} openNavigation={openNavigation} refresh={refresh} /><main className="px-4 py-6 sm:px-7 sm:py-7 lg:px-10 lg:pb-6 lg:pt-0"><section className="webui-workspace-base mx-auto max-w-[1120px]"><Suspense fallback={<Skeleton className="h-[382px] w-full" />}><WorkspaceView workspace={workspace} dashboard={dashboard} api={api} reload={reload} /></Suspense></section></main></div></div></TooltipProvider>}</>;
+}
 
-  const pageTitle = t(navigation.find((entry) => entry.id === workspace)?.labelKey ?? "webui.nav.overview");
-  return <TooltipProvider><div className="grid min-h-screen bg-background lg:grid-cols-[236px_minmax(0,1fr)]"><Sidebar active={workspace} webuiVersion={presentation?.webuiVersion ?? "-"} dashboard={dashboard} navigate={navigate} /><Sheet open={menuOpen} onOpenChange={setMenuOpen}><SheetContent side="left" className="w-72 p-0"><SheetHeader className="sr-only"><SheetTitle>Navigation</SheetTitle></SheetHeader><Sidebar active={workspace} webuiVersion={presentation?.webuiVersion ?? "-"} dashboard={dashboard} drawer navigate={navigate} /></SheetContent></Sheet><div className="min-w-0"><TopStatusBar dashboard={dashboard} pageTitle={pageTitle} openNavigation={() => setMenuOpen(true)} refresh={() => void reload()} /><main className="px-4 py-6 sm:px-7 sm:py-7 lg:px-10 lg:py-6"><section className="webui-workspace-base mx-auto max-w-[1120px]"><WorkspaceView workspace={workspace} dashboard={dashboard} openOperation={setOperation} /></section></main></div><OperationDialog operation={operation} close={() => setOperation(null)} api={api} reload={reload} /></div></TooltipProvider>;
+function PresentationSynchronizer({ reload }: { reload: (locale: string) => Promise<void> }) {
+  const { locale } = useLocale();
+  useEffect(() => { void reload(locale); }, [locale, reload]);
+  return null;
 }
 
 function Loading() {

--- a/webui/src/app/App.tsx
+++ b/webui/src/app/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CircleAlert, RefreshCw } from "lucide-react";
 
 import { Sidebar, TopStatusBar } from "@/components/app-shell";
@@ -28,16 +28,21 @@ export function App() {
   const [error, setError] = useState<string | null>(null);
   const [sessionReady, setSessionReady] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const reloadSequence = useRef(0);
 
   const reload = useCallback(async (requestedLocale?: string) => {
+    const requestId = reloadSequence.current + 1;
+    reloadSequence.current = requestId;
     try {
-      setError(null);
       await api.initialize();
-      setSessionReady(true);
       const [bootstrap, ledger, catalog, audit, resolvedPresentation] = await Promise.all([api.bootstrap(), api.ledger(), api.catalog(), api.audit(), api.presentation(requestedLocale ?? getLocale())]);
+      if (requestId !== reloadSequence.current) return;
+      setError(null);
+      setSessionReady(true);
       applyPresentation(resolvedPresentation);
       setDashboard(projectDashboard(bootstrap, ledger, catalog.operations, audit.items));
     } catch (cause) {
+      if (requestId !== reloadSequence.current) return;
       setDashboard(null);
       setSessionReady(false);
       setError(cause instanceof Error ? cause.message : "webui.request_failed");

--- a/webui/src/components/app-shell.tsx
+++ b/webui/src/components/app-shell.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { memo, useRef } from "react";
 import { Activity, Boxes, Cable, Cog, Languages, Menu, Network, Radio, RefreshCw, SunMoon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -20,22 +20,23 @@ export const navigation: { id: Workspace; labelKey: string; icon: typeof Activit
   { id: "configuration", labelKey: "webui.nav.configuration", icon: Cog },
 ];
 
-export function TopStatusBar({ dashboard, pageTitle, openNavigation, refresh }: { dashboard: Dashboard; pageTitle: string; openNavigation: () => void; refresh: () => void }) {
+export const TopStatusBar = memo(function TopStatusBar({ dashboard, workspace, openNavigation, refresh }: { dashboard: Dashboard; workspace: Workspace; openNavigation: () => void; refresh: () => void }) {
   const { locale, setLocale, t } = useLocale();
   const { accent, mode, setAccent, setMode } = useThemeController();
   const themeButton = useRef<HTMLButtonElement>(null);
   const ready = dashboard.kernelState === "ready";
   const activeRuntimes = dashboard.runtimes.filter((runtime) => runtime.state === "ready").length;
   const runtimeSummary = t("webui.status.runtimes", { active: activeRuntimes, total: dashboard.runtimes.length });
+  const pageTitle = t(navigation.find((entry) => entry.id === workspace)?.labelKey ?? "webui.nav.overview");
   const applyLocale = (value: string) => { if (value === "en-US" || value === "zh-CN") setLocale(value as Locale); };
   const applyAccent = (value: string) => { if (accents.includes(value as Accent)) setAccent(value as Accent); };
   const applyMode = (value: string) => { if (["system", "light", "dark"].includes(value)) setMode(value as ThemeMode, themeButton.current); };
 
   return <header className="webui-topbar"><div className="webui-topbar-page"><Button className="lg:hidden" variant="outline" size="icon" onClick={openNavigation} aria-label={t("webui.header.open_navigation")}><Menu /></Button><h1>{pageTitle}</h1></div><div className="webui-topbar-actions"><div className={cn("webui-topbar-state", !ready && "webui-topbar-state--attention")} aria-label={`Kernel ${dashboard.kernelState}`}><span className="webui-status-dot" /><span className="font-medium">{ready ? t("webui.status.ready") : dashboard.kernelState}</span><span className="webui-topbar-runtime-summary">{runtimeSummary}</span></div><DropdownMenu><DropdownMenuTrigger asChild><Button variant="outline" size="icon" aria-label={t("webui.header.language")}><Languages size={16} /></Button></DropdownMenuTrigger><DropdownMenuContent align="end"><DropdownMenuRadioGroup value={locale} onValueChange={applyLocale}><DropdownMenuRadioItem value="en-US">English</DropdownMenuRadioItem><DropdownMenuRadioItem value="zh-CN">简体中文</DropdownMenuRadioItem></DropdownMenuRadioGroup></DropdownMenuContent></DropdownMenu><DropdownMenu><DropdownMenuTrigger asChild><Button ref={themeButton} variant="outline" size="icon" aria-label={t("webui.header.theme")}><SunMoon size={16} /></Button></DropdownMenuTrigger><DropdownMenuContent align="end"><DropdownMenuRadioGroup value={mode} onValueChange={applyMode}><DropdownMenuRadioItem value="system">{t("webui.theme.system")}</DropdownMenuRadioItem><DropdownMenuRadioItem value="light">{t("webui.theme.light")}</DropdownMenuRadioItem><DropdownMenuRadioItem value="dark">{t("webui.theme.dark")}</DropdownMenuRadioItem></DropdownMenuRadioGroup><Separator className="my-1" /><DropdownMenuRadioGroup value={accent} onValueChange={applyAccent}>{accents.map((item) => <DropdownMenuRadioItem value={item} key={item}><span className={`webui-theme-swatch webui-theme-swatch--${item}`} />{t(`webui.theme.${item}`)}</DropdownMenuRadioItem>)}</DropdownMenuRadioGroup></DropdownMenuContent></DropdownMenu><Tooltip><TooltipTrigger asChild><Button variant="outline" size="icon" onClick={refresh} aria-label={t("webui.action.refresh")}><RefreshCw size={16} /></Button></TooltipTrigger><TooltipContent>{t("webui.action.refresh")}</TooltipContent></Tooltip></div></header>;
-}
+});
 
-export function Sidebar({ active, dashboard, drawer = false, navigate, webuiVersion }: { active: Workspace; dashboard: Dashboard; drawer?: boolean; navigate: (workspace: Workspace) => void; webuiVersion: string }) {
-  const { t } = useLocale();
+export const Sidebar = memo(function Sidebar({ active, dashboard, drawer = false, navigate }: { active: Workspace; dashboard: Dashboard; drawer?: boolean; navigate: (workspace: Workspace) => void }) {
+  const { presentation, t } = useLocale();
   const isOverview = active === "overview";
-  return <aside className={cn("webui-sidebar h-full min-h-screen flex-col", drawer ? "webui-sidebar--drawer flex" : "hidden lg:flex")}><button type="button" className="webui-sidebar-brand" aria-current={isOverview ? "page" : undefined} onClick={() => { if (!isOverview) navigate("overview"); }}><span className="webui-sidebar-brand-name">{t("webui.app.name")}</span></button><nav className="webui-sidebar-nav">{navigation.map(({ id, labelKey, icon: Icon }) => <Button key={id} variant="ghost" data-active={active === id || undefined} className="webui-sidebar-nav-item" onClick={() => navigate(id)}><Icon size={16} strokeWidth={1.8} />{t(labelKey)}</Button>)}</nav><div className="webui-sidebar-version font-mono">v{dashboard.version}+{webuiVersion}</div></aside>;
-}
+  return <aside className={cn("webui-sidebar h-full min-h-screen flex-col", drawer ? "webui-sidebar--drawer flex" : "hidden lg:flex")}><button type="button" className="webui-sidebar-brand" aria-current={isOverview ? "page" : undefined} onClick={() => { if (!isOverview) navigate("overview"); }}><span className="webui-sidebar-brand-name">{t("webui.app.name")}</span></button><nav className="webui-sidebar-nav">{navigation.map(({ id, labelKey, icon: Icon }) => <Button key={id} variant="ghost" data-active={active === id || undefined} className="webui-sidebar-nav-item" onClick={() => navigate(id)}><Icon size={16} strokeWidth={1.8} />{t(labelKey)}</Button>)}</nav><div className="webui-sidebar-version font-mono">v{dashboard.version}+{presentation?.webuiVersion ?? "-"}</div></aside>;
+});

--- a/webui/src/features/workspaces/workspace-view.tsx
+++ b/webui/src/features/workspaces/workspace-view.tsx
@@ -1,94 +1,126 @@
+import { lazy, memo, Suspense, useCallback, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { ArrowRight, Boxes, Cable, CheckCircle2, CircleAlert, CircleDot, FileClock, Play, ShieldCheck } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { SurfaceCard } from "@/components/surface-card";
 import { useLocale } from "@/i18n/locale";
-import type { WebUiOperation } from "@/models/api";
-import type { Dashboard } from "@/models/dashboard";
-import type { Workspace } from "@/models/workspace";
 import { cn } from "@/lib/utils";
+import type { WebUiOperation } from "@/models/api";
+import type { Dashboard, LedgerView } from "@/models/dashboard";
+import type { Workspace } from "@/models/workspace";
+import type { WebUiApi } from "@/services/webui-api";
+
+const OperationDialog = lazy(() =>
+  import("@/features/operations/operation-dialog").then(({ OperationDialog: Dialog }) => ({ default: Dialog })),
+);
+
+const POSITIVE_STATES = new Set(["ready", "running", "enabled", "healthy", "succeeded"]);
+const WARNING_STATES = new Set(["attention", "recovering", "queued", "running"]);
 
 type WorkspaceViewProps = {
   workspace: Workspace;
   dashboard: Dashboard;
-  openOperation: (operation: WebUiOperation) => void;
+  api: WebUiApi;
+  reload: () => Promise<void>;
 };
 
-export function WorkspaceView({ workspace, dashboard, openOperation }: WorkspaceViewProps) {
-  if (workspace === "overview") return <Overview dashboard={dashboard} openOperation={openOperation} />;
-  if (workspace === "events") return <Ledger dashboard={dashboard} />;
-  if (workspace === "topology") return <Topology dashboard={dashboard} />;
-  if (workspace === "runtimes") return <Runtimes dashboard={dashboard} openOperation={openOperation} />;
-  if (workspace === "plugins") return <Plugins dashboard={dashboard} />;
-  return <Configuration dashboard={dashboard} />;
-}
+export const WorkspaceView = memo(function WorkspaceView({ workspace, dashboard, api, reload }: WorkspaceViewProps) {
+  const [operation, setOperation] = useState<WebUiOperation | null>(null);
+  const openOperation = useCallback((next: WebUiOperation) => setOperation(next), []);
+  const closeOperation = useCallback(() => setOperation(null), []);
 
-function Overview({ dashboard, openOperation }: { dashboard: Dashboard; openOperation: (operation: WebUiOperation) => void }) {
+  const content = workspace === "overview" ? <Overview dashboard={dashboard} openOperation={openOperation} />
+    : workspace === "events" ? <Ledger dashboard={dashboard} />
+      : workspace === "topology" ? <Topology dashboard={dashboard} />
+        : workspace === "runtimes" ? <Runtimes dashboard={dashboard} openOperation={openOperation} />
+          : workspace === "plugins" ? <Plugins dashboard={dashboard} />
+            : <Configuration dashboard={dashboard} />;
+
+  return <>{content}{operation ? <Suspense fallback={null}><OperationDialog operation={operation} close={closeOperation} api={api} reload={reload} /></Suspense> : null}</>;
+});
+
+const Overview = memo(function Overview({ dashboard, openOperation }: { dashboard: Dashboard; openOperation: (operation: WebUiOperation) => void }) {
   const { t } = useLocale();
   const running = dashboard.runtimes.filter((runtime) => runtime.state === "ready").length;
   const unresolved = dashboard.audit.filter((record) => ["failed", "unknown"].includes(record.state)).length;
   const kernelReady = dashboard.kernelState === "ready";
-  return <div className="grid gap-4 xl:grid-cols-[minmax(0,1.55fr)_365px]"><div className={cn("webui-status-strip xl:col-span-2 flex min-h-14 flex-wrap items-center gap-x-3 gap-y-2 px-4 py-3 text-sm", !kernelReady && "webui-status-strip--attention")}>{kernelReady ? <CheckCircle2 className="text-emerald-600" size={18} /> : <CircleAlert className="text-amber-700" size={18} />}<strong>{kernelReady ? t("webui.overview.healthy") : t("webui.overview.kernel", { state: dashboard.kernelState })}</strong><span className="text-muted-foreground">{t("webui.overview.active_runtimes", { active: running, total: dashboard.runtimes.length })}</span>{dashboard.operations[0] && <Button className="ml-auto rounded-lg bg-card text-foreground shadow-sm hover:bg-muted" variant="outline" size="sm" onClick={() => openOperation(dashboard.operations[0])}>{t("webui.overview.new_operation")} <Play size={14} /></Button>}</div><section className="grid grid-cols-2 gap-3 sm:grid-cols-4 xl:col-span-2"><Metric label={t("webui.metric.active_runtimes")} value={String(running)} detail={t("webui.metric.configured", { count: dashboard.runtimes.length })} /><Metric label={t("webui.metric.enabled_plugins")} value={String(dashboard.plugins.length)} detail={t("webui.metric.loaded_generations")} /><Metric label={t("webui.metric.operation_records")} value={String(dashboard.ledger.length)} detail={t("webui.metric.retained_evidence")} /><Metric label={t("webui.metric.unresolved_faults")} value={String(unresolved)} detail={unresolved === 0 ? t("webui.metric.none_recorded") : t("webui.metric.requires_review")} emphasis={unresolved > 0} /></section><Ledger dashboard={dashboard} compact /><aside className="grid content-start gap-4"><RuntimeHealth dashboard={dashboard} /><RecentEvidence dashboard={dashboard} /></aside></div>;
-}
+  return <div className="grid gap-4 xl:grid-cols-[minmax(0,1.55fr)_365px]"><div className={cn("webui-status-strip xl:col-span-2 flex min-h-14 flex-wrap items-center gap-x-3 gap-y-2 px-4 py-3 text-sm", !kernelReady && "webui-status-strip--attention")}>{kernelReady ? <CheckCircle2 className="text-emerald-600" size={18} /> : <CircleAlert className="text-amber-700" size={18} />}<strong>{kernelReady ? t("webui.overview.healthy") : t("webui.overview.kernel", { state: dashboard.kernelState })}</strong><span className="text-muted-foreground">{t("webui.overview.active_runtimes", { active: running, total: dashboard.runtimes.length })}</span>{dashboard.operations[0] ? <Button className="ml-auto rounded-lg bg-card text-foreground shadow-sm hover:bg-muted" variant="outline" size="sm" onClick={() => openOperation(dashboard.operations[0])}>{t("webui.overview.new_operation")} <Play size={14} /></Button> : null}</div><section className="grid grid-cols-2 gap-3 sm:grid-cols-4 xl:col-span-2"><Metric label={t("webui.metric.active_runtimes")} value={String(running)} detail={t("webui.metric.configured", { count: dashboard.runtimes.length })} /><Metric label={t("webui.metric.enabled_plugins")} value={String(dashboard.plugins.length)} detail={t("webui.metric.loaded_generations")} /><Metric label={t("webui.metric.operation_records")} value={String(dashboard.ledger.length)} detail={t("webui.metric.retained_evidence")} /><Metric label={t("webui.metric.unresolved_faults")} value={String(unresolved)} detail={unresolved === 0 ? t("webui.metric.none_recorded") : t("webui.metric.requires_review")} emphasis={unresolved > 0} /></section><Ledger dashboard={dashboard} compact /><aside className="grid content-start gap-4"><RuntimeHealth dashboard={dashboard} /><RecentEvidence dashboard={dashboard} /></aside></div>;
+});
 
-function Metric({ label, value, detail, emphasis = false }: { label: string; value: string; detail: string; emphasis?: boolean }) {
+const Metric = memo(function Metric({ label, value, detail, emphasis = false }: { label: string; value: string; detail: string; emphasis?: boolean }) {
   return <SurfaceCard><CardContent className="p-4"><p className="text-xs text-muted-foreground">{label}</p><strong className={cn("mt-2 block font-mono text-[26px] font-semibold", emphasis && "text-amber-600")}>{value}</strong><span className="mt-1 block text-[11px] text-muted-foreground">{detail}</span></CardContent></SurfaceCard>;
-}
+});
 
-function Ledger({ dashboard, compact = false }: { dashboard: Dashboard; compact?: boolean }) {
+const Ledger = memo(function Ledger({ dashboard, compact = false }: { dashboard: Dashboard; compact?: boolean }) {
   const { t } = useLocale();
-  return <SurfaceCard className={cn(compact && "min-h-[382px]")}><CardHeader className="flex-row items-start justify-between px-5 pt-5"><CardTitle className="text-sm font-semibold">{t("webui.ledger.title")}</CardTitle></CardHeader><CardContent className="px-5 pb-5">{dashboard.ledger.length === 0 ? <Empty label={t("webui.ledger.empty")} /> : <ScrollArea className="max-h-[310px]"><Table><TableHeader><TableRow><TableHead>{t("webui.ledger.operation")}</TableHead><TableHead>{t("webui.ledger.state")}</TableHead><TableHead className="hidden sm:table-cell">{t("webui.ledger.updated")}</TableHead></TableRow></TableHeader><TableBody>{dashboard.ledger.map((item) => <TableRow key={item.id}><TableCell><div><p className="font-medium">{item.title}</p><p className="font-mono text-xs text-muted-foreground">{item.source}</p></div></TableCell><TableCell><State value={item.status} /></TableCell><TableCell className="hidden font-mono text-xs text-muted-foreground sm:table-cell">{item.at}</TableCell></TableRow>)}</TableBody></Table></ScrollArea>}</CardContent></SurfaceCard>;
-}
+  return <SurfaceCard className={cn(compact && "min-h-[382px]")}><CardHeader className="flex-row items-start justify-between px-5 pt-5"><CardTitle className="text-sm font-semibold">{t("webui.ledger.title")}</CardTitle></CardHeader><CardContent className="px-5 pb-5">{dashboard.ledger.length === 0 ? <Empty label={t("webui.ledger.empty")} /> : <VirtualLedgerTable items={dashboard.ledger} />}</CardContent></SurfaceCard>;
+});
 
-function RuntimeHealth({ dashboard }: { dashboard: Dashboard }) {
+const VirtualLedgerTable = memo(function VirtualLedgerTable({ items }: { items: LedgerView[] }) {
+  const { t } = useLocale();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const getItemKey = useCallback((index: number) => items[index].id, [items]);
+  const virtualizer = useVirtualizer({ count: items.length, getScrollElement: () => scrollRef.current, estimateSize: () => 58, getItemKey, overscan: 6 });
+  const virtualItems = virtualizer.getVirtualItems();
+  const paddingTop = virtualItems[0]?.start ?? 0;
+  const paddingBottom = virtualizer.getTotalSize() - (virtualItems.at(-1)?.end ?? 0);
+
+  return <div ref={scrollRef} data-slot="ledger-viewport" className="max-h-[310px] overflow-auto"><Table className="table-fixed"><colgroup><col /><col className="w-28" /><col className="hidden w-40 sm:table-column" /></colgroup><TableHeader className="sticky top-0 z-10 bg-card"><TableRow><TableHead>{t("webui.ledger.operation")}</TableHead><TableHead>{t("webui.ledger.state")}</TableHead><TableHead className="hidden sm:table-cell">{t("webui.ledger.updated")}</TableHead></TableRow></TableHeader><TableBody>{paddingTop > 0 ? <tr aria-hidden="true"><td colSpan={3} className="h-0 p-0" style={{ height: paddingTop }} /></tr> : null}{virtualItems.map((virtualItem) => <LedgerRow key={virtualItem.key} item={items[virtualItem.index]} height={virtualItem.size} index={virtualItem.index} />)}{paddingBottom > 0 ? <tr aria-hidden="true"><td colSpan={3} className="h-0 p-0" style={{ height: paddingBottom }} /></tr> : null}</TableBody></Table></div>;
+});
+
+const LedgerRow = memo(function LedgerRow({ item, height, index }: { item: LedgerView; height: number; index: number }) {
+  return <TableRow data-virtual-index={index} style={{ height }}><TableCell><div><p className="font-medium">{item.title}</p><p className="font-mono text-xs text-muted-foreground">{item.source}</p></div></TableCell><TableCell><State value={item.status} /></TableCell><TableCell className="hidden font-mono text-xs text-muted-foreground sm:table-cell">{item.at}</TableCell></TableRow>;
+});
+
+const RuntimeHealth = memo(function RuntimeHealth({ dashboard }: { dashboard: Dashboard }) {
   const { t } = useLocale();
   return <SurfaceCard className="min-h-[190px]"><CardHeader className="px-4 pt-4"><CardTitle className="text-sm font-semibold">{t("webui.runtime.health")}</CardTitle></CardHeader><CardContent className="px-4 pb-3">{dashboard.runtimes.length === 0 ? <Empty label={t("webui.runtime.empty")} /> : <div className="grid">{dashboard.runtimes.slice(0, 4).map((runtime) => <div className="grid grid-cols-[28px_minmax(0,1fr)_auto] items-center gap-2 border-t py-3 first:border-t-0" key={runtime.id}><span className="webui-runtime-mark"><Cable size={15} /></span><div className="min-w-0"><p className="truncate text-xs font-semibold">{runtime.id}</p><p className="mt-0.5 truncate text-[11px] text-muted-foreground">{runtime.kind} · {runtime.activity}</p></div><State value={runtime.state} /></div>)}</div>}</CardContent></SurfaceCard>;
-}
+});
 
-function RecentEvidence({ dashboard }: { dashboard: Dashboard }) {
+const RecentEvidence = memo(function RecentEvidence({ dashboard }: { dashboard: Dashboard }) {
   const { t } = useLocale();
   const evidence = dashboard.audit.slice(0, 3);
   return <SurfaceCard className="min-h-[150px]"><CardHeader className="px-4 pt-4"><CardTitle className="text-sm font-semibold">{t("webui.audit.recent")}</CardTitle></CardHeader><CardContent className="px-4 pb-3">{evidence.length === 0 ? <Empty label={t("webui.audit.empty")} /> : evidence.map((record) => <div className="grid grid-cols-[18px_minmax(0,1fr)_16px] items-center gap-2 border-t py-3" key={record.id}><CircleDot className="text-amber-500" size={16} /><div className="min-w-0"><p className="truncate text-xs font-semibold">{record.operation}</p><p className="mt-0.5 truncate text-[11px] text-muted-foreground">{record.target} · {record.updated_at}</p></div><ArrowRight className="text-muted-foreground" size={15} /></div>)}</CardContent></SurfaceCard>;
-}
+});
 
-function Runtimes({ dashboard, openOperation }: { dashboard: Dashboard; openOperation: (operation: WebUiOperation) => void }) {
+const Runtimes = memo(function Runtimes({ dashboard, openOperation }: { dashboard: Dashboard; openOperation: (operation: WebUiOperation) => void }) {
   const { t } = useLocale();
-  return <Card><CardHeader className="flex-row items-start justify-between"><CardTitle>{t("webui.runtimes.title")}</CardTitle>{dashboard.operations[0] && <Button size="sm" onClick={() => openOperation(dashboard.operations[0])}>{t("webui.runtimes.queue_action")}</Button>}</CardHeader><CardContent><Table><TableHeader><TableRow><TableHead>{t("webui.runtimes.runtime")}</TableHead><TableHead>{t("webui.ledger.state")}</TableHead><TableHead className="hidden md:table-cell">{t("webui.runtimes.protocol")}</TableHead><TableHead className="hidden md:table-cell">{t("webui.runtimes.activity")}</TableHead></TableRow></TableHeader><TableBody>{dashboard.runtimes.map((runtime) => <TableRow key={runtime.id}><TableCell><p className="font-medium">{runtime.id}</p><p className="text-xs text-muted-foreground">{runtime.kind}</p></TableCell><TableCell><State value={runtime.state} /></TableCell><TableCell className="hidden font-mono text-xs md:table-cell">{runtime.protocol}</TableCell><TableCell className="hidden text-xs text-muted-foreground md:table-cell">{runtime.activity}</TableCell></TableRow>)}</TableBody></Table></CardContent></Card>;
-}
+  return <Card><CardHeader className="flex-row items-start justify-between"><CardTitle>{t("webui.runtimes.title")}</CardTitle>{dashboard.operations[0] ? <Button size="sm" onClick={() => openOperation(dashboard.operations[0])}>{t("webui.runtimes.queue_action")}</Button> : null}</CardHeader><CardContent><Table><TableHeader><TableRow><TableHead>{t("webui.runtimes.runtime")}</TableHead><TableHead>{t("webui.ledger.state")}</TableHead><TableHead className="hidden md:table-cell">{t("webui.runtimes.protocol")}</TableHead><TableHead className="hidden md:table-cell">{t("webui.runtimes.activity")}</TableHead></TableRow></TableHeader><TableBody>{dashboard.runtimes.map((runtime) => <TableRow key={runtime.id}><TableCell><p className="font-medium">{runtime.id}</p><p className="text-xs text-muted-foreground">{runtime.kind}</p></TableCell><TableCell><State value={runtime.state} /></TableCell><TableCell className="hidden font-mono text-xs md:table-cell">{runtime.protocol}</TableCell><TableCell className="hidden text-xs text-muted-foreground md:table-cell">{runtime.activity}</TableCell></TableRow>)}</TableBody></Table></CardContent></Card>;
+});
 
-function Plugins({ dashboard }: { dashboard: Dashboard }) {
+const Plugins = memo(function Plugins({ dashboard }: { dashboard: Dashboard }) {
   const { t } = useLocale();
-  return <Card><CardHeader><CardTitle>{t("webui.plugins.title")}</CardTitle></CardHeader><CardContent><div className="grid gap-3 md:grid-cols-2">{dashboard.plugins.map((plugin) => <Card key={plugin.id} className="bg-muted/30 shadow-none"><CardContent className="p-4"><div className="flex items-start justify-between gap-2"><div><p className="font-medium">{plugin.name}</p><p className="font-mono text-xs text-muted-foreground">{plugin.id} · {plugin.version}</p></div><State value={plugin.state} /></div><div className="mt-4 flex flex-wrap gap-1">{plugin.provides.slice(0, 4).map((service) => <Badge key={service} variant="secondary" className="font-mono text-[10px]">{service}</Badge>)}</div></CardContent></Card>)}</div>{dashboard.plugins.length === 0 && <Empty label={t("webui.plugins.empty")} />}</CardContent></Card>;
-}
+  return <Card><CardHeader><CardTitle>{t("webui.plugins.title")}</CardTitle></CardHeader><CardContent><div className="grid gap-3 md:grid-cols-2">{dashboard.plugins.map((plugin) => <Card key={plugin.id} className="bg-muted/30 shadow-none"><CardContent className="p-4"><div className="flex items-start justify-between gap-2"><div><p className="font-medium">{plugin.name}</p><p className="font-mono text-xs text-muted-foreground">{plugin.id} · {plugin.version}</p></div><State value={plugin.state} /></div><div className="mt-4 flex flex-wrap gap-1">{plugin.provides.slice(0, 4).map((service) => <Badge key={service} variant="secondary" className="font-mono text-[10px]">{service}</Badge>)}</div></CardContent></Card>)}</div>{dashboard.plugins.length === 0 ? <Empty label={t("webui.plugins.empty")} /> : null}</CardContent></Card>;
+});
 
-function Topology({ dashboard }: { dashboard: Dashboard }) {
+const Topology = memo(function Topology({ dashboard }: { dashboard: Dashboard }) {
   const { t } = useLocale();
   return <div className="grid gap-4 md:grid-cols-2"><TopologyCard icon={ShieldCheck} title={t("webui.topology.kernel")} rows={[[dashboard.version, dashboard.kernelState]]} /><TopologyCard icon={Cable} title={t("webui.topology.runtimes")} rows={dashboard.runtimes.map((runtime) => [runtime.id, runtime.state])} /><TopologyCard icon={Boxes} title={t("webui.topology.plugins")} rows={dashboard.plugins.map((plugin) => [plugin.id, plugin.state])} /><TopologyCard icon={FileClock} title={t("webui.topology.audit")} rows={[[t("webui.topology.records", { count: dashboard.audit.length }), t("webui.state.retained")]]} /></div>;
-}
+});
 
 function TopologyCard({ icon: Icon, title, rows }: { icon: typeof ShieldCheck; title: string; rows: string[][] }) {
   return <Card><CardHeader><CardTitle className="flex items-center gap-2 text-sm"><Icon size={16} className="text-primary" />{title}</CardTitle></CardHeader><CardContent className="grid gap-2">{rows.map(([label, state]) => <div key={label} className="flex items-center justify-between rounded-md bg-muted/45 px-3 py-2 text-sm"><span className="font-mono text-xs">{label}</span><State value={state} /></div>)}</CardContent></Card>;
 }
 
-function Configuration({ dashboard }: { dashboard: Dashboard }) {
+const Configuration = memo(function Configuration({ dashboard }: { dashboard: Dashboard }) {
   const { t } = useLocale();
   return <Card><CardHeader><CardTitle>{t("webui.configuration.title")}</CardTitle></CardHeader><CardContent className="grid divide-y"><Setting label={t("webui.configuration.instance")} value={dashboard.instance} /><Setting label={t("webui.configuration.kernel")} value={dashboard.version} /><Setting label={t("webui.configuration.transport")} value={t("webui.configuration.loopback")} /><Setting label={t("webui.configuration.owner")} value={t("webui.configuration.daemon")} /></CardContent></Card>;
-}
+});
 
 function Setting({ label, value }: { label: string; value: string }) {
   return <div className="grid gap-1 py-4 sm:grid-cols-[180px_1fr]"><span className="text-sm text-muted-foreground">{label}</span><strong className="font-mono text-sm">{value}</strong></div>;
 }
 
-function State({ value }: { value: string }) {
+const State = memo(function State({ value }: { value: string }) {
   const { t } = useLocale();
-  const positive = ["ready", "running", "enabled", "healthy", "succeeded"].includes(value);
-  const warning = ["attention", "recovering", "queued", "running"].includes(value);
+  const positive = POSITIVE_STATES.has(value);
+  const warning = WARNING_STATES.has(value);
   return <Badge variant={positive ? "secondary" : warning ? "outline" : "destructive"} className={cn("capitalize", positive && "border-emerald-200 bg-emerald-50 text-emerald-700")}>{t(`webui.state.${value}`)}</Badge>;
-}
+});
 
 function Empty({ label }: { label: string }) {
   return <div className="grid min-h-32 place-items-center border-t text-sm text-muted-foreground">{label}</div>;

--- a/webui/src/i18n/locale.tsx
+++ b/webui/src/i18n/locale.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import type { WebUiPresentation } from "@/models/api";
 
@@ -30,6 +30,8 @@ type LocaleContextValue = {
 };
 
 const LocaleContext = createContext<LocaleContextValue | null>(null);
+type LocaleActionsContextValue = Pick<LocaleContextValue, "setLocale" | "applyPresentation"> & { getLocale: () => Locale };
+const LocaleActionsContext = createContext<LocaleActionsContextValue | null>(null);
 
 function initialLocale(): Locale {
   try {
@@ -44,8 +46,11 @@ function normalizeLocale(value: string | null | undefined): Locale {
 }
 
 export function LocaleProvider({ children }: { children: ReactNode }) {
-  const [locale, setLocale] = useState<Locale>(initialLocale);
+  const [locale, setLocaleState] = useState<Locale>(initialLocale);
   const [presentation, setPresentation] = useState<Presentation | null>(null);
+  const localeRef = useRef(locale);
+  const setLocale = useCallback((next: Locale) => { localeRef.current = next; setLocaleState(next); }, []);
+  const getLocale = useCallback(() => localeRef.current, []);
 
   useEffect(() => {
     document.documentElement.lang = locale;
@@ -69,11 +74,18 @@ export function LocaleProvider({ children }: { children: ReactNode }) {
     () => ({ locale, setLocale, presentation, applyPresentation, t }),
     [locale, presentation, applyPresentation, t],
   );
-  return <LocaleContext.Provider value={value}>{children}</LocaleContext.Provider>;
+  const actions = useMemo(() => ({ setLocale, applyPresentation, getLocale }), [setLocale, applyPresentation, getLocale]);
+  return <LocaleActionsContext.Provider value={actions}><LocaleContext.Provider value={value}>{children}</LocaleContext.Provider></LocaleActionsContext.Provider>;
 }
 
 export function useLocale() {
   const value = useContext(LocaleContext);
   if (value === null) throw new Error("useLocale must be rendered inside LocaleProvider");
+  return value;
+}
+
+export function useLocaleActions() {
+  const value = useContext(LocaleActionsContext);
+  if (value === null) throw new Error("useLocaleActions must be rendered inside LocaleProvider");
   return value;
 }

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -157,5 +157,10 @@ html.webui-theme-transition [data-slot="button"] {
   transition: background-color 900ms cubic-bezier(.25, 0, .7, .2), border-color 900ms cubic-bezier(.25, 0, .7, .2);
 }
 
+@media (min-width: 1024px) {
+  .webui-topbar { min-height: 110px; grid-template-columns: minmax(0, 1fr) auto; grid-template-rows: 66px 44px; column-gap: 16px; row-gap: 0; }
+  .webui-topbar-page { grid-column: 1 / -1; grid-row: 2; width: min(1120px, calc(100% - 32px)); align-self: stretch; justify-self: center; justify-content: flex-start; padding-top: 12px; }
+  .webui-topbar-actions { grid-column: 2; grid-row: 1; }
+}
 @media (max-width: 1023px) { .webui-sidebar--drawer { background-color: var(--card); } .webui-topbar { display: flex; justify-content: space-between; } .webui-topbar-page, .webui-topbar-actions { grid-column: auto; justify-self: auto; } }
 @media (max-width: 639px) { .webui-topbar { min-height: 60px; padding: 0 16px; } .webui-topbar-runtime-summary { display: none; } }

--- a/webui/tests/shell.spec.ts
+++ b/webui/tests/shell.spec.ts
@@ -106,7 +106,8 @@ test("workspaces project live ledger, topology, runtimes, and plugins", async ({
 });
 
 test("ledger virtualizes large retained record lists", async ({ page }) => {
-  const records = Array.from({ length: 300 }, (_, index) => ({ id: `op-${index}`, at: `2026-08-15T03:${String(index).padStart(2, "0")}:00Z`, title: `operation-${index}`, source: "redacted", status: "healthy", detail: "ok" }));
+  const firstRecordAt = new Date("2026-08-15T03:00:00Z");
+  const records = Array.from({ length: 300 }, (_, index) => ({ id: `op-${index}`, at: new Date(firstRecordAt.getTime() + index * 60_000).toISOString(), title: `operation-${index}`, source: "redacted", status: "healthy", detail: "ok" }));
   await mockDaemon(page, undefined, records);
   await page.goto("/#/events");
   const viewport = page.locator('[data-slot="ledger-viewport"]');

--- a/webui/tests/shell.spec.ts
+++ b/webui/tests/shell.spec.ts
@@ -48,7 +48,7 @@ const zhMessages = {
   "webui.error.unavailable": "本地服务不可用", "webui.error.unavailable_detail": "WebUI 无法读取正在运行的 daemon。", "webui.action.retry": "重试", "webui.operation.queued": "操作已加入队列", "webui.operation.queued_failed": "操作无法加入队列", "webui.operation.description": "daemon 执行前会校验操作输入并记录到本地账本。", "webui.operation.confirm_hint": "高影响操作需要准确确认目标。", "webui.operation.confirm_target": "确认目标", "webui.operation.confirm_placeholder": "输入准确的目标标识", "webui.action.cancel": "取消", "webui.operation.queue": "加入操作队列", "webui.operation.queueing": "正在加入队列", "webui.operation.enter": "输入{field}",
 };
 
-async function mockDaemon(page: Page, onSubmit?: (body: unknown) => void) {
+async function mockDaemon(page: Page, onSubmit?: (body: unknown) => void, ledgerItems?: unknown[]) {
   await page.route("**/api/v1/**", async (route) => {
     const url = new URL(route.request().url());
     const path = url.pathname;
@@ -59,7 +59,7 @@ async function mockDaemon(page: Page, onSubmit?: (body: unknown) => void) {
     }
     if (path.endsWith("/bootstrap") || path.endsWith("/snapshot")) return route.fulfill({ contentType: "application/json", body: JSON.stringify(bootstrap) });
     if (path.endsWith("/operations/catalog")) return route.fulfill({ contentType: "application/json", body: JSON.stringify(catalog) });
-    if (path.endsWith("/ledger")) return route.fulfill({ contentType: "application/json", body: JSON.stringify({ items: [{ id: "op-1", at: "2026-08-15T03:00:00Z", title: "management.runtime.restart", source: "redacted", status: "healthy", detail: "ok" }] }) });
+    if (path.endsWith("/ledger")) return route.fulfill({ contentType: "application/json", body: JSON.stringify({ items: ledgerItems ?? [{ id: "op-1", at: "2026-08-15T03:00:00Z", title: "management.runtime.restart", source: "redacted", status: "healthy", detail: "ok" }] }) });
     if (path.endsWith("/audit")) return route.fulfill({ contentType: "application/json", body: JSON.stringify({ items: [] }) });
     if (path.endsWith("/events")) return route.fulfill({ contentType: "text/event-stream", body: "event: heartbeat\ndata: {}\n\n" });
     if (path.endsWith("/operations") && route.request().method() === "POST") { onSubmit?.(route.request().postDataJSON()); return route.fulfill({ contentType: "application/json", body: JSON.stringify({ id: "op-2", state: "queued" }) }); }
@@ -82,10 +82,14 @@ for (const [name, viewport] of [["desktop", { width: 1440, height: 960 }], ["mob
       await expect(page.locator(".webui-workspace-base")).toHaveCSS("box-shadow", "none");
       const sidebarBackground = await page.locator(".webui-sidebar").evaluate((element) => getComputedStyle(element).backgroundColor);
       await expect(page.locator(".webui-topbar")).toHaveCSS("background-color", sidebarBackground);
-      const [topbar, title] = await Promise.all([page.locator(".webui-topbar").boundingBox(), page.getByRole("heading", { name: "Overview" }).boundingBox()]);
+      const [topbar, workspace, title] = await Promise.all([page.locator(".webui-topbar").boundingBox(), page.locator(".webui-workspace-base").boundingBox(), page.getByRole("heading", { name: "Overview" }).boundingBox()]);
       expect(topbar).not.toBeNull();
+      expect(workspace).not.toBeNull();
       expect(title).not.toBeNull();
-      expect(Math.abs((title!.x + title!.width / 2) - (topbar!.x + topbar!.width / 2))).toBeLessThan(1);
+      expect(Math.abs(title!.x - workspace!.x)).toBeLessThan(3);
+      expect(title!.y).toBeGreaterThan(topbar!.y);
+      expect(title!.y + title!.height).toBeLessThan(topbar!.y + topbar!.height);
+      expect(title!.y + title!.height).toBeLessThan(workspace!.y);
     }
   });
 }
@@ -99,6 +103,18 @@ test("workspaces project live ledger, topology, runtimes, and plugins", async ({
   await expect(page.getByText("onebot-primary")).toBeVisible();
   await page.goto("/#/plugins");
   await expect(page.getByText("Profile", { exact: true })).toBeVisible();
+});
+
+test("ledger virtualizes large retained record lists", async ({ page }) => {
+  const records = Array.from({ length: 300 }, (_, index) => ({ id: `op-${index}`, at: `2026-08-15T03:${String(index).padStart(2, "0")}:00Z`, title: `operation-${index}`, source: "redacted", status: "healthy", detail: "ok" }));
+  await mockDaemon(page, undefined, records);
+  await page.goto("/#/events");
+  const viewport = page.locator('[data-slot="ledger-viewport"]');
+  await expect(viewport).toBeVisible();
+  await expect(page.getByText("operation-0")).toBeVisible();
+  expect(await page.locator("tr[data-virtual-index]").count()).toBeLessThan(32);
+  await viewport.evaluate((element) => { element.scrollTop = element.scrollHeight; element.dispatchEvent(new Event("scroll")); });
+  await expect(page.getByText("operation-299")).toBeVisible();
 });
 
 test("brand returns to overview only from another workspace", async ({ page }) => {


### PR DESCRIPTION
Move the desktop page title into the requested two-row top bar layout and reduce WebUI rendering work.\n\n- virtualize retained ledger rows\n- lazy-load workspace and operation dialog chunks\n- keep operation state local to the workspace and isolate locale action subscriptions\n- memoize shell and workspace boundaries with stable callbacks\n\nValidation:\n- pnpm --dir webui typecheck\n- pnpm --dir webui test:e2e -- shell.spec.ts\n- pnpm --dir webui build\n- uv run --extra webui pytest -q packages/webui/tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved performance when displaying large ledger lists through virtualized scrolling.
  * Added locale-aware presentation updates when switching languages.
  * Added responsive desktop layout improvements for the top bar and page heading.
  * Added faster loading for workspace content with a loading placeholder.

* **Bug Fixes**
  * Improved workspace navigation, refreshing, and operation dialog handling.
  * Updated status and page titles to reflect the active workspace and locale.
  * Improved layout alignment across desktop views.

* **Tests**
  * Added coverage for large ledger virtualization and desktop shell layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->