### PR TITLE
feat(broker): connect kernel peer to native event bus

### DIFF
--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -23,10 +23,13 @@ published runtime packages, so the kernel has no framework or v6 dependency.
 `LiteyukiApp` creates an immutable settings snapshot, event bus, service
 registry, plugin manager, local control server, and optional HTTP server. The
 standalone B5 broker is independently host-initialized; it is not an app
-bootstrap or child supervisor. Legacy runtime-supervisor code remains only as
-historical compatibility context and is not selected by the v5 configuration
-schema. Failures trigger reverse cleanup and shutdown rejects new work before
-owned tasks are stopped.
+bootstrap or child supervisor. When a reserved `broker.bridges.<id>` entry has
+`kind = "kernel"`, the app registers one in-process full broker peer after
+native plugins start and stops it before EventBus teardown. This does not start
+the broker or make it a child supervisor. Legacy runtime-supervisor code
+remains only as historical compatibility context and is not selected by the v5
+configuration schema. Failures trigger reverse cleanup and shutdown rejects new
+work before owned tasks are stopped.
 
 Native plugins are explicitly enabled and resolve from the
 `liteyukibot.plugins` entry-point group or explicitly named local modules. An
@@ -67,6 +70,13 @@ the `full` access class wins before `limited`, then the longest matching prefix
 wins within the selected class. Same-class ambiguity and registered ownership
 conflicts are rejected. Adapter-specific behavior stays in the owning bridge
 rather than leaking into the broker.
+
+The B5-5 kernel peer verifies source provenance, replaces the source envelope
+ID with the broker-generated kernel ID, and publishes the result to the native
+EventBus. Native plugin `SendMessage` actions may route back through the
+delivered event's authenticated source bridge; the kernel declares no action
+ownership. Generic API calls and message editing remain outside this portable
+surface.
 
 ## Broker Peer Protocol
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,12 @@ The broker uses a local loopback endpoint by default and treats each
 [broker]
 endpoint = "tcp://127.0.0.1:20217"
 
+[broker.bridges.kernel]
+kind = "kernel"
+token_secret = "broker.kernel.token"
+access = "full"
+subscriptions = ["message.created"]
+
 [broker.bridges.nonebot]
 kind = "nonebot"
 token_secret = "broker.nonebot.token"
@@ -256,8 +262,11 @@ plugins = ["plugins"]
 plugin_dirs = []
 ```
 
-The `kind` must be provided by an installed `liteyukibot.bridges` entry point.
-Registration is rejected when a bridge manifest differs from this table.
-`full` bridges receive every topic; `limited` bridges receive only their
+Except for the reserved `kernel` kind, `kind` must be provided by an installed
+`liteyukibot.bridges` entry point. The kernel entry is unique, uses `full`
+access, declares subscriptions, and cannot declare action-resource ownership;
+the app registers it during `liteyuki run`, while `liteyuki broker run` remains
+separate. Registration is rejected when a bridge manifest differs from this
+table. `full` bridges receive every topic; `limited` bridges receive only their
 configured subscriptions. The B5-4 NoneBot bridge currently publishes
 `message.created` and owns the portable `message.send` action only.

--- a/docs/development/custom-runtimes.md
+++ b/docs/development/custom-runtimes.md
@@ -16,6 +16,12 @@ broker assigns the session ID and kernel event ID. A bridge must not create
 either value, select event recipients, set an absolute monotonic deadline, or
 connect directly to another bridge.
 
+`kind = "kernel"` is reserved for LiteyukiApp's in-process full peer. It is
+not a `liteyukibot.bridges` entry point, cannot declare action-resource
+ownership, and must not be launched with `liteyuki bridge run`. It must use
+`access = "full"` and declare at least one subscription. The app registers it
+after native plugins start; the broker remains a separate process.
+
 For each `EventMessage`, retain its opaque lease and respond once with
 `EventAccepted`, then with `EventCompleted` after the active delivery has a
 terminal outcome. `lease_ttl_ms` is advisory only; the broker evaluates its
@@ -30,10 +36,12 @@ is supplied under its `options` mapping. The B5-4 NoneBot bridge is the
 reference implementation. A new bridge must document its own lifecycle and
 test it against the same peer contract before claiming compatibility.
 
-For B5-4, the portable surface is intentionally narrow: publish
+For B5-4/B5-5, the portable surface is intentionally narrow: publish
 `message.created` and handle `message.send`. The resource key for a bot owned
-by bridge `bridge-id` is `bot:bridge-id:<bot-id>`. `CallApi`, message editing,
-and a generic function/decorator DSL are deferred to later version planning.
+by bridge `bridge-id` is `bot:bridge-id:<bot-id>`. The kernel peer may issue
+that action only while dispatching the matching active broker delivery. `CallApi`,
+message editing, and a generic function/decorator DSL are deferred to later
+version planning.
 
 ## Legacy supervised child runtimes (historical)
 

--- a/docs/specs/runtime-ipc-v6.md
+++ b/docs/specs/runtime-ipc-v6.md
@@ -1,8 +1,8 @@
 # Broker Peer IPC v6
 
 - Specification version: `6`
-- Applies to: the implemented B5 standalone broker peer contract and the B5-4
-  NoneBot bridge.
+- Applies to: the implemented B5 standalone broker peer contract, the B5-4
+  NoneBot bridge, and the B5-5 in-process kernel peer.
 - Compatibility: pre-stable hard cut. This contract is not interoperable with
   the former child-supervisor Runtime IPC v1 through v5 catalog.
 
@@ -14,6 +14,13 @@ configure, supervise, or restart framework processes. Bridge processes own
 their framework lifecycle and are discovered through the
 `liteyukibot.bridges` entry-point group. The B5-4 NoneBot bridge is the first
 production bridge and is started with `liteyuki bridge run <bridge-id>`.
+
+`kind = "kernel"` is a reserved in-process bridge, not an entry-point package
+or a process launched with `liteyuki bridge run`. When present, `LiteyukiApp`
+resolves its vault token and registers it as a normal `full` peer after the
+native plugin manager has started. It must be unique, subscribe to at least one
+topic, and declare no action-resource ownership. The standalone broker still
+starts independently with `liteyuki broker run`.
 
 The broker registry in `liteyuki.toml` is authoritative: a bridge must match
 the configured access class, subscriptions, and action resources at
@@ -84,6 +91,11 @@ remaining duration for the peer. The broker evaluates expiry on its own clock;
 the wire contract deliberately carries no cross-process
 `deadline_monotonic` value.
 
+When a bridge issues an action through a delivery, the shared host runner also
+uses that TTL as its local upper bound while awaiting the correlated result. It
+does not reinterpret the value as a synchronized deadline; the broker remains
+the authority for delivery expiry.
+
 The delivery lifecycle is `pending -> offered -> accepted -> active ->`
 `completed | failed | expired`. A bridge must acknowledge an offered delivery
 with the matching lease; that acknowledgement advances it through accepted to
@@ -133,9 +145,24 @@ The first portable action is `message.send`. Its resource key is
 `CallApi`, message editing, and decorator-based function APIs are outside this
 version of the contract.
 
+### B5-5 kernel peer dispatch
+
+The kernel peer validates a delivered payload as an `EventEnvelope`, requires
+its payload `id` to equal `source_event_id` and its `runtime_id` to equal the
+authenticated source bridge, then replaces the envelope ID with the broker's
+`kernel_event_id` before publishing it to the native EventBus. Native plugins
+therefore see broker-issued event identities while retaining the source bridge
+as the event runtime identity.
+
+While that EventBus dispatch is active, the peer may translate a native
+`SendMessage` action into the B5 portable `message.send` request. Its resource
+key is resolved against the event's authenticated source bridge; the kernel
+does not own action resources. `CallApi`, `EditMessage`, and locally injected
+events have no B5-5 broker action path.
+
 ## Evidence
 
 Run `uv run pytest tests/test_broker_peer.py tests/test_broker_business.py
