### PR TITLE
feat(release): add Alpha 1 bundle baseline

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,9 @@ These workflows are the executable CI and publishing contracts for v7.
 - `publish.yml` releases the root package from an immutable `v7.*` tag.
 - `publish-plugins.yaml` releases first-party packages from immutable
   package-specific tags.
+- `alpha-release.yaml` creates the signed, no-PyPI Alpha bundle from a
+  `v7.0.0a*` tag after staged bundle verification.
 
 Keep tag patterns, trusted-publisher environments, `scripts/check_release.py`,
-and `docs/development/releasing.md` synchronized. Never add publishing tokens
-or weaken isolated wheel verification.
+`scripts/alpha_release.py`, and `docs/development/releasing.md` synchronized.
+Never add publishing tokens or weaken isolated wheel verification.

--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -1,0 +1,114 @@
+name: Build LiteyukiBot Alpha Bundle
+
+on:
+  push:
+    tags: ["v7.0.0a*"]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  native:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            manylinux: "2_28"
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            manylinux: "2_28"
+            qemu: true
+          - os: macos-13
+            target: x86_64-apple-darwin
+            manylinux: "off"
+          - os: macos-14
+            target: aarch64-apple-darwin
+            manylinux: "off"
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            manylinux: "off"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        if: matrix.os != 'ubuntu-latest'
+        with:
+          python-version: "3.14"
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        if: matrix.qemu == true
+      - uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
+        with:
+          working-directory: packages/ipc-native
+          maturin-version: v1.14.1
+          target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
+          args: --release --locked --compatibility pypi --out ../../dist/alpha
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: alpha-native-${{ matrix.target }}
+          path: dist/alpha/*.whl
+          if-no-files-found: error
+
+  bundle:
+    needs: native
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        with:
+          version: 11.5.3
+          run_install: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version-file: .node-version
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: "0.11.16"
+          enable-cache: true
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: alpha-native-*
+          path: dist/alpha
+          merge-multiple: true
+      - name: Install locked workspace
+        run: |
+          uv python install 3.14
+          uv sync --locked --all-packages --extra onebot --extra satori --extra webui
+      - name: Validate Alpha source registry
+        run: |
+          test "$RELEASE_TAG" = "v7.0.0a1"
+          uv run --group release python scripts/alpha_release.py check-source
+      - name: Build lockstep Python artifacts
+        run: |
+          pnpm --dir webui install --frozen-lockfile
+          pnpm --dir webui build
+          uv run python scripts/stage_webui_assets.py
+          uv build --out-dir dist/alpha
+          uv build --project packages/cordis --out-dir dist/alpha
+          uv build --project packages/runtime-nonebot --out-dir dist/alpha
+          uv build --project packages/runtime-astrbot --out-dir dist/alpha
+          uv build --project packages/runtime-adapter --out-dir dist/alpha
+          uv build --project packages/webui --out-dir dist/alpha
+      - name: Build Native IPC source distribution
+        run: uv build --project packages/ipc-native --sdist --out-dir dist/alpha
+      - name: Generate bundle evidence
+        run: uv run --group release python scripts/alpha_release.py generate --dist dist/alpha
+      - name: Sign canonical manifest
+        run: >-
+          uv run --group release sigstore sign --bundle dist/alpha/artifacts.manifest.sigstore.json
+          dist/alpha/artifacts.manifest.json
+      - name: Verify the staged bundle outside the source tree
+        run: |
+          bundle="$(mktemp -d)"
+          cp -a dist/alpha/. "$bundle"
+          uv run --group release python scripts/alpha_release.py verify --bundle "$bundle"
+          uv run python -m scripts.run_alpha_bundle_installs --bundle "$bundle"
+      - name: Create immutable GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$RELEASE_TAG" dist/alpha/* --title "$RELEASE_TAG" --generate-notes

--- a/.github/workflows/publish-plugins.yaml
+++ b/.github/workflows/publish-plugins.yaml
@@ -83,7 +83,7 @@ jobs:
         id: release
         run: >-
           uv run --no-project --python 3.14 python scripts/check_release.py
-          --tag "$RELEASE_TAG" --github-output "$GITHUB_OUTPUT"
+          --tag "$RELEASE_TAG" --github-output "$GITHUB_OUTPUT" --reject-alpha
       - name: Build plugin distribution
         run: |
           if [[ "${{ steps.release.outputs.package }}" == "webui" ]]; then
@@ -181,7 +181,7 @@ jobs:
       - name: Validate native release identity
         run: >-
           uv run --no-project --python 3.14 python scripts/check_release.py
-          --tag "$RELEASE_TAG"
+          --tag "$RELEASE_TAG" --reject-alpha
       - name: Generate native SBOM and artifact manifest
         run: |
           uv export --project packages/ipc-native --no-dev --no-emit-project \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Require published Yukilog 1.x
         run: uv run --no-project --python 3.14 --with "yukilog>=1,<2" python -c "import yukilog"
       - name: Validate release identity
-        run: uv run --no-project --python 3.14 python scripts/check_release.py --tag "$RELEASE_TAG"
+        run: uv run --no-project --python 3.14 python scripts/check_release.py --tag "$RELEASE_TAG" --reject-alpha
       - name: Build distribution
         run: |
           uv build

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ they exchange frozen Event and Action models with the kernel rather than SDK
 objects.
 
 The default branch is the maintained LiteyukiBot v7 line. The prior v6 line is
-preserved on the `v6` branch. Its current published release is
-`liteyukibot-v7==7.0.0b2`.
+preserved on the `v6` branch. The current source is the `7.0.0a1` Alpha bundle
+baseline; it is not a PyPI release. The earlier `7.0.0b2` B7 package is
+historical release evidence.
 
 ## Features
 
@@ -146,7 +147,7 @@ This repository is a uv workspace containing the kernel, first-party packages,
 examples, tests, developer tools, documentation, and release workflows.
 Directory-level development guidance is provided by each directory's README.
 
-[Liteyuki7]: https://img.shields.io/badge/LiteyukiBot-7.0.0b2-blue?style=for-the-badge
+[Liteyuki7]: https://img.shields.io/badge/LiteyukiBot-7.0.0a1-blue?style=for-the-badge
 [Python3.14]: https://img.shields.io/badge/Python-3.14+-blue?style=for-the-badge
 [Usage]: https://img.shields.io/badge/Usage-CLI-blue?style=for-the-badge
 [Repo]: https://img.shields.io/badge/Distribution-PyPI-blue?style=for-the-badge

--- a/docs/architecture/v7.md
+++ b/docs/architecture/v7.md
@@ -233,13 +233,13 @@ documented in
 
 ## Current Release State
 
-The current source pre-release is `liteyukibot-v7==7.0.0b2`. B7 work is still
-pre-release implementation and qualification work: it must not be represented
-as a stable release, a completed 72-hour soak, or a completed full-workspace
-theoretical benchmark. Resources and profile remain optional business plugins;
-their storage and migration ownership does not belong to the kernel. The Beta1
-compatibility tiers, supported installation path, security boundary, and known
-limits are recorded in the
+The current source pre-release is `liteyukibot-v7==7.0.0a1`. It is the Alpha 1
+lockstep bundle baseline, not a PyPI release, stable release, completed 72-hour
+soak, or completed full-workspace theoretical benchmark. B7 is the migration
+and architecture-validation baseline for this Alpha line. Resources and profile
+remain optional business plugins; their storage and migration ownership does not
+belong to the kernel. The Beta1 compatibility tiers, supported installation
+path, security boundary, and known limits are recorded in the
 [`Beta1 archive`](../archive/2026-08-17/beta1-contract.md).
 
 Current release procedure and package identities are in

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -106,11 +106,11 @@ from the PyPI JSON endpoint is expected before the first trusted upload; an
 existing project owned elsewhere is a release blocker, not a reason to rename a
 distribution inside the workflow.
 
-## Historical Identities
+## Historical B7 Identities
 
 | Package | Source | Tag |
 | --- | --- | --- |
-| `liteyukibot-v7==7.0.0b2` | `pyproject.toml` | `v7.0.0b2` |
+| `liteyukibot-v7==7.0.0b2` | historical B7 release metadata | `v7.0.0b2` |
 | `liteyukibot-v7-permissions==0.2.0a2` | `packages/permissions` | `permissions-v0.2.0a2` |
 | `liteyukibot-v7-commands==0.2.0a2` | `packages/commands` | `commands-v0.2.0a2` |
 | `liteyukibot-v7-resources==0.1.0a2` | `packages/resources` | `resources-v0.1.0a2` |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -22,7 +22,7 @@ and tests in the same pull request.
 - [Management and Command v1](management-command-v1.md)
 - [Release and Maintenance v1](release-maintenance-v1.md)
 - [Instance Daemon v1](instance-daemon-v1.md)
-- [Configuration v4](configuration-v4.md)
+- [Configuration v5](configuration-v5.md)
 - [Resources v1](resources-v1.md)
 - [v6 Compatibility](v6-compatibility.md)
 

--- a/docs/specs/configuration-v5.md
+++ b/docs/specs/configuration-v5.md
@@ -1,15 +1,15 @@
-# Configuration v4
+# Configuration v5
 
-- Specification version: `4`
-- Applies to: current `config_version = 4` workspace configuration
+- Specification version: `5`
+- Applies to: current `config_version = 5` workspace configuration
 - Compatibility: root configurations without `config_version`, and every
-  version through `3`, are pre-release input. Startup preserves them and
-  blocks for a manual upgrade. Versions greater than `4` are rejected.
+  version through `4`, are pre-release input. Startup preserves them and
+  blocks for a manual upgrade. Versions greater than `5` are rejected.
 
 Configuration is typed, strict, and loaded in precedence order: defaults, root
 configuration, instance overlay, explicit configuration path, environment
 overrides, and CLI overrides. Diagnostics retain provenance and redact secret
-values. A root workspace configuration must declare version `4`; lower-level
+values. A root workspace configuration must declare version `5`; lower-level
 configuration loading may omit it only to support partial programmatic layers.
 
 ## LYIP
@@ -41,8 +41,8 @@ The resolved per-direction profiles are immutable:
 values are powers of two in `256..65536`, `32..4096`, and `256..65536`;
 `blob_arena_mib` is a power of two in `4..512`.
 
-A worker resolves a requested link once at startup and never switches it live.
-Beta3's active child lifecycle binds ZMQ. The native diagnostics report wheel,
+A bridge or compatibility worker resolves a requested link once at startup and
+never switches it live. The native diagnostics report wheel,
 ABI, platform, and fallback reason without becoming a configuration flag; the
 optional native package exposes an SPSC ring primitive, but no SHM LYIP
 transport adapter. Consequently `auto` and `zmq` resolve to ZMQ; an explicit
@@ -79,16 +79,16 @@ operation audit store.
 ## Cutover And Recovery
 
 `liteyuki config upgrade` never edits the root `liteyuki.toml`. For a missing
-version or a version through `3`, it copies the exact source to a timestamped
+version or a version through `4`, it copies the exact source to a timestamped
 read-only `.liteyuki/config-backups/<timestamp>/liteyuki.toml`, then writes a
-fresh v4 template and instructions under `.liteyuki/config-upgrades/`. An old
-file is not parsed as v4 before backup, so removed fields do not prevent
+fresh v5 template and instructions under `.liteyuki/config-upgrades/`. An old
+file is not parsed as v5 before backup, so removed fields do not prevent
 recovery. Repeated calls use the first material until `--refresh`, which creates
 a new backup and template set. Startup remains blocked until the operator
-replaces the root with valid v4 TOML. The backup can only be used by an older
-pre-v4 beta; v4 has no rollback command because it never changed the root.
+replaces the root with valid v5 TOML. The backup can only be used by an older
+pre-v5 build; v5 has no rollback command because it never changed the root.
 
-Versions greater than `4` are rejected without backup or generated material.
+Versions greater than `5` are rejected without backup or generated material.
 
 ## Evidence
 

--- a/docs/specs/release-maintenance-v1.md
+++ b/docs/specs/release-maintenance-v1.md
@@ -39,8 +39,31 @@ configured PyPI Trusted Publisher environment. SBOMs, checksum manifests, and
 other release evidence are retained as workflow artifacts rather than uploaded
 as distributions.
 
+## Alpha Bundle
+
+The source Alpha 1 contract uses the exact `7.0.0a1` version for the kernel,
+Native IPC, Cordis, NoneBot bridge, AstrBot bridge, generic adapter bridge, and
+WebUI. The DevCLI identifier is reserved in the bundle inventory but has no
+artifact in Alpha 1. Independent business packages do not join this lockstep
+set.
+
+`scripts/alpha_release.py` validates source metadata, writes canonical UTF-8
+`artifacts.manifest.json`, and writes the deterministic CycloneDX 1.5
+`sbom.cdx.json`. The manifest records tag, common version, frozen LYIP v2 /
+Runtime IPC v6 / broker v6 / configuration v5 baselines, inventory, artifact
+metadata, sizes, and SHA-256 hashes. Its Sigstore sidecar is named
+`artifacts.manifest.sigstore.json` and must verify the GitHub OIDC issuer,
+repository, Alpha workflow path, and exact tag.
+
+`.github/workflows/alpha-release.yaml` is the only Alpha publication path. It
+builds the lockstep bundle, validates it in a fresh directory, exercises every
+staged install verifier, and uploads assets to an immutable GitHub Release. It
+never calls `uv publish`. The historical PyPI workflows call
+`scripts/check_release.py --reject-alpha` before building, so an Alpha version
+cannot reach their publish steps.
+
 ## Evidence
 
 Run `uv build --all-packages --out-dir dist/workspace --clear`,
 `uv run python -m scripts.run_webui_install`, and
-`uv run pytest tests/test_release_v7.py`.
+`uv run pytest tests/test_release_v7.py tests/test_alpha_release.py`.

--- a/packages/adapter-onebot/pyproject.toml
+++ b/packages/adapter-onebot/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7-runtime-adapter>=0.1.0a2,<1",
+    "liteyukibot-v7-runtime-adapter>=7.0.0a1,<8",
     "websockets>=15,<16",
 ]
 

--- a/packages/adapter-satori/pyproject.toml
+++ b/packages/adapter-satori/pyproject.toml
@@ -8,8 +8,8 @@ license = "LicenseRef-LSO"
 license-files = ["LICENSE"]
 authors = [{ name = "LiteyukiStudio" }]
 dependencies = [
-    "liteyukibot-v7>=7.0.0b2,<8",
-    "liteyukibot-v7-runtime-adapter>=0.1.0a2,<1",
+    "liteyukibot-v7>=7.0.0a1,<8",
+    "liteyukibot-v7-runtime-adapter>=7.0.0a1,<8",
     "websockets>=15,<16",
 ]
 

--- a/packages/agent/pyproject.toml
+++ b/packages/agent/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a17,<8",
+    "liteyukibot-v7>=7.0.0a1,<8",
     "liteyukibot-v7-commands>=0.2.0a2,<0.3",
     "liteyukibot-v7-agent-resolver>=0.1.0a1,<0.2",
     "openai>=2,<3",

--- a/packages/commands/pyproject.toml
+++ b/packages/commands/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a10,<8",
+    "liteyukibot-v7>=7.0.0a1,<8",
     "liteyukibot-v7-permissions>=0.2.0a1,<0.3",
 ]
 

--- a/packages/cordis/pyproject.toml
+++ b/packages/cordis/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "liteyukibot-v7-cordis"
-version = "0.1.0b6"
+version = "7.0.0a1"
 description = "Python-first Cordis Plugin v1 host for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
 license = "LicenseRef-LSO"
 license-files = ["LICENSE"]
 authors = [{ name = "LiteyukiStudio" }]
-dependencies = ["liteyukibot-v7>=7.0.0b2,<8"]
+dependencies = ["liteyukibot-v7==7.0.0a1"]
 
 [project.entry-points."liteyukibot.cordis_hosts"]
 python = "liteyukibot_cordis:host_factory"

--- a/packages/essentials/pyproject.toml
+++ b/packages/essentials/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a10,<8",
+    "liteyukibot-v7>=7.0.0a1,<8",
     "liteyukibot-v7-commands>=0.2.0a2,<0.3",
 ]
 

--- a/packages/functions/pyproject.toml
+++ b/packages/functions/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a7,<8",
+    "liteyukibot-v7>=7.0.0a1,<8",
 ]
 
 [project.entry-points."liteyukibot.function_executors"]

--- a/packages/ipc-native/pyproject.toml
+++ b/packages/ipc-native/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "liteyukibot-v7-ipc-native"
-version = "0.1.0b3"
+version = "7.0.0a1"
 description = "Optional native primitives for Liteyuki IPC."
 requires-python = ">=3.14"
 license = "LicenseRef-LSO"

--- a/packages/permissions/pyproject.toml
+++ b/packages/permissions/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a3,<8",
+    "liteyukibot-v7>=7.0.0a1,<8",
 ]
 
 [project.entry-points."liteyukibot.plugins"]

--- a/packages/profile/pyproject.toml
+++ b/packages/profile/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a10,<8",
+    "liteyukibot-v7>=7.0.0a1,<8",
     "liteyukibot-v7-resources>=0.1.0a2,<0.2",
 ]
 

--- a/packages/resources/pyproject.toml
+++ b/packages/resources/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a10,<8",
+    "liteyukibot-v7>=7.0.0a1,<8",
     "liteyukibot-v7-commands>=0.2.0a2,<0.3",
     "liteyukibot-v7-permissions>=0.2.0a1,<0.3",
 ]

--- a/packages/runtime-adapter/pyproject.toml
+++ b/packages/runtime-adapter/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-adapter"
-version = "0.1.0a2"
+version = "7.0.0a1"
 description = "Python platform adapter host for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a10,<8",
+    "liteyukibot-v7==7.0.0a1",
 ]
 
 [project.entry-points."liteyukibot.runtimes"]

--- a/packages/runtime-astrbot/pyproject.toml
+++ b/packages/runtime-astrbot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a7"
+version = "7.0.0a1"
 description = "AstrBot platform gateway for the LiteyukiBot v7 broker."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -9,7 +9,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a15,<8",
+    "liteyukibot-v7==7.0.0a1",
     "AstrBot==4.27.2",
 ]
 

--- a/packages/runtime-mofox/pyproject.toml
+++ b/packages/runtime-mofox/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a15,<8",
+    "liteyukibot-v7>=7.0.0a1,<8",
 ]
 
 [project.entry-points."liteyukibot.runtimes"]

--- a/packages/runtime-nonebot/pyproject.toml
+++ b/packages/runtime-nonebot/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-runtime-nonebot"
-version = "0.1.0a1"
+version = "7.0.0a1"
 description = "NoneBot2 broker bridge for LiteyukiBot v7."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a3,<8",
+    "liteyukibot-v7==7.0.0a1",
     "nonebot2[fastapi,httpx,websockets]>=2.5,<3",
 ]
 

--- a/packages/runtime-v6/pyproject.toml
+++ b/packages/runtime-v6/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "LiteyukiStudio" },
 ]
 dependencies = [
-    "liteyukibot-v7>=7.0.0a9,<8",
+    "liteyukibot-v7>=7.0.0a1,<8",
 ]
 
 [project.entry-points."liteyukibot.runtimes"]

--- a/packages/webui/pyproject.toml
+++ b/packages/webui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7-webui"
-version = "0.1.0b4"
+version = "7.0.0a1"
 description = "Local WebUI distribution wrapper for LiteyukiBot v7."
 requires-python = ">=3.14"
 license = "LicenseRef-LSO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "liteyukibot-v7"
-version = "7.0.0b2"
+version = "7.0.0a1"
 description = "A protocol-neutral, multi-runtime chatbot kernel."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -33,7 +33,7 @@ http = [
 webui = [
     "fastapi>=0.141,<1",
     "uvicorn>=0.52,<1",
-    "liteyukibot-v7-webui[server]>=0.1.0b4",
+    "liteyukibot-v7-webui[server]==7.0.0a1",
 ]
 
 [project.scripts]
@@ -55,6 +55,7 @@ dev = [
 release = [
     "cyclonedx-bom>=7.3.1",
     "license-expression>=30.4.4",
+    "sigstore>=4,<5",
 ]
 
 [build-system]

--- a/scripts/alpha_release.py
+++ b/scripts/alpha_release.py
@@ -1,0 +1,434 @@
+"""Build and verify the signed, lockstep Alpha release bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shlex
+import subprocess
+import tarfile
+import tomllib
+import zipfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+from typing import Any, cast
+
+
+class AlphaReleaseError(RuntimeError):
+    """Raised when an Alpha bundle does not satisfy its frozen contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class AlphaComponent:
+    """One distribution included in the Alpha 1 lockstep bundle."""
+
+    component_id: str
+    project_dir: str
+    distribution: str
+    requires_sdist: bool = True
+
+
+ALPHA_VERSION = "7.0.0a1"
+ALPHA_TAG = f"v{ALPHA_VERSION}"
+MANIFEST_NAME = "artifacts.manifest.json"
+SBOM_NAME = "sbom.cdx.json"
+SIGNATURE_NAME = "artifacts.manifest.sigstore.json"
+OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+WORKFLOW_PATH = ".github/workflows/alpha-release.yaml"
+BASELINE: Mapping[str, int] = {
+    "lyip": 2,
+    "runtime_ipc": 6,
+    "broker": 6,
+    "configuration": 5,
+}
+LOCKSTEP_COMPONENTS: tuple[AlphaComponent, ...] = (
+    AlphaComponent("kernel", ".", "liteyukibot-v7"),
+    AlphaComponent("ipc-native", "packages/ipc-native", "liteyukibot-v7-ipc-native"),
+    AlphaComponent("cordis", "packages/cordis", "liteyukibot-v7-cordis"),
+    AlphaComponent("nonebot-bridge", "packages/runtime-nonebot", "liteyukibot-v7-runtime-nonebot"),
+    AlphaComponent("astrbot-bridge", "packages/runtime-astrbot", "liteyukibot-v7-runtime-astrbot"),
+    AlphaComponent("adapter-bridge", "packages/runtime-adapter", "liteyukibot-v7-runtime-adapter"),
+    AlphaComponent("webui", "packages/webui", "liteyukibot-v7-webui"),
+)
+
+SignatureVerifier = Callable[[Path, Path, str], None]
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _project(root: Path, component: AlphaComponent) -> dict[str, Any]:
+    project_file = root / component.project_dir / "pyproject.toml"
+    try:
+        document = tomllib.loads(project_file.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise AlphaReleaseError(f"cannot read {project_file}") from error
+    project = document.get("project")
+    if not isinstance(project, dict):
+        raise AlphaReleaseError(f"{project_file} does not contain a [project] table")
+    return cast(dict[str, Any], project)
+
+
+def _string_field(project: Mapping[str, Any], name: str, *, context: str) -> str:
+    value = project.get(name)
+    if not isinstance(value, str) or not value:
+        raise AlphaReleaseError(f"{context} has no non-empty project.{name}")
+    return value
+
+
+def certificate_identity(tag: str = ALPHA_TAG) -> str:
+    return f"https://github.com/LiteyukiStudio/LiteyukiBot/{WORKFLOW_PATH}@refs/tags/{tag}"
+
+
+def validate_source_registry(root: Path) -> None:
+    """Check that source metadata is exactly the Alpha 1 lockstep inventory."""
+
+    for component in LOCKSTEP_COMPONENTS:
+        project = _project(root, component)
+        context = str(Path(component.project_dir) / "pyproject.toml")
+        if _string_field(project, "name", context=context) != component.distribution:
+            raise AlphaReleaseError(f"{context} distribution does not match the Alpha registry")
+        if _string_field(project, "version", context=context) != ALPHA_VERSION:
+            raise AlphaReleaseError(f"{context} must use lockstep version {ALPHA_VERSION}")
+
+    root_project = _project(root, LOCKSTEP_COMPONENTS[0])
+    optional = root_project.get("optional-dependencies")
+    webui_extra = optional.get("webui") if isinstance(optional, dict) else None
+    if not isinstance(webui_extra, list) or f"liteyukibot-v7-webui[server]=={ALPHA_VERSION}" not in webui_extra:
+        raise AlphaReleaseError("root webui extra must pin the Alpha WebUI wheel exactly")
+
+    for component in LOCKSTEP_COMPONENTS:
+        if component.component_id in {"kernel", "ipc-native", "webui"}:
+            continue
+        project = _project(root, component)
+        dependencies = project.get("dependencies")
+        if not isinstance(dependencies, list) or f"liteyukibot-v7=={ALPHA_VERSION}" not in dependencies:
+            raise AlphaReleaseError(f"{component.component_id} must pin liteyukibot-v7 to {ALPHA_VERSION}")
+
+
+def _distribution_metadata(path: Path) -> tuple[str, str]:
+    metadata_bytes: bytes
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            names = tuple(name for name in archive.namelist() if name.endswith(".dist-info/METADATA"))
+            if len(names) != 1:
+                raise AlphaReleaseError(f"{path.name} has no unique wheel METADATA file")
+            metadata_bytes = archive.read(names[0])
+    elif path.name.endswith(".tar.gz"):
+        with tarfile.open(path, "r:gz") as archive:
+            members = tuple(member for member in archive.getmembers() if member.name.endswith("/PKG-INFO"))
+            if len(members) != 1:
+                raise AlphaReleaseError(f"{path.name} has no unique source PKG-INFO file")
+            extracted = archive.extractfile(members[0])
+            if extracted is None:
+                raise AlphaReleaseError(f"cannot read {path.name} PKG-INFO")
+            metadata_bytes = extracted.read()
+    else:
+        raise AlphaReleaseError(f"unsupported release artifact {path.name}")
+    message = BytesParser(policy=policy.default).parsebytes(metadata_bytes)
+    name, version = message.get("Name"), message.get("Version")
+    if not isinstance(name, str) or not isinstance(version, str) or not name or not version:
+        raise AlphaReleaseError(f"{path.name} has invalid package metadata")
+    return name, version
+
+
+def _artifact_kind(path: Path) -> str:
+    if path.suffix == ".whl":
+        return "wheel"
+    if path.name.endswith(".tar.gz"):
+        return "sdist"
+    raise AlphaReleaseError(f"unsupported release artifact {path.name}")
+
+
+def _artifact_records(dist: Path) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for path in sorted(dist.iterdir()):
+        if not path.is_file() or path.name in {MANIFEST_NAME, SBOM_NAME, SIGNATURE_NAME}:
+            continue
+        if path.suffix != ".whl" and not path.name.endswith(".tar.gz"):
+            continue
+        distribution, version = _distribution_metadata(path)
+        records.append(
+            {
+                "filename": path.name,
+                "bytes": path.stat().st_size,
+                "sha256": _sha256(path),
+                "distribution": distribution,
+                "version": version,
+                "kind": _artifact_kind(path),
+            }
+        )
+    return records
+
+
+def _validate_artifact_set(records: Sequence[Mapping[str, object]]) -> None:
+    expected = {component.distribution: component for component in LOCKSTEP_COMPONENTS}
+    observed: dict[str, set[str]] = {distribution: set() for distribution in expected}
+    for record in records:
+        distribution = record.get("distribution")
+        version = record.get("version")
+        kind = record.get("kind")
+        if not isinstance(distribution, str) or not isinstance(version, str) or not isinstance(kind, str):
+            raise AlphaReleaseError("manifest artifact has invalid metadata")
+        if distribution not in expected:
+            raise AlphaReleaseError(f"bundle contains non-Alpha distribution {distribution!r}")
+        if version != ALPHA_VERSION:
+            raise AlphaReleaseError(f"{distribution} artifact must use lockstep version {ALPHA_VERSION}")
+        observed[distribution].add(kind)
+    for component in LOCKSTEP_COMPONENTS:
+        kinds = observed[component.distribution]
+        if "wheel" not in kinds:
+            raise AlphaReleaseError(f"bundle is missing a wheel for {component.distribution}")
+        if component.requires_sdist and "sdist" not in kinds:
+            raise AlphaReleaseError(f"bundle is missing a source distribution for {component.distribution}")
+
+
+def create_manifest(root: Path, dist: Path) -> Path:
+    """Write the exact canonical Alpha manifest for staged release artifacts."""
+
+    validate_source_registry(root)
+    records = _artifact_records(dist)
+    _validate_artifact_set(records)
+    components: list[dict[str, object]] = []
+    for component in LOCKSTEP_COMPONENTS:
+        project = _project(root, component)
+        components.append(
+            {
+                "id": component.component_id,
+                "distribution": component.distribution,
+                "version": ALPHA_VERSION,
+                "license": _string_field(project, "license", context=component.project_dir),
+                "reserved": False,
+            }
+        )
+    components.append(
+        {
+            "id": "devcli",
+            "distribution": "liteyukibot-v7-devcli",
+            "version": ALPHA_VERSION,
+            "reserved": True,
+        }
+    )
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "release": {"tag": ALPHA_TAG, "version": ALPHA_VERSION},
+        "baseline": dict(BASELINE),
+        "components": components,
+        "artifacts": records,
+    }
+    output = dist / MANIFEST_NAME
+    output.write_bytes(_canonical_json(payload))
+    return output
+
+
+def create_sbom(dist: Path) -> Path:
+    """Write a deterministic CycloneDX inventory for the manifest's component set."""
+
+    manifest = _read_manifest(dist / MANIFEST_NAME)
+    components = manifest["components"]
+    assert isinstance(components, list)
+    bom_components: list[dict[str, object]] = []
+    for component in components:
+        if not isinstance(component, dict):
+            raise AlphaReleaseError("manifest component is invalid")
+        license_value = component.get("license")
+        license_entry = (
+            {"name": license_value}
+            if isinstance(license_value, str) and license_value.startswith("LicenseRef-")
+            else {"id": license_value}
+            if isinstance(license_value, str)
+            else None
+        )
+        bom_components.append(
+            {
+                "type": "library",
+                "name": component["distribution"],
+                "version": component["version"],
+                "licenses": [{"license": license_entry}] if license_entry is not None else [],
+                "properties": [{"name": "liteyuki:reserved", "value": "true"}] if component["reserved"] else [],
+            }
+        )
+    payload = {"bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1, "components": bom_components}
+    output = dist / SBOM_NAME
+    output.write_bytes(_canonical_json(payload))
+    return output
+
+
+def _read_manifest(path: Path) -> dict[str, object]:
+    try:
+        raw = path.read_bytes()
+        value = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as error:
+        raise AlphaReleaseError(f"cannot read canonical manifest {path}") from error
+    if not isinstance(value, dict) or raw != _canonical_json(value):
+        raise AlphaReleaseError("manifest is not canonical UTF-8 JSON")
+    return cast(dict[str, object], value)
+
+
+def _verify_manifest_shape(manifest: Mapping[str, object], *, tag: str) -> list[Mapping[str, object]]:
+    if manifest.get("schema_version") != 1 or manifest.get("baseline") != dict(BASELINE):
+        raise AlphaReleaseError("manifest schema or frozen baseline does not match Alpha 1")
+    release = manifest.get("release")
+    if release != {"tag": tag, "version": ALPHA_VERSION}:
+        raise AlphaReleaseError("manifest release tag or version is invalid")
+    components = manifest.get("components")
+    if not isinstance(components, list):
+        raise AlphaReleaseError("manifest components are invalid")
+    expected = {component.component_id: component.distribution for component in LOCKSTEP_COMPONENTS}
+    expected["devcli"] = "liteyukibot-v7-devcli"
+    observed: dict[str, str] = {}
+    for component in components:
+        if not isinstance(component, dict):
+            raise AlphaReleaseError("manifest component is invalid")
+        component_id, distribution = component.get("id"), component.get("distribution")
+        if not isinstance(component_id, str) or not isinstance(distribution, str):
+            raise AlphaReleaseError("manifest component identity is invalid")
+        observed[component_id] = distribution
+    if observed != expected:
+        raise AlphaReleaseError("manifest component inventory does not match Alpha 1")
+    if len(components) != len(expected):
+        raise AlphaReleaseError("manifest component inventory contains duplicates")
+    for component in components:
+        assert isinstance(component, dict)
+        component_id = cast(str, component["id"])
+        if component.get("version") != ALPHA_VERSION or component.get("reserved") is not (component_id == "devcli"):
+            raise AlphaReleaseError("manifest component version or reserved state is invalid")
+        if component_id != "devcli" and not isinstance(component.get("license"), str):
+            raise AlphaReleaseError("manifest component license is invalid")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list) or not all(isinstance(record, dict) for record in artifacts):
+        raise AlphaReleaseError("manifest artifacts are invalid")
+    return [cast(Mapping[str, object], record) for record in artifacts]
+
+
+def _run_sigstore(signature: Path, manifest: Path, tag: str, command: str) -> None:
+    completed = subprocess.run(
+        [
+            *shlex.split(command),
+            "verify",
+            "identity",
+            "--bundle",
+            str(signature),
+            "--cert-identity",
+            certificate_identity(tag),
+            "--cert-oidc-issuer",
+            OIDC_ISSUER,
+            str(manifest),
+        ],
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise AlphaReleaseError("Sigstore identity verification failed")
+
+
+def verify_bundle(
+    bundle: Path,
+    *,
+    tag: str = ALPHA_TAG,
+    sigstore_command: str = "sigstore",
+    signature_verifier: SignatureVerifier | None = None,
+) -> None:
+    """Verify a downloaded Alpha bundle without reading source metadata."""
+
+    if tag != ALPHA_TAG:
+        raise AlphaReleaseError(f"Alpha 1 tag must be {ALPHA_TAG}")
+    manifest_path = bundle / MANIFEST_NAME
+    signature_path = bundle / SIGNATURE_NAME
+    if not signature_path.is_file():
+        raise AlphaReleaseError("bundle is missing the Sigstore manifest bundle")
+    manifest = _read_manifest(manifest_path)
+    records = _verify_manifest_shape(manifest, tag=tag)
+    _validate_artifact_set(records)
+    filenames: set[str] = set()
+    for record in records:
+        filename, size, digest, distribution, version = (
+            record.get("filename"),
+            record.get("bytes"),
+            record.get("sha256"),
+            record.get("distribution"),
+            record.get("version"),
+        )
+        if not isinstance(filename, str):
+            raise AlphaReleaseError("manifest artifact filename is invalid")
+        if not isinstance(size, int):
+            raise AlphaReleaseError("manifest artifact size is invalid")
+        if not isinstance(digest, str) or not isinstance(distribution, str) or not isinstance(version, str):
+            raise AlphaReleaseError("manifest artifact record has invalid fields")
+        if Path(filename).name != filename or filename in filenames:
+            raise AlphaReleaseError("manifest artifact filename is invalid")
+        filenames.add(filename)
+        artifact = bundle / filename
+        if not artifact.is_file() or artifact.stat().st_size != size or _sha256(artifact) != digest:
+            raise AlphaReleaseError(f"artifact integrity check failed for {filename}")
+        observed_distribution, observed_version = _distribution_metadata(artifact)
+        if (observed_distribution, observed_version) != (distribution, version):
+            raise AlphaReleaseError(f"artifact metadata check failed for {filename}")
+    try:
+        sbom = json.loads((bundle / SBOM_NAME).read_bytes())
+    except (OSError, json.JSONDecodeError) as error:
+        raise AlphaReleaseError("bundle is missing a valid CycloneDX SBOM") from error
+    if not isinstance(sbom, dict) or sbom.get("bomFormat") != "CycloneDX" or sbom.get("specVersion") != "1.5":
+        raise AlphaReleaseError("bundle SBOM is not CycloneDX 1.5")
+    sbom_components = sbom.get("components")
+    if not isinstance(sbom_components, list):
+        raise AlphaReleaseError("bundle SBOM components are invalid")
+    inventory: dict[str, str] = {}
+    for component in sbom_components:
+        if not isinstance(component, dict):
+            raise AlphaReleaseError("bundle SBOM component is invalid")
+        name, version = component.get("name"), component.get("version")
+        if not isinstance(name, str) or not isinstance(version, str):
+            raise AlphaReleaseError("bundle SBOM component identity is invalid")
+        inventory[name] = version
+    expected_inventory = {component.distribution: ALPHA_VERSION for component in LOCKSTEP_COMPONENTS}
+    expected_inventory["liteyukibot-v7-devcli"] = ALPHA_VERSION
+    if inventory != expected_inventory or len(sbom_components) != len(expected_inventory):
+        raise AlphaReleaseError("bundle SBOM inventory does not match Alpha 1")
+    verifier = signature_verifier or (
+        lambda signature, manifest, release_tag: _run_sigstore(signature, manifest, release_tag, sigstore_command)
+    )
+    verifier(signature_path, manifest_path, tag)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    check = commands.add_parser("check-source")
+    check.add_argument("--root", type=Path, default=Path.cwd())
+    generate = commands.add_parser("generate")
+    generate.add_argument("--root", type=Path, default=Path.cwd())
+    generate.add_argument("--dist", type=Path, required=True)
+    verify = commands.add_parser("verify")
+    verify.add_argument("--bundle", type=Path, required=True)
+    verify.add_argument("--tag", default=ALPHA_TAG)
+    verify.add_argument("--sigstore-command", default="sigstore")
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "check-source":
+        validate_source_registry(args.root.resolve())
+        return 0
+    if args.command == "generate":
+        dist = args.dist.resolve()
+        create_manifest(args.root.resolve(), dist)
+        create_sbom(dist)
+        return 0
+    if args.command == "verify":
+        verify_bundle(args.bundle.resolve(), tag=args.tag, sigstore_command=args.sigstore_command)
+        return 0
+    raise AssertionError(f"unexpected command {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_ALPHA_VERSION = re.compile(r"a\d+(?:[.+-]|$)", re.IGNORECASE)
 
 
 @dataclass(frozen=True, slots=True)
@@ -207,6 +209,7 @@ def validate_release(
     *,
     project: ReleaseProject = RELEASE_PROJECTS["root"],
     tag: str | None = None,
+    reject_alpha: bool = False,
 ) -> None:
     if identity.distribution != project.distribution:
         raise RuntimeError(f"expected project.name={project.distribution!r}, got {identity.distribution!r}")
@@ -214,6 +217,8 @@ def validate_release(
         expected_tag = f"{project.tag_prefix}{identity.version}"
         if tag != expected_tag:
             raise RuntimeError(f"expected release tag {expected_tag!r}, got {tag!r}")
+    if reject_alpha and _ALPHA_VERSION.search(identity.version):
+        raise RuntimeError("Alpha releases must use the signed GitHub bundle workflow, not PyPI")
 
 
 def _result(project: ReleaseProject, identity: ReleaseIdentity) -> dict[str, str]:
@@ -231,6 +236,7 @@ def main() -> int:
     parser.add_argument("--package", choices=tuple(RELEASE_PROJECTS))
     parser.add_argument("--tag")
     parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--reject-alpha", action="store_true")
     args = parser.parse_args()
 
     if args.package is not None:
@@ -240,7 +246,7 @@ def main() -> int:
     else:
         project = RELEASE_PROJECTS["root"]
     identity = read_release_identity(project.project_file)
-    validate_release(identity, project=project, tag=args.tag)
+    validate_release(identity, project=project, tag=args.tag, reject_alpha=args.reject_alpha)
     result = _result(project, identity)
 
     if args.github_output is not None:

--- a/scripts/run_alpha_bundle_installs.py
+++ b/scripts/run_alpha_bundle_installs.py
@@ -1,0 +1,139 @@
+"""Exercise every Alpha 1 lockstep wheel from a staged bundle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from scripts.alpha_release import ALPHA_VERSION, MANIFEST_NAME, AlphaReleaseError
+from scripts.run_isolated_install import _clean_environment
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True, slots=True)
+class InstallVerification:
+    name: str
+    distributions: tuple[str, ...]
+    verifier: str
+    arguments: tuple[str, ...] = ()
+
+
+VERIFICATIONS: tuple[InstallVerification, ...] = (
+    InstallVerification(
+        "kernel",
+        ("liteyukibot-v7",),
+        "scripts/verify_published_install.py",
+        ("--expected-version", ALPHA_VERSION),
+    ),
+    InstallVerification("cordis", ("liteyukibot-v7", "liteyukibot-v7-cordis"), "scripts/verify_cordis_install.py"),
+    InstallVerification(
+        "nonebot-bridge",
+        ("liteyukibot-v7", "liteyukibot-v7-runtime-nonebot"),
+        "scripts/verify_nonebot_runtime_install.py",
+        ("--expected-version", ALPHA_VERSION),
+    ),
+    InstallVerification(
+        "astrbot-bridge",
+        ("liteyukibot-v7", "liteyukibot-v7-runtime-astrbot"),
+        "scripts/verify_astrbot_runtime_install.py",
+        ("--expected-version", ALPHA_VERSION),
+    ),
+    InstallVerification(
+        "adapter-bridge",
+        ("liteyukibot-v7", "liteyukibot-v7-runtime-adapter"),
+        "scripts/verify_adapter_runtime_install.py",
+        ("--expected-version", ALPHA_VERSION),
+    ),
+    InstallVerification("webui", ("liteyukibot-v7-webui",), "scripts/verify_webui_install.py"),
+    InstallVerification("ipc-native", ("liteyukibot-v7-ipc-native",), "scripts/verify_ipc_native_install.py"),
+)
+
+
+def _manifest(bundle: Path) -> list[Mapping[str, object]]:
+    try:
+        document = json.loads((bundle / MANIFEST_NAME).read_bytes())
+    except (OSError, json.JSONDecodeError) as error:
+        raise AlphaReleaseError("cannot read Alpha bundle manifest") from error
+    artifacts = document.get("artifacts") if isinstance(document, dict) else None
+    if not isinstance(artifacts, list) or not all(isinstance(item, dict) for item in artifacts):
+        raise AlphaReleaseError("Alpha bundle manifest has invalid artifacts")
+    return [cast(Mapping[str, object], item) for item in artifacts]
+
+
+def _native_wheel(candidates: Sequence[Path]) -> Path:
+    if len(candidates) == 1:
+        return candidates[0]
+    if sys.platform == "win32":
+        markers = ("win_amd64", "win32")
+    elif sys.platform == "darwin":
+        markers = ("macosx",)
+    else:
+        markers = ("manylinux", "linux_")
+    matching = tuple(path for path in candidates if any(marker in path.name.lower() for marker in markers))
+    if len(matching) != 1:
+        raise AlphaReleaseError(f"bundle has no unique native wheel for {sys.platform}")
+    return matching[0]
+
+
+def wheels_for(bundle: Path, distribution: str) -> tuple[Path, ...]:
+    """Return the staged wheels suitable for one verifier on this platform."""
+
+    candidates: list[Path] = []
+    for record in _manifest(bundle):
+        if record.get("distribution") != distribution or record.get("kind") != "wheel":
+            continue
+        filename = record.get("filename")
+        if not isinstance(filename, str):
+            raise AlphaReleaseError("Alpha bundle artifact filename is invalid")
+        wheel = bundle / filename
+        if not wheel.is_file():
+            raise AlphaReleaseError(f"Alpha bundle wheel is missing: {filename}")
+        candidates.append(wheel)
+    if not candidates:
+        raise AlphaReleaseError(f"Alpha bundle is missing a wheel for {distribution}")
+    if distribution == "liteyukibot-v7-ipc-native":
+        return (_native_wheel(candidates),)
+    if len(candidates) != 1:
+        raise AlphaReleaseError(f"Alpha bundle has multiple wheels for {distribution}")
+    return tuple(candidates)
+
+
+def command_for(bundle: Path, verification: InstallVerification, uv: str) -> list[str]:
+    command = [uv, "run", "--no-project", "--python", "3.14"]
+    for distribution in verification.distributions:
+        for wheel in wheels_for(bundle, distribution):
+            command.extend(("--with", str(wheel.resolve())))
+    command.extend(("python", str((ROOT / verification.verifier).resolve()), *verification.arguments))
+    return command
+
+
+def run(bundle: Path) -> None:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv executable was not found")
+    environment = _clean_environment(os.environ)
+    with tempfile.TemporaryDirectory(prefix="liteyuki-alpha-bundle-") as directory:
+        for verification in VERIFICATIONS:
+            subprocess.run(command_for(bundle, verification, uv), cwd=directory, env=environment, check=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bundle", type=Path, required=True)
+    arguments = parser.parse_args()
+    run(arguments.bundle.resolve())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_alpha_release.py
+++ b/tests/test_alpha_release.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+from scripts.alpha_release import (
+    ALPHA_TAG,
+    ALPHA_VERSION,
+    LOCKSTEP_COMPONENTS,
+    MANIFEST_NAME,
+    SIGNATURE_NAME,
+    AlphaReleaseError,
+    create_manifest,
+    create_sbom,
+    validate_source_registry,
+    verify_bundle,
+)
+from scripts.run_alpha_bundle_installs import VERIFICATIONS, command_for, wheels_for
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _metadata(distribution: str) -> bytes:
+    return f"Metadata-Version: 2.3\nName: {distribution}\nVersion: {ALPHA_VERSION}\n".encode()
+
+
+def _wheel(dist: Path, distribution: str) -> None:
+    filename = f"{distribution.replace('-', '_')}-{ALPHA_VERSION}-py3-none-any.whl"
+    with zipfile.ZipFile(dist / filename, "w") as archive:
+        archive.writestr(
+            f"{distribution.replace('-', '_')}-{ALPHA_VERSION}.dist-info/METADATA", _metadata(distribution)
+        )
+
+
+def _sdist(dist: Path, distribution: str) -> None:
+    filename = dist / f"{distribution}-{ALPHA_VERSION}.tar.gz"
+    payload = _metadata(distribution)
+    with tarfile.open(filename, "w:gz") as archive:
+        info = tarfile.TarInfo(f"{distribution}-{ALPHA_VERSION}/PKG-INFO")
+        info.size = len(payload)
+        archive.addfile(info, io.BytesIO(payload))
+
+
+def _bundle(tmp_path: Path) -> Path:
+    dist = tmp_path / "bundle"
+    dist.mkdir(parents=True)
+    for component in LOCKSTEP_COMPONENTS:
+        _wheel(dist, component.distribution)
+        if component.requires_sdist:
+            _sdist(dist, component.distribution)
+    create_manifest(ROOT, dist)
+    create_sbom(dist)
+    (dist / SIGNATURE_NAME).write_text("{}", encoding="utf-8")
+    return dist
+
+
+def test_source_registry_matches_the_lockstep_alpha_one_metadata() -> None:
+    validate_source_registry(ROOT)
+
+
+def test_bundle_manifest_is_canonical_and_verifies_artifact_metadata(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    manifest = json.loads((bundle / MANIFEST_NAME).read_bytes())
+
+    assert manifest["release"] == {"tag": ALPHA_TAG, "version": ALPHA_VERSION}
+    assert manifest["baseline"] == {"broker": 6, "configuration": 5, "lyip": 2, "runtime_ipc": 6}
+    assert manifest["components"][-1] == {
+        "distribution": "liteyukibot-v7-devcli",
+        "id": "devcli",
+        "reserved": True,
+        "version": ALPHA_VERSION,
+    }
+    assert b"\n" not in (bundle / MANIFEST_NAME).read_bytes()
+
+    calls: list[tuple[Path, Path, str]] = []
+    verify_bundle(
+        bundle, signature_verifier=lambda signature, manifest_path, tag: calls.append((signature, manifest_path, tag))
+    )
+
+    assert calls == [(bundle / SIGNATURE_NAME, bundle / MANIFEST_NAME, ALPHA_TAG)]
+
+
+def test_bundle_verifier_rejects_tampered_artifacts_and_wrong_tag(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    artifact = next(bundle.glob("*.whl"))
+    artifact.write_bytes(b"tampered")
+
+    with pytest.raises(AlphaReleaseError, match="integrity"):
+        verify_bundle(bundle, signature_verifier=lambda _signature, _manifest, _tag: None)
+    with pytest.raises(AlphaReleaseError, match="tag"):
+        verify_bundle(bundle, tag="v7.0.0a2", signature_verifier=lambda _signature, _manifest, _tag: None)
+
+
+def test_bundle_verifier_requires_signature_and_canonical_manifest(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    (bundle / SIGNATURE_NAME).unlink()
+    with pytest.raises(AlphaReleaseError, match="Sigstore"):
+        verify_bundle(bundle, signature_verifier=lambda _signature, _manifest, _tag: None)
+
+    (bundle / SIGNATURE_NAME).write_text("{}", encoding="utf-8")
+    (bundle / MANIFEST_NAME).write_text("{}\n", encoding="utf-8")
+    with pytest.raises(AlphaReleaseError, match="canonical"):
+        verify_bundle(bundle, signature_verifier=lambda _signature, _manifest, _tag: None)
+
+
+def test_bundle_verifier_rejects_component_drift_and_path_escape(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    manifest_path = bundle / MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_bytes())
+    manifest["components"][-1]["reserved"] = False
+    manifest_path.write_bytes(json.dumps(manifest, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    with pytest.raises(AlphaReleaseError, match="reserved"):
+        verify_bundle(bundle, signature_verifier=lambda _signature, _manifest, _tag: None)
+
+    bundle = _bundle(tmp_path / "escaped")
+    manifest_path = bundle / MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_bytes())
+    manifest["artifacts"][0]["filename"] = "../outside.whl"
+    manifest_path.write_bytes(json.dumps(manifest, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    with pytest.raises(AlphaReleaseError, match="filename"):
+        verify_bundle(bundle, signature_verifier=lambda _signature, _manifest, _tag: None)
+
+
+def test_bundle_install_commands_use_only_staged_wheels(tmp_path: Path) -> None:
+    bundle = _bundle(tmp_path)
+    command = command_for(bundle, VERIFICATIONS[1], "uv")
+
+    assert command[:4] == ["uv", "run", "--no-project", "--python"]
+    assert str(bundle / "liteyukibot_v7-7.0.0a1-py3-none-any.whl") in command
+    assert str(bundle / "liteyukibot_v7_cordis-7.0.0a1-py3-none-any.whl") in command
+    assert wheels_for(bundle, "liteyukibot-v7-webui") == (bundle / "liteyukibot_v7_webui-7.0.0a1-py3-none-any.whl",)

--- a/tests/test_release_v7.py
+++ b/tests/test_release_v7.py
@@ -26,24 +26,24 @@ def test_kernel_import_namespace_uses_distribution_version() -> None:
 @pytest.mark.parametrize(
     ("name", "tag"),
     [
-        ("root", "v7.0.0b2"),
+        ("root", "v7.0.0a1"),
         ("permissions", "permissions-v0.2.0a2"),
         ("commands", "commands-v0.2.0a2"),
         ("resources", "resources-v0.1.0a2"),
         ("functions", "functions-v0.1.0a2"),
         ("profile", "profile-v0.1.0a2"),
         ("essentials", "essentials-v0.2.0a3"),
-        ("runtime-nonebot", "runtime-nonebot-v0.1.0a1"),
-        ("runtime-adapter", "runtime-adapter-v0.1.0a2"),
+        ("runtime-nonebot", "runtime-nonebot-v7.0.0a1"),
+        ("runtime-adapter", "runtime-adapter-v7.0.0a1"),
         ("adapter-onebot", "adapter-onebot-v0.1.0a1"),
         ("adapter-satori", "adapter-satori-v0.1.0a2"),
         ("runtime-v6", "runtime-v6-v0.1.0a2"),
         ("agent-resolver", "agent-resolver-v0.1.0a1"),
         ("agent", "agent-v0.1.0a9"),
-        ("runtime-astrbot", "runtime-astrbot-v0.1.0a7"),
+        ("runtime-astrbot", "runtime-astrbot-v7.0.0a1"),
         ("runtime-mofox", "runtime-mofox-v0.1.0a8"),
-        ("webui", "webui-v0.1.0b4"),
-        ("ipc-native", "ipc-native-v0.1.0b3"),
+        ("webui", "webui-v7.0.0a1"),
+        ("ipc-native", "ipc-native-v7.0.0a1"),
     ],
 )
 def test_current_release_identities_accept_exact_tags(name: str, tag: str) -> None:
@@ -76,6 +76,16 @@ def test_release_identity_rejects_mismatches(
 ) -> None:
     with pytest.raises(RuntimeError, match=message):
         validate_release(identity, project=RELEASE_PROJECTS[project_name], tag=tag)
+
+
+def test_release_identity_rejects_alpha_from_pypi_workflows() -> None:
+    with pytest.raises(RuntimeError, match="signed GitHub bundle"):
+        validate_release(
+            ReleaseIdentity("liteyukibot-v7", "7.0.0a1"),
+            project=RELEASE_PROJECTS["root"],
+            tag="v7.0.0a1",
+            reject_alpha=True,
+        )
 
 
 @pytest.mark.parametrize("tag", ["v6.9.0", "plugin-v0.1.0", ""])

--- a/uv.lock
+++ b/uv.lock
@@ -697,12 +697,34 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -1091,6 +1113,18 @@ wheels = [
 ]
 
 [[package]]
+name = "id"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/04/c2156091427636080787aac190019dc64096e56a23b7364d3c1764ee3a06/id-1.6.1.tar.gz", hash = "sha256:d0732d624fb46fd4e7bc4e5152f00214450953b9e772c182c1c22964def1a069", size = 18088, upload-time = "2026-02-04T16:19:41.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/77/de194443bf38daed9452139e960c632b0ef9f9a5dd9ce605fdf18ca9f1b1/id-1.6.1-py3-none-any.whl", hash = "sha256:f5ec41ed2629a508f5d0988eda142e190c9c6da971100612c4de9ad9f9b237ca", size = 14689, upload-time = "2026-02-04T16:19:40.051Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -1306,7 +1340,7 @@ wheels = [
 
 [[package]]
 name = "liteyukibot-v7"
-version = "7.0.0b2"
+version = "7.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -1349,6 +1383,7 @@ dev = [
 release = [
     { name = "cyclonedx-bom" },
     { name = "license-expression" },
+    { name = "sigstore" },
 ]
 
 [package.metadata]
@@ -1386,6 +1421,7 @@ dev = [
 release = [
     { name = "cyclonedx-bom", specifier = ">=7.3.1" },
     { name = "license-expression", specifier = ">=30.4.4" },
+    { name = "sigstore", specifier = ">=4,<5" },
 ]
 
 [[package]]
@@ -1461,7 +1497,7 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-cordis"
-version = "0.1.0b6"
+version = "7.0.0a1"
 source = { editable = "packages/cordis" }
 dependencies = [
     { name = "liteyukibot-v7" },
@@ -1498,7 +1534,7 @@ requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-ipc-native"
-version = "0.1.0b3"
+version = "7.0.0a1"
 source = { editable = "packages/ipc-native" }
 
 [[package]]
@@ -1546,7 +1582,7 @@ requires-dist = [
 
 [[package]]
 name = "liteyukibot-v7-runtime-adapter"
-version = "0.1.0a2"
+version = "7.0.0a1"
 source = { editable = "packages/runtime-adapter" }
 dependencies = [
     { name = "liteyukibot-v7" },
@@ -1557,7 +1593,7 @@ requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-runtime-astrbot"
-version = "0.1.0a7"
+version = "7.0.0a1"
 source = { editable = "packages/runtime-astrbot" }
 dependencies = [
     { name = "astrbot" },
@@ -1583,7 +1619,7 @@ requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-runtime-nonebot"
-version = "0.1.0a1"
+version = "7.0.0a1"
 source = { editable = "packages/runtime-nonebot" }
 dependencies = [
     { name = "liteyukibot-v7" },
@@ -1620,7 +1656,7 @@ requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-webui"
-version = "0.1.0b4"
+version = "7.0.0a1"
 source = { editable = "packages/webui" }
 
 [package.optional-dependencies]
@@ -2260,6 +2296,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2441,6 +2486,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
 ]
 
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
 [[package]]
 name = "pydantic-core"
 version = "2.46.4"
@@ -2535,6 +2585,18 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/e8/7325d258199b159eb2c03fe32107533e2832e70e63f4fb88a6aa00023201/pyopenssl-26.4.0.tar.gz", hash = "sha256:28dfcce0162b9211413e26dfbfdf1d24317fbeba18fc93c12400a1856b2a0bc7", size = 182046, upload-time = "2026-08-01T19:50:50.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/ad/2cf6d3fa2fae5c79e1ed9960c0d42badd0f94d81dd12b50604cdc839e648/pyopenssl-26.4.0-py3-none-any.whl", hash = "sha256:f0eb0cb2d581d3ad2b9c489468485e7f2ab6727d08401bcf9d824c3caddf3c1c", size = 56026, upload-time = "2026-08-01T19:50:48.94Z" },
 ]
 
 [[package]]
@@ -2889,6 +2951,29 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3161-client"
+version = "1.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a6/cf05ce2b73da1e7c876c8992035bcbede938483f16ad04f0bda34c39b299/rfc3161_client-1.0.8.tar.gz", hash = "sha256:4bda5a2bc6947c16b6f8df90ff0e99cb333d78ab1465517f637d313d75703651", size = 107402, upload-time = "2026-07-29T13:54:05.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/0a/a06fa0af9676fa8ae6962def859cb1966fb1caf0be507d5abcc22994ca13/rfc3161_client-1.0.8-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3951db9573e4f6b4a1a62ad4f0074683610714625bf50c010739ffa568f23beb", size = 2108437, upload-time = "2026-07-29T13:53:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/38/59/62123806432e3fa42c06e74ee66b0dbdce66fa5cc0582d478de4ef6934e3/rfc3161_client-1.0.8-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4bdb12618f98ee634d3625208f4f1c3cdde2306a8187a7416bfa47d45cad3dba", size = 2437251, upload-time = "2026-07-29T13:53:46.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d6/64bf6b0af601e3a532d1800180058088a086bca6bd8119acd576dba3c8b7/rfc3161_client-1.0.8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29cebab8dadec88b85eac43505db186749e23ddf1c7699ffa08f7cbdc86a52fe", size = 2648056, upload-time = "2026-07-29T13:53:48.384Z" },
+    { url = "https://files.pythonhosted.org/packages/59/66/b739e4c8778e8221eb58e09de47543fa07da039204ef2c87d3aa6e3ec4d4/rfc3161_client-1.0.8-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38c5c278c7d4605e9c166a332c13b286475730b750109235b547f7d1b21c5c6f", size = 2047923, upload-time = "2026-07-29T13:53:50.08Z" },
+    { url = "https://files.pythonhosted.org/packages/03/2b/fdbcf18d362eb7e149d4a6552ccb3e2c8c40d058cb8a44b2f305d6f16a2d/rfc3161_client-1.0.8-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9826227dc04e1a86f2598f9c1829f078afc35f558987df77578ea1508d1460a1", size = 2416368, upload-time = "2026-07-29T13:53:51.667Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f5/6e0775d3219d791cac11e30b5a3071d62a2a7fe21bbfffa801903a15ab12/rfc3161_client-1.0.8-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55cd9366f20dcea8dc65f93b08d12607c071015d2f5b5d24129128f04643a77d", size = 2410483, upload-time = "2026-07-29T13:53:53.327Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f1/99638e03afae594418f9e9c27aeb189fe6dabc3d853cd48b36a1cf61e0a4/rfc3161_client-1.0.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e95ca8a64fddfdd639e09e48bab4722f31b26ce099067ad2bb8e85f88fcc707b", size = 2993036, upload-time = "2026-07-29T13:53:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a6/d5f7964d180b6ecf659d989d3474edaa7ef721a0038562b226ec89fc8811/rfc3161_client-1.0.8-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:7f8b82c97c1935a09376591b45bd81aa57a4232f4d446eee3a44c025ef7c4d5a", size = 2353705, upload-time = "2026-07-29T13:53:57.184Z" },
+    { url = "https://files.pythonhosted.org/packages/23/fa/ad5e2a354d01d2f1cedaa5ea24548f7cf71cef427715bf3104f3f81c461d/rfc3161_client-1.0.8-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:51adc82dbd04d2b88e3a17f524f0e57d0270d7276887a5800c81833f79fb4f4a", size = 2564143, upload-time = "2026-07-29T13:53:59.098Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/49/141ecbee41a7cef5d819ad692305d99775af3ecb5b145d323dfd8458f32f/rfc3161_client-1.0.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d3c25311c67a7daeef990fb5b94eaed706135c6a6fd98c6e382bbc857faa4214", size = 2639490, upload-time = "2026-07-29T13:54:00.832Z" },
+    { url = "https://files.pythonhosted.org/packages/65/53/0de416266baddfac030b80602a8034e0133673deb18d4934623f78087d44/rfc3161_client-1.0.8-cp39-abi3-win32.whl", hash = "sha256:9d382372e7fdfde592584f985fb1063d1506ae0573df45fcb2b41e2ed82e3431", size = 1991195, upload-time = "2026-07-29T13:54:02.859Z" },
+    { url = "https://files.pythonhosted.org/packages/76/57/da3c2f7784d1e7b7c48f8ce2e391314f6e50a14f5eb1a9d9460bb7b4fc8e/rfc3161_client-1.0.8-cp39-abi3-win_amd64.whl", hash = "sha256:5c1889d6bae269dc0f1e418f82e554b413066b5f8dd864f9367cf1ffb3d0a312", size = 2426065, upload-time = "2026-07-29T13:54:04.48Z" },
+]
+
+[[package]]
 name = "rfc3339-validator"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2919,6 +3004,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+]
+
+[[package]]
+name = "rfc8785"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da", size = 14321, upload-time = "2024-09-27T16:33:31.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48", size = 9240, upload-time = "2024-09-27T16:33:29.683Z" },
 ]
 
 [[package]]
@@ -3026,6 +3120,15 @@ wheels = [
 ]
 
 [[package]]
+name = "securesystemslib"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/11/9623c61604f9b8955248d43fc6a75658bb687c0d3ab65b032b2e43613bd5/securesystemslib-1.4.0.tar.gz", hash = "sha256:faea87be0f9c4b4277a5fa1b54bf9bfd807be9a94ab11be6c557dc8b75c43285", size = 934332, upload-time = "2026-05-27T08:01:53.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/29/3ff76b9d90ce4482dc8e8d216dc3a6b6d0c934c52f68b0738e2c99ca685f/securesystemslib-1.4.0-py3-none-any.whl", hash = "sha256:a0743a3d978cf26e98a70a57e3fbd5a18e0a74c20cabe615f6a55b02ef0272b3", size = 871457, upload-time = "2026-05-27T08:01:51.093Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3058,6 +3161,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0c/72/9aebc032e5a385020b11c73bc5ab9945c30ab0c4e6a90a22fb8f84c5b40a/shipyard_python_sdk-0.2.4.tar.gz", hash = "sha256:4c129a21d55ffc31698fc84b1082c91df122ab330481e17d7dda551076a800c2", size = 7223, upload-time = "2026-01-13T13:00:51.328Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/07/a0a81d4861107739b0bc188395aab449fcd20d24711348cbeac4234e6274/shipyard_python_sdk-0.2.4-py3-none-any.whl", hash = "sha256:a6324846ba5125ff0e778111adc18ac500294bb5bfa0c770a0f7c60c44cba839", size = 9211, upload-time = "2026-01-13T13:00:52.231Z" },
+]
+
+[[package]]
+name = "sigstore"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "id" },
+    { name = "platformdirs" },
+    { name = "pyasn1" },
+    { name = "pydantic" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "requests" },
+    { name = "rfc3161-client" },
+    { name = "rfc8785" },
+    { name = "rich" },
+    { name = "sigstore-models" },
+    { name = "sigstore-rekor-types" },
+    { name = "tuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/e0/279419065e2d7102413605b3456122adbbccbc42e010b499c7b882fc01f8/sigstore-4.5.0.tar.gz", hash = "sha256:020d3e07f622b2916bf453e66ff6ff0711e1fdc5ab69e8bd8902f71d9fcb316f", size = 90969, upload-time = "2026-07-28T07:34:01.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7f/51dc313c06dd3ec6c5b308e334492cfdea0b02c9184a0da7b2db8c2a30a1/sigstore-4.5.0-py3-none-any.whl", hash = "sha256:f045b207f2e12605cf775ec38e89c5eda625d71ffa7830477db65e47ec2bc8b2", size = 111724, upload-time = "2026-07-28T07:34:00.211Z" },
+]
+
+[[package]]
+name = "sigstore-models"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ed/5c0ff809f90b19f4e971e17c1ed11f4df60082c6010b32a82054087e91e0/sigstore_models-0.0.6.tar.gz", hash = "sha256:c766c09470c2a7e8a4a333c893f07e2001c56a3ff1757b1a246119f53169a849", size = 7037, upload-time = "2025-11-26T19:18:12.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/dc/7a19864a7bc9f43121ab459e12768ab0080590e3e1b60a29b2f2eb01fb85/sigstore_models-0.0.6-py3-none-any.whl", hash = "sha256:5201a68f4d7d0f8bec1e2f4378eb646b084c52609a4e31db8c385095fff68b2e", size = 13213, upload-time = "2025-11-26T19:18:11.365Z" },
+]
+
+[[package]]
+name = "sigstore-rekor-types"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", extra = ["email"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/54/102e772445c5e849b826fbdcd44eb9ad7b3d10fda17b08964658ec7027dc/sigstore_rekor_types-0.0.18.tar.gz", hash = "sha256:19aef25433218ebf9975a1e8b523cc84aaf3cd395ad39a30523b083ea7917ec5", size = 15687, upload-time = "2024-11-22T13:59:54.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/7c/f0b4e19fd424df4cc964f5d454e1d814fd2dc3b386342e6040441024318f/sigstore_rekor_types-0.0.18-py3-none-any.whl", hash = "sha256:b62bf38c5b1a62bc0d7fe0ee51a0709e49311d137c7880c329882a8f4b2d1d78", size = 20610, upload-time = "2024-11-22T13:59:52.684Z" },
 ]
 
 [[package]]
@@ -3288,6 +3441,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "tuf"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "securesystemslib" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/40/25ceaf7f02e18b0d99150d94e200929351a542479c54abb7b92e1fd74b10/tuf-7.0.0.tar.gz", hash = "sha256:9d2e6723538e0d5a3e482b6de805fcfe64481448d5853039ba6b06ba541efd7f", size = 272032, upload-time = "2026-05-18T08:28:57.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/c7/301f699ad9427bb0e06935ed56850dd26eecb2b3e8e07b80311875eae676/tuf-7.0.0-py3-none-any.whl", hash = "sha256:572bdbdc9ff4a82278a0d4773e6100863b9b33023f27575e84ca65b486dd0d79", size = 55277, upload-time = "2026-05-18T08:28:56.123Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add the signed no-PyPI Alpha 1 bundle workflow and external verifier
- align the seven lockstep components at 7.0.0a1 and retain independent package versions
- freeze the configuration v5 and Alpha release documentation

## Validation
- uv run pytest
- uv run ruff check src tests scripts examples packages
- uv run mypy
- uv build --all-packages --out-dir dist/workspace --clear
- staged seven-component bundle install verification

## Release impact
Alpha tags publish only the signed GitHub Release bundle. Historical PyPI workflows reject Alpha versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a signed Alpha bundle release process with cross-platform artifacts, integrity checks, SBOMs, and staged installation verification.
  * Introduced Configuration v5 with startup validation and upgrade templates.
* **Bug Fixes**
  * Standard publishing now blocks Alpha versions, preventing unintended release promotion.
* **Documentation**
  * Updated release status, architecture guidance, release procedures, and specifications for the 7.0.0a1 Alpha baseline.
* **Tests**
  * Added coverage for bundle validation, signatures, tamper detection, component consistency, and staged installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->