-tests/test_broker_routing.py`. The executable definitions are under
+tests/test_broker_routing.py tests/test_broker_kernel.py`. The executable definitions are under
 `src/liteyukibot/broker/`; LYIP frame mechanics are specified by
 [Runtime LYIP v2](runtime-lyip-v2.md).

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -19,6 +19,7 @@ from .agents import (
     AgentToolResult,
     EventAgentToolCatalog,
 )
+from .broker import KernelBrokerPeer, configured_kernel_bridge
 from .capabilities import ADAPTER_CALL_API, AGENT_HISTORY_CLEAR, PERMISSION_SERVICE_MAJOR, PERMISSION_SERVICE_NAME
 from .config import AppSettings, RuntimeEventRoute
 from .control import ControlServer
@@ -162,6 +163,9 @@ class LiteyukiApp:
             action_executor=self._execute_event_action,
             logger=self.logger,
         )
+        self._kernel_broker_peer: KernelBrokerPeer | None = None
+        self._configured_kernel_bridge = configured_kernel_bridge(settings)
+        self._runtime_secrets = dict(runtime_secrets or {})
         self.plugins = PluginManager(
             services=self.services,
             events=self.events,
@@ -197,6 +201,7 @@ class LiteyukiApp:
         self._logging_started = False
         self._plugins_setup = False
         self._runtimes_started = False
+        self._kernel_broker_started = False
         self._management_started = False
         self._control_started = False
         self._http_started = False
@@ -453,6 +458,16 @@ class LiteyukiApp:
             await self.runtimes.start()
             self._runtimes_started = True
             await self.plugins.start()
+            if self._configured_kernel_bridge is not None:
+                _bridge_id, bridge = self._configured_kernel_bridge
+                token = self._runtime_secrets.get(bridge.token_secret)
+                if token is None:
+                    raise RuntimeError("kernel broker bridge token is unavailable")
+                self._kernel_broker_peer = KernelBrokerPeer.from_settings(
+                    self.settings, token=token, events=self.events
+                )
+                await self._kernel_broker_peer.start()
+                self._kernel_broker_started = True
 
             self._control_started = True
             await self.control.start()
@@ -613,6 +628,12 @@ class LiteyukiApp:
             except BaseException as error:
                 errors.append(error)
             self._management_started = False
+        if self._kernel_broker_started and self._kernel_broker_peer is not None:
+            try:
+                await self._kernel_broker_peer.stop()
+            except BaseException as error:
+                errors.append(error)
+            self._kernel_broker_started = False
         try:
             await self.events.aclose()
         except BaseException as error:
@@ -785,6 +806,10 @@ class LiteyukiApp:
         )
 
     async def _execute_event_action(self, event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
+        if self._kernel_broker_peer is not None:
+            result = await self._kernel_broker_peer.execute_action(event, action)
+            if result is not None:
+                return result
         return await self.actions.execute(action, event=event)
 
     async def _clear_agent_history(self, event: EventEnvelope) -> int:

--- a/src/liteyukibot/broker/__init__.py
+++ b/src/liteyukibot/broker/__init__.py
@@ -23,6 +23,7 @@ from .business import (
     encode_business_message,
 )
 from .host import ActionOutcome, BrokerBridgeRunner, BrokerDelivery
+from .kernel import KernelBridgeError, KernelBrokerPeer, configured_kernel_bridge
 from .peer import (
     BridgeClient,
     BridgeRegistrationError,
@@ -79,6 +80,8 @@ __all__ = [
     "BridgeClient",
     "BrokerBridgeRunner",
     "BrokerDelivery",
+    "KernelBridgeError",
+    "KernelBrokerPeer",
     "BridgeManifest",
     "BridgeRegister",
     "BridgeRegistered",
@@ -112,6 +115,7 @@ __all__ = [
     "encode_business_message",
     "encode_broker_message",
     "bridge_token_from_vault",
+    "configured_kernel_bridge",
     "make_message_send_request",
     "message_send_resource_key",
     "parse_message_send_request",

--- a/src/liteyukibot/broker/host.py
+++ b/src/liteyukibot/broker/host.py
@@ -51,6 +51,7 @@ class BrokerDelivery:
             kind=kind,
             resource_key=resource_key,
             payload=payload,
+            timeout_seconds=self.message.lease_ttl_ms / 1_000,
         )
 
 
@@ -138,6 +139,7 @@ class BrokerBridgeRunner:
         kind: str,
         resource_key: str,
         payload: Mapping[str, JsonValue] | None = None,
+        timeout_seconds: float | None = None,
     ) -> ActionResult:
         """Send one active-delivery action and await its exact correlation result."""
 
@@ -146,6 +148,8 @@ class BrokerBridgeRunner:
             raise ValueError("action correlation ID must be non-empty")
         if normalized_correlation in self._pending_results:
             raise BridgeRegistrationError("an action result is already pending for this correlation ID")
+        if timeout_seconds is not None and timeout_seconds <= 0:
+            raise ValueError("action timeout must be positive")
         future: asyncio.Future[ActionResult] = asyncio.get_running_loop().create_future()
         self._pending_results[normalized_correlation] = future
         try:
@@ -159,7 +163,10 @@ class BrokerBridgeRunner:
                     payload=payload or {},
                 )
             )
-            result = await future
+            if timeout_seconds is None:
+                result = await future
+            else:
+                result = await asyncio.wait_for(future, timeout=timeout_seconds)
             return result
         finally:
             if self._pending_results.get(normalized_correlation) is future:

--- a/src/liteyukibot/broker/kernel.py
+++ b/src/liteyukibot/broker/kernel.py
@@ -1,0 +1,171 @@
+"""Kernel-side full broker peer for native EventBus dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from urllib.parse import urlparse
+from uuid import uuid4
+
+import zmq.asyncio
+
+from ..config.models import AppSettings, BrokerBridgeSettings, configured_kernel_bridge_settings
+from ..events import ActionEnvelope, ActionResult, EventBus, EventEnvelope, SendMessage
+from ..lyip import LyipLane
+from .actions import MessageSendPayload, make_message_send_request
+from .host import BrokerBridgeRunner, BrokerDelivery
+from .peer import BridgeClient, BridgeRegistrationError
+from .protocol import BridgeAccess, BridgeManifest
+
+
+class KernelBridgeError(RuntimeError):
+    """Raised when the in-process kernel bridge violates its broker contract."""
+
+
+def configured_kernel_bridge(settings: AppSettings) -> tuple[str, BrokerBridgeSettings] | None:
+    """Return the unique configured in-process kernel bridge, if any."""
+
+    try:
+        return configured_kernel_bridge_settings(settings.broker.bridges)
+    except ValueError as error:
+        raise KernelBridgeError(str(error)) from error
+
+
+class KernelBrokerPeer:
+    """Adapt broker deliveries to the in-process Native Plugin EventBus.
+
+    A broker delivery is bound to its broker-generated event ID only while its
+    EventBus dispatch is outstanding. This keeps portable action requests
+    lease-scoped even though EventBus runs its FIFO worker in a separate task.
+    """
+
+    def __init__(self, bridge_id: str, client: BridgeClient, events: EventBus) -> None:
+        self.bridge_id = bridge_id
+        self._events = events
+        self._active_deliveries: dict[str, BrokerDelivery] = {}
+        self._runner = BrokerBridgeRunner(client, event_handler=self._handle_delivery)
+        self._serve_task: asyncio.Task[None] | None = None
+
+    @classmethod
+    def from_settings(cls, settings: AppSettings, *, token: str, events: EventBus) -> KernelBrokerPeer:
+        configured = configured_kernel_bridge(settings)
+        if configured is None:
+            raise KernelBridgeError("kernel bridge is not configured")
+        bridge_id, bridge = configured
+        normalized_token = token.strip()
+        if not normalized_token:
+            raise KernelBridgeError("kernel bridge token must be non-empty")
+        client = BridgeClient(
+            context=zmq.asyncio.Context.instance(),
+            endpoints=_broker_endpoints(settings.broker.endpoint),
+            generation=settings.broker.generation,
+            identity=f"kernel:{bridge_id}:{uuid4()}".encode("ascii"),
+            manifest=BridgeManifest(
+                bridge_id=bridge_id,
+                access=BridgeAccess.FULL,
+                subscriptions=bridge.subscriptions,
+            ),
+            instance_token=normalized_token,
+        )
+        return cls(bridge_id, client, events)
+
+    async def start(self) -> None:
+        if self._serve_task is not None:
+            raise KernelBridgeError("kernel bridge is already running")
+        await self._runner.start()
+        self._serve_task = asyncio.create_task(self._runner.serve_forever(), name="liteyuki-kernel-broker")
+
+    async def stop(self) -> None:
+        task, self._serve_task = self._serve_task, None
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        try:
+            await self._runner.stop()
+        finally:
+            self._runner.close()
+
+    async def execute_action(self, event: EventEnvelope, action: ActionEnvelope) -> ActionResult | None:
+        """Execute one native action through the delivery currently bound to this task.
+
+        ``None`` means that the EventBus dispatch did not originate from this
+        broker peer, allowing the application's legacy-independent action path
+        to handle locally injected events.
+        """
+
+        delivery = self._active_deliveries.get(event.id)
+        if delivery is None:
+            return None
+        if action.event_id != event.id or action.runtime_id != event.runtime_id or action.bot_id != event.bot_id:
+            return _action_error(action.action_id, "BROKER_ACTION_PROVENANCE", "action does not match its delivery")
+        if not isinstance(action.action, SendMessage):
+            return _action_error(
+                action.action_id,
+                "BROKER_ACTION_UNSUPPORTED",
+                "only send_message is portable through the broker in B5",
+            )
+        request = make_message_send_request(
+            delivery_id=delivery.message.delivery_id,
+            lease_id=delivery.message.lease_id,
+            correlation_id=action.action_id,
+            owner_bridge_id=delivery.message.event.source_bridge_id,
+            payload=MessageSendPayload(
+                bot_id=action.bot_id,
+                message=action.action.message,
+                conversation=action.action.conversation,
+                reply_token=action.action.reply_token,
+            ),
+        )
+        try:
+            result = await delivery.request_action(
+                correlation_id=request.correlation_id,
+                kind=request.kind,
+                resource_key=request.resource_key,
+                payload=request.payload,
+            )
+        except (BridgeRegistrationError, TimeoutError, ValueError) as error:
+            return _action_error(action.action_id, "BROKER_ACTION_UNAVAILABLE", str(error))
+        if result.success:
+            return ActionResult(action_id=action.action_id, success=True, data=result.payload)
+        return _action_error(action.action_id, "BROKER_ACTION_FAILED", "bridge action owner rejected the request")
+
+    async def _handle_delivery(self, delivery: BrokerDelivery) -> None:
+        broker_event = delivery.message.event
+        try:
+            source_event = EventEnvelope.model_validate(broker_event.payload)
+        except ValueError as error:
+            raise KernelBridgeError("broker delivery payload is not a valid EventEnvelope") from error
+        if source_event.id != broker_event.source_event_id:
+            raise KernelBridgeError("broker delivery source event identity does not match its payload")
+        if source_event.runtime_id != broker_event.source_bridge_id:
+            raise KernelBridgeError("broker delivery runtime identity does not match its authenticated source")
+        event = source_event.model_copy(
+            update={"id": broker_event.kernel_event_id, "runtime_id": broker_event.source_bridge_id}
+        )
+        self._active_deliveries[event.id] = delivery
+        try:
+            result = await self._events.publish(event)
+        finally:
+            self._active_deliveries.pop(event.id, None)
+        if result.status != "processed":
+            raise KernelBridgeError(f"native EventBus returned {result.status!r} for broker delivery")
+
+
+def _broker_endpoints(endpoint: str) -> Mapping[LyipLane, str]:
+    """Derive the existing adjacent control/business endpoints from v5 config."""
+
+    parsed = urlparse(endpoint)
+    if parsed.scheme != "tcp" or parsed.hostname is None or parsed.port is None:
+        raise KernelBridgeError("broker endpoint must be a valid tcp URL")
+    host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    return {
+        LyipLane.CONTROL: f"tcp://{host}:{parsed.port}",
+        LyipLane.BUSINESS: f"tcp://{host}:{parsed.port + 1}",
+    }
+
+
+def _action_error(action_id: str, code: str, message: str) -> ActionResult:
+    return ActionResult(action_id=action_id, success=False, error_code=code, error_message=message)
+
+
+__all__ = ["KernelBridgeError", "KernelBrokerPeer", "configured_kernel_bridge"]

--- a/src/liteyukibot/broker/service.py
+++ b/src/liteyukibot/broker/service.py
@@ -56,6 +56,8 @@ class BridgeCatalog:
         bridge = settings.broker.bridges.get(bridge_id)
         if bridge is None:
             raise RuntimeError(f"broker bridge {bridge_id!r} is not configured")
+        if bridge.kind == "kernel":
+            raise RuntimeError("the reserved kernel bridge starts with liteyuki run, not liteyuki bridge run")
         launcher = self.discover().get(bridge.kind)
         if launcher is None:
             raise RuntimeError(f"broker bridge kind {bridge.kind!r} is not installed")

--- a/src/liteyukibot/cli.py
+++ b/src/liteyukibot/cli.py
@@ -24,6 +24,7 @@ from tomli_w import dumps as dump_toml
 
 from . import __version__
 from .app import LiteyukiApp
+from .broker import configured_kernel_bridge
 from .broker.service import BridgeCatalog, BrokerService, bridge_token_from_vault
 from .config import (
     AppSettings,
@@ -633,6 +634,9 @@ def _runtime_secrets(settings: AppSettings, workspace: ConfigWorkspace) -> dict[
         if runtime.enabled
         for secret_name in runtime.secret_env.values()
     }
+    configured_kernel = configured_kernel_bridge(settings)
+    if configured_kernel is not None:
+        names.add(configured_kernel[1].token_secret)
     if not names:
         return {}
     values = SecretVault(workspace.management_directory).read(_vault_password(workspace))
@@ -653,6 +657,9 @@ async def _broker_command(settings: AppSettings, workspace: ConfigWorkspace) -> 
 
 
 async def _bridge_command(settings: AppSettings, workspace: ConfigWorkspace, bridge_id: str) -> int:
+    configured = settings.broker.bridges.get(bridge_id)
+    if configured is not None and configured.kind == "kernel":
+        raise RuntimeError("the reserved kernel bridge starts with liteyuki run, not liteyuki bridge run")
     _bridge, token = bridge_token_from_vault(
         settings,
         bridge_id,

--- a/src/liteyukibot/config/models.py
+++ b/src/liteyukibot/config/models.py
@@ -488,6 +488,26 @@ class BrokerBridgeSettings(FrozenSettingsModel):
         return cast(dict[str, Any], _thaw(value))
 
 
+def configured_kernel_bridge_settings(
+    bridges: Mapping[str, BrokerBridgeSettings],
+) -> tuple[str, BrokerBridgeSettings] | None:
+    """Validate and return the reserved in-process kernel bridge, if configured."""
+
+    matches = tuple((bridge_id, bridge) for bridge_id, bridge in bridges.items() if bridge.kind == "kernel")
+    if len(matches) > 1:
+        raise ValueError("broker configuration must not contain multiple kernel bridges")
+    if not matches:
+        return None
+    bridge_id, bridge = matches[0]
+    if bridge.access != "full":
+        raise ValueError("kernel bridge must use full access")
+    if not bridge.subscriptions:
+        raise ValueError("kernel bridge must declare at least one subscription")
+    if bridge.action_resources:
+        raise ValueError("kernel bridge must not declare action ownership")
+    return bridge_id, bridge
+
+
 class BrokerSettings(FrozenSettingsModel):
     endpoint: str = "tcp://127.0.0.1:20217"
     generation: int = Field(default=1, ge=1)
@@ -527,8 +547,9 @@ class BrokerSettings(FrozenSettingsModel):
         return dict(value)
 
     @model_validator(mode="after")
-    def reject_duplicate_action_resources(self) -> BrokerSettings:
+    def validate_bridge_contracts(self) -> BrokerSettings:
         owners: dict[tuple[str, str, str], str] = {}
+        configured_kernel_bridge_settings(self.bridges)
         for bridge_id, bridge in self.bridges.items():
             for resource in bridge.action_resources:
                 key = (bridge.access, resource.kind, resource.resource_prefix)

--- a/tests/test_broker_host.py
+++ b/tests/test_broker_host.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+from typing import cast
 
 import pytest
 import zmq.asyncio
@@ -182,3 +183,24 @@ async def test_runner_correlates_concurrent_action_results_and_completes_deliver
         source.close()
         server.close()
         context.term()
+
+
+@pytest.mark.asyncio
+async def test_runner_expires_an_unresolved_delivery_scoped_action() -> None:
+    class PendingClient:
+        async def send_action_request(self, _request: ActionRequest) -> None:
+            return None
+
+    runner = BrokerBridgeRunner(cast(BridgeClient, PendingClient()))
+
+    with pytest.raises(TimeoutError):
+        await runner.request_action(
+            delivery_id="delivery-1",
+            lease_id="lease-1",
+            correlation_id="action-1",
+            kind="message.send",
+            resource_key="bot:source:bot-1",
+            timeout_seconds=0.01,
+        )
+
+    assert not runner._pending_results

--- a/tests/test_broker_kernel.py
+++ b/tests/test_broker_kernel.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+import zmq.asyncio
+from pydantic import ValidationError
+
+from liteyukibot.app import LiteyukiApp
+from liteyukibot.broker import (
+    MESSAGE_SEND_KIND,
+    ActionOutcome,
+    ActionRequest,
+    ActionResourceDeclaration,
+    BridgeAccess,
+    BridgeClient,
+    BridgeManifest,
+    BrokerBridgeRunner,
+    BrokerPeerServer,
+    EventIngress,
+    KernelBrokerPeer,
+    configured_kernel_bridge,
+    parse_message_send_request,
+)
+from liteyukibot.config import AppSettings
+from liteyukibot.events import (
+    ActionEnvelope,
+    ActionResult,
+    ActorRef,
+    ConversationRef,
+    EventBus,
+    EventEnvelope,
+    HandlerResult,
+    Message,
+    Segment,
+    SendMessage,
+)
+
+
+def _kernel_settings(
+    *,
+    access: str = "full",
+    subscriptions: tuple[str, ...] = ("message.created",),
+    action_resources: tuple[dict[str, str], ...] = (),
+) -> AppSettings:
+    return AppSettings.model_validate(
+        {
+            "config_version": 5,
+            "broker": {
+                "bridges": {
+                    "kernel": {
+                        "kind": "kernel",
+                        "token_secret": "broker.kernel.token",
+                        "access": access,
+                        "subscriptions": list(subscriptions),
+                        "action_resources": list(action_resources),
+                    }
+                }
+            },
+        }
+    )
+
+
+def _source_event() -> EventEnvelope:
+    return EventEnvelope(
+        id="source-event-1",
+        runtime_id="nonebot",
+        adapter="onebot-v11",
+        bot_id="bot-1",
+        type="message.group.normal",
+        conversation=ConversationRef(id="group-1", type="group"),
+        actor=ActorRef(id="user-1"),
+        message=Message(segments=(Segment(type="text", data={"text": "hello"}),)),
+        reply_token="reply-1",
+    )
+
+
+class _FakeLogger:
+    def bind(self, **_fields: Any) -> _FakeLogger:
+        return self
+
+    def debug(self, _message: str, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def info(self, _message: str, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def warning(self, _message: str, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def error(self, _message: str, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def exception(self, _message: str, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+
+def _unused_tcp_port() -> int:
+    for _ in range(100):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as first:
+            first.bind(("127.0.0.1", 0))
+            port = int(first.getsockname()[1])
+        if port == 65_535:
+            continue
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as second:
+            try:
+                second.bind(("127.0.0.1", port + 1))
+            except OSError:
+                continue
+        return port
+    pytest.fail("could not find adjacent free TCP ports")
+
+
+async def _wait_for_settled(server: BrokerPeerServer, event_id: str) -> None:
+    for _ in range(100):
+        if server.service.ledger.event_snapshot(event_id).status == "settled":
+            return
+        await asyncio.sleep(0.01)
+    pytest.fail("broker did not settle the kernel delivery")
+
+
+async def _pump_control(server: BrokerPeerServer) -> None:
+    while True:
+        await server.serve_control_once()
+
+
+async def _pump_business(server: BrokerPeerServer) -> None:
+    while True:
+        await server.serve_business_once()
+
+
+def test_kernel_bridge_requires_full_subscribed_non_owner_manifest() -> None:
+    configured = configured_kernel_bridge(_kernel_settings())
+    assert configured is not None
+    assert configured[0] == "kernel"
+    for settings, message in (
+        ({"access": "limited"}, "full access"),
+        ({"subscriptions": ()}, "at least one subscription"),
+        (
+            {"action_resources": ({"kind": MESSAGE_SEND_KIND, "resource_prefix": "bot:kernel:"},)},
+            "must not declare action ownership",
+        ),
+    ):
+        with pytest.raises(ValidationError, match=message):
+            _kernel_settings(**settings)
+    with pytest.raises(ValidationError, match="multiple kernel bridges"):
+        AppSettings.model_validate(
+            {
+                "config_version": 5,
+                "broker": {
+                    "bridges": {
+                        "kernel-a": {
+                            "kind": "kernel",
+                            "token_secret": "broker.kernel-a.token",
+                            "access": "full",
+                            "subscriptions": ["message.created"],
+                        },
+                        "kernel-b": {
+                            "kind": "kernel",
+                            "token_secret": "broker.kernel-b.token",
+                            "access": "full",
+                            "subscriptions": ["message.created"],
+                        },
+                    }
+                },
+            }
+        )
+
+
+def test_app_defers_kernel_peer_creation_until_start() -> None:
+    app = LiteyukiApp(_kernel_settings(), logger=_FakeLogger())  # type: ignore[arg-type]
+
+    assert app._configured_kernel_bridge is not None
+    assert app._kernel_broker_peer is None
+
+
+@pytest.mark.asyncio
+async def test_kernel_peer_dispatches_native_event_and_routes_send_message_to_source_owner() -> None:
+    context = zmq.asyncio.Context()
+    server = BrokerPeerServer(
+        context=context,
+        endpoint="inproc://kernel-peer",
+        generation=1,
+        instance_tokens={"nonebot": "nonebot-token", "kernel": "kernel-token"},
+    )
+    peer: KernelBrokerPeer | None = None
+    source_owner: BrokerBridgeRunner | None = None
+    event_bus: EventBus | None = None
+    control_task: asyncio.Task[None] | None = None
+    business_task: asyncio.Task[None] | None = None
+    owner_task: asyncio.Task[None] | None = None
+    seen: list[EventEnvelope] = []
+    sent: list[ActionRequest] = []
+    action_completed = asyncio.Event()
+    try:
+        async def owner_action(request: ActionRequest) -> ActionOutcome:
+            payload = parse_message_send_request(request, owner_bridge_id="nonebot")
+            sent.append(request)
+            assert payload.bot_id == "bot-1"
+            assert payload.reply_token == "reply-1"
+            action_completed.set()
+            return ActionOutcome(success=True, payload={"message_id": "native-send-1"})
+
+        source_owner = BrokerBridgeRunner(
+            BridgeClient(
+                context=context,
+                endpoints=server.endpoints,
+                generation=1,
+                identity=b"nonebot",
+                manifest=BridgeManifest(
+                    bridge_id="nonebot",
+                    access=BridgeAccess.LIMITED,
+                    action_resources=(
+                        ActionResourceDeclaration(kind=MESSAGE_SEND_KIND, resource_prefix="bot:nonebot:"),
+                    ),
+                ),
+                instance_token="nonebot-token",
+            ),
+            action_handlers={MESSAGE_SEND_KIND: owner_action},
+        )
+
+        async def execute_native_action(event: EventEnvelope, action: ActionEnvelope) -> ActionResult:
+            assert peer is not None
+            result = await peer.execute_action(event, action)
+            assert result is not None
+            return result
+
+        event_bus = EventBus(action_executor=execute_native_action)
+        kernel_client = BridgeClient(
+            context=context,
+            endpoints=server.endpoints,
+            generation=1,
+            identity=b"kernel",
+            manifest=BridgeManifest(
+                bridge_id="kernel",
+                access=BridgeAccess.FULL,
+                subscriptions=("message.created",),
+            ),
+            instance_token="kernel-token",
+        )
+        peer = KernelBrokerPeer("kernel", kernel_client, event_bus)
+
+        async def native_plugin(event: EventEnvelope) -> HandlerResult:
+            seen.append(event)
+            return HandlerResult(
+                actions=(
+                    ActionEnvelope(
+                        action_id="native-send-1",
+                        event_id=event.id,
+                        runtime_id=event.runtime_id,
+                        bot_id=event.bot_id,
+                        action=SendMessage(
+                            message=Message(segments=(Segment(type="text", data={"text": "pong"}),)),
+                            reply_token="reply-1",
+                        ),
+                    ),
+                )
+            )
+
+        event_bus.subscribe(native_plugin, name="native-plugin")
+        await event_bus.start()
+        control_task = asyncio.create_task(_pump_control(server))
+        business_task = asyncio.create_task(_pump_business(server))
+        await source_owner.start()
+        await peer.start()
+        owner_task = asyncio.create_task(source_owner.serve_forever())
+
+        event = _source_event()
+        await source_owner.client.send_event_ingress(
+            EventIngress(
+                source_event_id=event.id,
+                topic="message.created",
+                ordering_key=event.conversation.ordering_key,
+                payload=event.model_dump(mode="json"),
+            )
+        )
+        await asyncio.wait_for(action_completed.wait(), timeout=1)
+        await _wait_for_settled(server, seen[0].id)
+
+        assert len(seen) == 1
+        assert seen[0].id != event.id
+        assert seen[0].runtime_id == "nonebot"
+        assert [request.kind for request in sent] == [MESSAGE_SEND_KIND]
+    finally:
+        if peer is not None:
+            await peer.stop()
+        if source_owner is not None:
+            await source_owner.stop()
+            source_owner.close()
+        for task in (owner_task, business_task, control_task):
+            if task is not None:
+                task.cancel()
+        await asyncio.gather(
+            *(task for task in (owner_task, business_task, control_task) if task is not None),
+            return_exceptions=True,
+        )
+        if event_bus is not None:
+            await event_bus.aclose()
+        server.close()
+        context.term()
+
+
+@pytest.mark.asyncio
+async def test_app_lifecycle_registers_kernel_peer_and_dispatches_bridge_ingress(tmp_path: Path) -> None:
+    port = _unused_tcp_port()
+    endpoint = f"tcp://127.0.0.1:{port}"
+    context = zmq.asyncio.Context()
+    server = BrokerPeerServer(
+        context=context,
+        endpoint=endpoint,
+        generation=1,
+        instance_tokens={"nonebot": "nonebot-token", "kernel": "kernel-token"},
+    )
+    app: LiteyukiApp | None = None
+    source: BridgeClient | None = None
+    control_task: asyncio.Task[None] | None = None
+    business_task: asyncio.Task[None] | None = None
+    seen: list[EventEnvelope] = []
+    dispatched = asyncio.Event()
+    try:
+        settings = AppSettings.model_validate(
+            {
+                "config_version": 5,
+                "core": {"data_dir": str(tmp_path / "data"), "cache_dir": str(tmp_path / "cache")},
+                "broker": {
+                    "endpoint": endpoint,
+                    "bridges": {
+                        "kernel": {
+                            "kind": "kernel",
+                            "token_secret": "broker.kernel.token",
+                            "access": "full",
+                            "subscriptions": ["message.created"],
+                        }
+                    },
+                },
+            }
+        )
+        app = LiteyukiApp(
+            settings,
+            logger=_FakeLogger(),  # type: ignore[arg-type]
+            runtime_secrets={"broker.kernel.token": "kernel-token"},
+        )
+
+        async def native_plugin(event: EventEnvelope) -> HandlerResult:
+            seen.append(event)
+            dispatched.set()
+            return HandlerResult()
+
+        app.events.subscribe(native_plugin, name="native-plugin")
+        source = BridgeClient(
+            context=context,
+            endpoints=server.endpoints,
+            generation=1,
+            identity=b"nonebot",
+            manifest=BridgeManifest(bridge_id="nonebot", access=BridgeAccess.LIMITED),
+            instance_token="nonebot-token",
+        )
+        control_task = asyncio.create_task(_pump_control(server))
+        business_task = asyncio.create_task(_pump_business(server))
+        await app.start()
+        await source.register()
+
+        event = _source_event()
+        await source.send_event_ingress(
+            EventIngress(
+                source_event_id=event.id,
+                topic="message.created",
+                ordering_key=event.conversation.ordering_key,
+                payload=event.model_dump(mode="json"),
+            )
+        )
+        await asyncio.wait_for(dispatched.wait(), timeout=1)
+
+        assert len(seen) == 1
+        assert seen[0].id != event.id
+        assert seen[0].runtime_id == "nonebot"
+        await _wait_for_settled(server, seen[0].id)
+    finally:
+        if app is not None:
+            await app.stop()
+        if source is not None:
+            await source.unregister()
+            source.close()
+        for task in (business_task, control_task):
+            if task is not None:
+                task.cancel()
+        await asyncio.gather(
+            *(task for task in (business_task, control_task) if task is not None),
+            return_exceptions=True,
+        )
+        server.close()
+        context.term()

--- a/tests/test_broker_service.py
+++ b/tests/test_broker_service.py
@@ -236,3 +236,25 @@ async def test_sync_bridge_launcher_runs_off_the_asyncio_thread() -> None:
 
     assert launch_thread
     assert launch_thread[0] != caller_thread
+
+
+@pytest.mark.asyncio
+async def test_catalog_rejects_the_in_process_kernel_bridge() -> None:
+    settings = AppSettings.model_validate(
+        {
+            "config_version": 5,
+            "broker": {
+                "bridges": {
+                    "kernel": {
+                        "kind": "kernel",
+                        "token_secret": "broker.kernel.token",
+                        "access": "full",
+                        "subscriptions": ["message.created"],
+                    }
+                }
+            },
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="reserved kernel bridge"):
+        await BridgeCatalog().launch(settings, "kernel", "secret")

--- a/tests/test_cli_v7.py
+++ b/tests/test_cli_v7.py
@@ -15,6 +15,7 @@ from filelock import Timeout
 
 import liteyukibot.cli as cli_module
 from liteyukibot.config import AppSettings, ConfigWorkspace
+from liteyukibot.config.vault import SecretVault
 from liteyukibot.init_wizard import InitWizardResult
 from liteyukibot.plugin_store import PlatformTarget, RuntimeGeneration, RuntimeGenerationStore
 
@@ -54,6 +55,60 @@ class FakeSignalLoop:
 
     def call_soon_threadsafe(self, callback: Callable[[], None]) -> None:
         callback()
+
+
+def test_runtime_secrets_loads_configured_kernel_bridge_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = ConfigWorkspace(tmp_path)
+    settings = AppSettings.model_validate(
+        {
+            "config_version": 5,
+            "broker": {
+                "bridges": {
+                    "kernel": {
+                        "kind": "kernel",
+                        "token_secret": "broker.kernel.token",
+                        "access": "full",
+                        "subscriptions": ["message.created"],
+                    }
+                }
+            },
+        }
+    )
+    SecretVault(workspace.management_directory).initialize("password", {"broker.kernel.token": "secret-token"})
+    monkeypatch.setattr(cli_module, "_vault_password", lambda _workspace: "password")
+
+    assert cli_module._runtime_secrets(settings, workspace) == {"broker.kernel.token": "secret-token"}
+
+
+@pytest.mark.asyncio
+async def test_bridge_command_rejects_reserved_kernel_before_reading_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = AppSettings.model_validate(
+        {
+            "config_version": 5,
+            "broker": {
+                "bridges": {
+                    "kernel": {
+                        "kind": "kernel",
+                        "token_secret": "broker.kernel.token",
+                        "access": "full",
+                        "subscriptions": ["message.created"],
+                    }
+                }
+            },
+        }
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "bridge_token_from_vault",
+        lambda *_args: pytest.fail("kernel bridge must not read the vault through bridge run"),
+    )
+
+    with pytest.raises(RuntimeError, match="reserved kernel bridge"):
+        await cli_module._bridge_command(settings, ConfigWorkspace(tmp_path), "kernel")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- register the reserved full kernel broker peer from LiteyukiApp and dispatch authenticated bridge ingress into the native EventBus
- route native SendMessage actions back to the originating bridge through the leased B5 portable action path
- validate the reserved config contract, vault loading, CLI rejection, and document the B5-5 boundary

## Validation
- uv sync --locked --all-packages --extra onebot --extra satori
- uv run pytest (617 passed, 15 skipped)
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv build --all-packages --out-dir dist/workspace --clear
- uv run python scripts/run_tool_install_smoke.py

## Scope
No Cordis, AstrBot, generic CallApi, EditMessage, benchmark, or broker process-supervision expansion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional in-process broker bridge support for receiving native events and routing message actions.
  * Added kernel bridge authentication, lifecycle management, provenance checks, and source-specific message delivery.
  * Added delivery-based time limits for pending broker actions.

* **Bug Fixes**
  * Prevented kernel bridges from launching as standalone bridge processes.
  * Added validation for duplicate bridges and invalid permissions or ownership settings.

* **Documentation**
  * Updated lifecycle, configuration, runtime, and IPC documentation for kernel bridge behavior and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->