### PR TITLE
feat(runtime): add v7 runtime API contract and broker routing

### DIFF
--- a/docs/roadmap/v7-alpha-8-devcli-updates.md
+++ b/docs/roadmap/v7-alpha-8-devcli-updates.md
@@ -1,10 +1,14 @@
-# v7 Alpha 8: DevCLI and Atomic Instance Updates
+# v7 Alpha 8b: DevCLI and Atomic Instance Updates
 
 > **Planned implementation contract.** This document does not authorize a
 > release updater or claim atomic process orchestration is implemented.
 
-Alpha 8 introduces a separate Python development scaffold and the first
+Alpha 8b is the second half of the ecosystem milestone. Alpha 8a first
+validates third-party Native/Cordis calls into a versioned runtime bridge API;
+this document retains the separate Python development scaffold and the first
 verified whole-instance update transaction.
+
+The combined Alpha 8 release is gated on both Alpha 8a and Alpha 8b.
 
 ## DevCLI
 

--- a/docs/roadmap/v7-alpha-roadmap.md
+++ b/docs/roadmap/v7-alpha-roadmap.md
@@ -131,19 +131,24 @@ behavior is consistent across Native and Cordis hosts; library/decorator
 boundaries are enforced; unsupported control flow has stable location-aware
 diagnostics rather than silent interpretation.
 
-### Alpha 8: Developer and update tooling
+### Alpha 8: Third-party ecosystem and developer tooling
 
-**Goal:** make the planned ecosystem usable and recoverable by developers and
-operators.
+**Goal:** make the planned ecosystem usable by third-party developers and
+recoverable by operators.
 
-**Work:** implement the [Alpha 8 DevCLI and updates]
-(v7-alpha-8-devcli-updates.md): ship the separate Python scaffold and npm
+**Work:** deliver two gates. Alpha 8a implements the [Runtime API v1]
+(../specs/runtime-api-v1.md) contract: Broker v7 API catalog/RPC, Native and
+Cordis runtime requirements and decorators, an independent AstrBot API SDK,
+and the AstrBot feasibility proof. Alpha 8b implements the [DevCLI and
+updates](v7-alpha-8-devcli-updates.md): the separate Python scaffold and npm
 launcher, verified GitHub/local bundle staging, daemon-managed full-instance
 atomic updates, and read-only LYF editor integration.
 
-**Exit criteria:** signature, digest, and lock failures are rejected; drain
-timeout, rollback, restart, and interrupted-update recovery are tested; no
-managed bridge or WebUI path can observe a half-updated instance.
+**Exit criteria:** Alpha 8a passes runtime API catalog, lease, schema,
+permission, disconnect, Native/Cordis parity, and AstrBot proof tests. Alpha
+8b rejects signature, digest, and lock failures; tests drain timeout, rollback,
+restart, and interrupted-update recovery; and no managed bridge or WebUI path
+can observe a half-updated instance. Both gates pass before `v7.0.0a8`.
 
 If Alpha 8 is not sufficient, continue with `7.0.0aN` releases. Do not enter
 Beta or RC solely because the numbered list is complete.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,7 +12,9 @@ configuration, or plugin contract changes only with its owning specification
 and tests in the same pull request.
 
 - [Core Event and Action v1](core-event-action-v1.md)
-- [Broker Peer IPC v6](runtime-ipc-v6.md)
+- [Broker Peer IPC v7](runtime-ipc-v7.md)
+- [Broker Peer IPC v6 (baseline)](runtime-ipc-v6.md)
+- [Runtime API v1](runtime-api-v1.md)
 - [Runtime LYIP v2](runtime-lyip-v2.md)
 - [Runtime IPC v5 (historical)](runtime-ipc-v5.md)
 - [Runtime LYIP v1 (historical)](runtime-lyip-v1.md)

--- a/docs/specs/runtime-api-v1.md
+++ b/docs/specs/runtime-api-v1.md
@@ -1,0 +1,55 @@
+# Runtime API v1
+
+## Status
+
+Applies to the Alpha8a Broker protocol v7 and the Native/Cordis Extension API
+v2 hosts. This is a first feasibility contract, not a promise to mirror any
+framework's complete public SDK.
+
+## Boundary
+
+Native and Cordis extensions may declare a runtime kind, optional bridge ID,
+API namespace, operation set, SemVer range, and optionality in their manifest.
+The `@runtime` decorator binds one namespace to an explicit keyword-only
+proxy parameter. The host validates the decorator against the manifest before
+registration.
+
+Runtime API calls are allowed only while an event or Tool invocation owns an
+active Broker delivery. The call carries the original event authorization,
+extension identity, current delivery lease, API operation, and JSON-safe
+arguments. Setup, start, and background tasks have no runtime API context.
+
+## Catalog and wire contract
+
+Each bridge registers immutable runtime API declarations containing the runtime
+kind, namespace, operation, API version, input schema, output schema, and
+required capability. The Broker routes `runtime.api.invoke` and
+`runtime.api.result` independently from `bridge.control.invoke`; it validates
+owner uniqueness, active leases, canonical request replay, result replay,
+expiry, and owner disconnect.
+
+The provider host validates the declared input and output schemas; the kernel
+validates JSON safety, provenance, permissions, and the active delivery lease.
+Provider exceptions never cross the wire; results use stable error codes and
+bounded JSON error details.
+
+## Alpha8a AstrBot proof
+
+The framework-neutral AstrBot SDK owns typed DTOs and proxy classes without
+depending on AstrBot. The bridge host owns AstrBot imports and maps the proof
+facade to the real `AstrMessageEvent`.
+
+The proof catalog contains `event.snapshot` for safe event metadata and
+message component projection, plus `event.send` for native-chain sending.
+The existing protocol-neutral `message.send` Action remains available as a
+fallback. Streaming, LLM calls, group objects, native object returns, and the
+remaining public methods are deferred to Alpha9.
+
+## Compatibility and security
+
+Runtime API versions use caret SemVer ranges such as `^1.0`; major versions
+are incompatible and minor versions are backward compatible. Each operation
+gets a capability named `runtime.<kind>.<namespace>.<operation>`. Native
+activation remains limited by the configured Permission v2 ceiling; Cordis
+keeps its existing full-by-default/downscoped policy. Missing optional APIs
+produce an unavailable proxy, never an empty successful result.

--- a/docs/specs/runtime-ipc-v7.md
+++ b/docs/specs/runtime-ipc-v7.md
@@ -1,0 +1,40 @@
+# Broker Peer IPC v7
+
+- Specification version: `7`
+- Applies to: the Alpha8 Broker v7 control/business catalogs and bridge
+  registration contract.
+- Compatibility: hard cut from the v6 broker catalog; v6 peers are rejected.
+
+## Baseline
+
+The registration, LYIP lane, event delivery, action, Tool, control, lease,
+replay, and retention rules are the v6 baseline described in
+[`runtime-ipc-v6.md`](runtime-ipc-v6.md). Alpha8 changes the broker wire
+version and adds the runtime API catalog without reusing the v6 control
+commands.
+
+## Runtime API Catalog
+
+`BridgeManifest.runtime_apis` contains immutable declarations with
+`runtime_kind`, namespace, operation, API version, JSON input/output schemas,
+and per-operation capabilities. A configured external bridge may provide its
+catalog dynamically at registration, but every declaration must use the
+configured bridge kind and duplicate `(runtime_kind, namespace.operation)`
+entries are rejected.
+
+Runtime API requests use `runtime.api.invoke` and results use
+`runtime.api.result`. Requests carry the source event ID, caller extension ID,
+API version range, authorization context, arguments, and the active delivery
+lease. The broker validates event provenance, active lease ownership, unique
+provider ownership, canonical correlation replay, result replay, expiry, and
+provider session ownership.
+
+Providers validate declared input and output schemas. Provider exceptions are
+converted to stable error codes and do not cross the wire. Runtime API calls
+cannot be initiated without an active delivery lease.
+
+## Versioning
+
+Alpha8 accepts exact versions and caret ranges such as `^1.0`. A caret range
+matches the same major version with an offered minor version at or above the
+requested minor version. Major versions are incompatible.

--- a/src/liteyukibot/__init__.py
+++ b/src/liteyukibot/__init__.py
@@ -55,6 +55,22 @@ from .plugins import (
     WebUiSurfaceManifest,
 )
 from .resource_packs import RESOURCE_CATALOG_SERVICE, ResourceCatalog, ResourcePackDeclaration
+from .runtime_api import (
+    RuntimeApiBackend,
+    RuntimeApiError,
+    RuntimeApiProxy,
+    RuntimeBinding,
+    RuntimeCallContext,
+    RuntimeNamespaceProxy,
+    RuntimeRequirement,
+    RuntimeUnavailable,
+    create_runtime_proxy,
+    invoke_with_runtime,
+    runtime,
+    runtime_bindings,
+    runtime_handler,
+    validate_runtime_bindings,
+)
 from .services import ServiceKey, ServiceRegistry, ServiceRequirement
 from .status import KERNEL_STATUS_SERVICE, KernelStatusProvider, KernelStatusSnapshot
 
@@ -119,6 +135,20 @@ __all__ = [
     "RESOURCE_CATALOG_SERVICE",
     "ResourceCatalog",
     "ResourcePackDeclaration",
+    "RuntimeApiBackend",
+    "RuntimeApiError",
+    "RuntimeApiProxy",
+    "RuntimeBinding",
+    "RuntimeCallContext",
+    "RuntimeNamespaceProxy",
+    "RuntimeRequirement",
+    "RuntimeUnavailable",
+    "create_runtime_proxy",
+    "invoke_with_runtime",
+    "runtime",
+    "runtime_bindings",
+    "runtime_handler",
+    "validate_runtime_bindings",
     "Translator",
     "WorkerOperationBridge",
     "__version__",

--- a/src/liteyukibot/broker/__init__.py
+++ b/src/liteyukibot/broker/__init__.py
@@ -1,6 +1,6 @@
 """Broker-side bridge registration primitives.
 
-This is the v6 broker migration entry point. It is intentionally not
+This is the v7 broker migration entry point. It is intentionally not
 interoperable with the legacy runtime child protocol.
 """
 
@@ -21,6 +21,8 @@ from .business import (
     BROKER_EVENT_COMPLETED_TYPE_ID,
     BROKER_EVENT_INGRESS_TYPE_ID,
     BROKER_EVENT_MESSAGE_TYPE_ID,
+    BROKER_RUNTIME_API_INVOKE_TYPE_ID,
+    BROKER_RUNTIME_API_RESULT_TYPE_ID,
     BROKER_TOOL_INVOKE_TYPE_ID,
     BROKER_TOOL_RESULT_TYPE_ID,
     BrokerBusinessWireError,
@@ -28,7 +30,7 @@ from .business import (
     encode_business_message,
 )
 from .diagnostics import BrokerDiagnosticsClient, BrokerDiagnosticsError
-from .host import ActionOutcome, BrokerBridgeRunner, BrokerDelivery, ControlOutcome, ToolOutcome
+from .host import ActionOutcome, BrokerBridgeRunner, BrokerDelivery, ControlOutcome, RuntimeApiOutcome, ToolOutcome
 from .kernel import KernelBridgeError, KernelBrokerPeer, configured_kernel_bridge
 from .peer import (
     BridgeClient,
@@ -51,6 +53,7 @@ from .protocol import (
     BridgeUnregistered,
     BrokerToolDeclaration,
     BrokerWireError,
+    RuntimeApiDeclaration,
     decode_broker_message,
     encode_broker_message,
 )
@@ -71,7 +74,10 @@ from .routing import (
     EventSnapshot,
     RoutedAction,
     RoutedControl,
+    RoutedRuntimeApi,
     RoutedTool,
+    RuntimeApiInvoke,
+    RuntimeApiResult,
     ToolInvoke,
     ToolResult,
 )
@@ -98,10 +104,13 @@ __all__ = [
     "BROKER_EVENT_MESSAGE_TYPE_ID",
     "BROKER_CONTROL_INVOKE_TYPE_ID",
     "BROKER_CONTROL_RESULT_TYPE_ID",
+    "BROKER_RUNTIME_API_INVOKE_TYPE_ID",
+    "BROKER_RUNTIME_API_RESULT_TYPE_ID",
     "ActionRequest",
     "ActionOutcome",
     "ToolOutcome",
     "ControlOutcome",
+    "RuntimeApiOutcome",
     "ActionResourceDeclaration",
     "AuthorizationContextWire",
     "ActionResult",
@@ -110,6 +119,7 @@ __all__ = [
     "BridgeControlInvoke",
     "BridgeControlResult",
     "BrokerToolDeclaration",
+    "RuntimeApiDeclaration",
     "BridgeAccess",
     "BridgeClient",
     "BrokerBridgeRunner",
@@ -149,7 +159,10 @@ __all__ = [
     "MessageSendPayload",
     "RoutedAction",
     "RoutedControl",
+    "RoutedRuntimeApi",
     "RoutedTool",
+    "RuntimeApiInvoke",
+    "RuntimeApiResult",
     "decode_broker_message",
     "decode_business_message",
     "encode_business_message",

--- a/src/liteyukibot/broker/business.py
+++ b/src/liteyukibot/broker/business.py
@@ -1,4 +1,4 @@
-"""Version 6 broker business-lane JSON catalog carried by LYIP frames."""
+"""Version 7 broker business-lane JSON catalog carried by LYIP frames."""
 
 from __future__ import annotations
 
@@ -16,6 +16,8 @@ from .routing import (
     EventCompleted,
     EventIngress,
     EventMessage,
+    RuntimeApiInvoke,
+    RuntimeApiResult,
     ToolInvoke,
     ToolResult,
 )
@@ -30,6 +32,8 @@ BROKER_TOOL_INVOKE_TYPE_ID: Final = 616
 BROKER_TOOL_RESULT_TYPE_ID: Final = 617
 BROKER_CONTROL_INVOKE_TYPE_ID: Final = 618
 BROKER_CONTROL_RESULT_TYPE_ID: Final = 619
+BROKER_RUNTIME_API_INVOKE_TYPE_ID: Final = 620
+BROKER_RUNTIME_API_RESULT_TYPE_ID: Final = 621
 
 
 class BrokerBusinessWireError(LyipError):
@@ -46,7 +50,9 @@ type BrokerBusinessMessage = Annotated[
     | ToolInvoke
     | ToolResult
     | BridgeControlInvoke
-    | BridgeControlResult,
+    | BridgeControlResult
+    | RuntimeApiInvoke
+    | RuntimeApiResult,
     Field(discriminator="type"),
 ]
 BROKER_BUSINESS_ADAPTER: Final[TypeAdapter[BrokerBusinessMessage]] = TypeAdapter(BrokerBusinessMessage)
@@ -62,6 +68,8 @@ _TYPE_IDS: Final[dict[type[object], int]] = {
     ToolResult: BROKER_TOOL_RESULT_TYPE_ID,
     BridgeControlInvoke: BROKER_CONTROL_INVOKE_TYPE_ID,
     BridgeControlResult: BROKER_CONTROL_RESULT_TYPE_ID,
+    RuntimeApiInvoke: BROKER_RUNTIME_API_INVOKE_TYPE_ID,
+    RuntimeApiResult: BROKER_RUNTIME_API_RESULT_TYPE_ID,
 }
 _MESSAGE_TYPES: Final[dict[int, type[object]]] = {type_id: model for model, type_id in _TYPE_IDS.items()}
 
@@ -74,7 +82,7 @@ def encode_business_message(
     sequence: int,
     lease_id: str,
 ) -> LyipFrame:
-    """Encode one v6 business message without transmitting a clock deadline."""
+    """Encode one v7 business message without transmitting a clock deadline."""
 
     return LyipFrame(
         protocol=1,
@@ -89,16 +97,16 @@ def encode_business_message(
 
 
 def decode_business_message(frame: LyipFrame) -> BrokerBusinessMessage:
-    """Decode exactly one known v6 business catalog message."""
+    """Decode exactly one known v7 business catalog message."""
 
     if frame.lane is not LyipLane.BUSINESS:
         raise BrokerBusinessWireError("broker business message arrived on the wrong LYIP lane")
     if frame.type_id not in _MESSAGE_TYPES:
-        raise BrokerBusinessWireError(f"unknown broker business v6 type ID: {frame.type_id}")
+        raise BrokerBusinessWireError(f"unknown broker business v7 type ID: {frame.type_id}")
     try:
         message = BROKER_BUSINESS_ADAPTER.validate_json(frame.payload)
     except ValueError as error:
-        raise BrokerBusinessWireError("broker business v6 payload is invalid") from error
+        raise BrokerBusinessWireError("broker business v7 payload is invalid") from error
     if _TYPE_IDS[type(message)] != frame.type_id:
-        raise BrokerBusinessWireError("broker business v6 type ID does not match payload type")
+        raise BrokerBusinessWireError("broker business v7 type ID does not match payload type")
     return message

--- a/src/liteyukibot/broker/host.py
+++ b/src/liteyukibot/broker/host.py
@@ -7,9 +7,11 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from jsonschema import Draft202012Validator, ValidationError
+
 from ..events.models import JsonValue
 from .peer import BridgeClient, BridgeRegistrationError
-from .protocol import AuthorizationContextWire
+from .protocol import AuthorizationContextWire, runtime_version_matches
 from .routing import (
     ActionRequest,
     ActionResult,
@@ -18,6 +20,8 @@ from .routing import (
     EventAccepted,
     EventCompleted,
     EventMessage,
+    RuntimeApiInvoke,
+    RuntimeApiResult,
     ToolInvoke,
     ToolResult,
 )
@@ -54,10 +58,21 @@ class ControlOutcome:
     error_details: Mapping[str, JsonValue] | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class RuntimeApiOutcome:
+    """One stable runtime API result; provider exceptions stay on the bridge."""
+
+    success: bool
+    result: JsonValue = None
+    error_code: str | None = None
+    error_details: Mapping[str, JsonValue] | None = None
+
+
 type EventHandler = Callable[[BrokerDelivery], Awaitable[None]]
 type ActionHandler = Callable[[ActionRequest], Awaitable[ActionOutcome]]
 type ToolHandler = Callable[[ToolInvoke], Awaitable[ToolOutcome]]
 type ControlHandler = Callable[[BridgeControlInvoke], Awaitable[ControlOutcome]]
+type RuntimeApiHandler = Callable[[RuntimeApiInvoke], Awaitable[RuntimeApiOutcome]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -133,6 +148,36 @@ class BrokerDelivery:
             ),
         )
 
+    async def request_runtime_api(
+        self,
+        *,
+        correlation_id: str,
+        runtime_kind: str,
+        version: str,
+        api_id: str,
+        caller_extension_id: str,
+        authorization: AuthorizationContextWire,
+        arguments: Mapping[str, JsonValue] | None = None,
+        bridge_id: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> RuntimeApiResult:
+        """Invoke one declared runtime API through the active delivery lease."""
+
+        return await self._runner.request_runtime_api(
+            delivery_id=self.message.delivery_id,
+            lease_id=self.message.lease_id,
+            source_event_id=self.message.event.source_event_id,
+            correlation_id=correlation_id,
+            runtime_kind=runtime_kind,
+            version=version,
+            bridge_id=bridge_id,
+            api_id=api_id,
+            caller_extension_id=caller_extension_id,
+            authorization=authorization,
+            arguments=arguments,
+            timeout_seconds=self.message.lease_ttl_ms / 1_000 if timeout_seconds is None else timeout_seconds,
+        )
+
 
 class BrokerBridgeRunner:
     """Coordinate a bridge host over one registered :class:`BridgeClient`.
@@ -150,15 +195,18 @@ class BrokerBridgeRunner:
         action_handlers: Mapping[str, ActionHandler] | None = None,
         tool_handlers: Mapping[str, ToolHandler] | None = None,
         control_handlers: Mapping[str, ControlHandler] | None = None,
+        runtime_api_handlers: Mapping[str, RuntimeApiHandler] | None = None,
     ) -> None:
         self.client = client
         self._event_handler = event_handler
         self._action_handlers = dict(action_handlers or {})
         self._tool_handlers = dict(tool_handlers or {})
         self._control_handlers = dict(control_handlers or {})
+        self._runtime_api_handlers = dict(runtime_api_handlers or {})
         self._pending_results: dict[str, asyncio.Future[ActionResult]] = {}
         self._pending_tool_results: dict[str, asyncio.Future[ToolResult]] = {}
         self._pending_control_results: dict[str, asyncio.Future[BridgeControlResult]] = {}
+        self._pending_runtime_api_results: dict[str, asyncio.Future[RuntimeApiResult]] = {}
         self._background: set[asyncio.Task[None]] = set()
         self._closing = False
 
@@ -192,6 +240,12 @@ class BrokerBridgeRunner:
             if not control_future.done():
                 control_future.set_exception(BridgeRegistrationError("bridge runner stopped before control result"))
         self._pending_control_results.clear()
+        for runtime_api_future in self._pending_runtime_api_results.values():
+            if not runtime_api_future.done():
+                runtime_api_future.set_exception(
+                    BridgeRegistrationError("bridge runner stopped before runtime API result")
+                )
+        self._pending_runtime_api_results.clear()
         if self.client.session_id is not None:
             await self.client.unregister()
 
@@ -225,10 +279,16 @@ class BrokerBridgeRunner:
             if message.invocation_id is None:
                 raise BridgeRegistrationError("broker sent a control invocation without an invocation ID")
             self._spawn(self._handle_control(message))
+        elif isinstance(message, RuntimeApiInvoke):
+            if message.invocation_id is None:
+                raise BridgeRegistrationError("broker sent a runtime API invocation without an invocation ID")
+            self._spawn(self._handle_runtime_api(message))
         elif isinstance(message, ToolResult):
             self._resolve_tool_result(message)
         elif isinstance(message, BridgeControlResult):
             self._resolve_control_result(message)
+        elif isinstance(message, RuntimeApiResult):
+            self._resolve_runtime_api_result(message)
         elif isinstance(message, ActionResult):
             self._resolve_action_result(message)
         else:
@@ -355,6 +415,55 @@ class BrokerBridgeRunner:
             if self._pending_control_results.get(normalized_correlation) is future:
                 self._pending_control_results.pop(normalized_correlation, None)
 
+    async def request_runtime_api(
+        self,
+        *,
+        delivery_id: str,
+        lease_id: str,
+        source_event_id: str,
+        correlation_id: str,
+        runtime_kind: str,
+        version: str,
+        api_id: str,
+        caller_extension_id: str,
+        authorization: AuthorizationContextWire,
+        arguments: Mapping[str, JsonValue] | None = None,
+        bridge_id: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> RuntimeApiResult:
+        normalized_correlation = correlation_id.strip()
+        if not normalized_correlation:
+            raise ValueError("runtime API correlation ID must be non-empty")
+        if normalized_correlation in self._pending_runtime_api_results:
+            raise BridgeRegistrationError("a runtime API result is already pending for this correlation ID")
+        if timeout_seconds is not None and timeout_seconds <= 0:
+            raise ValueError("runtime API timeout must be positive")
+        future: asyncio.Future[RuntimeApiResult] = asyncio.get_running_loop().create_future()
+        self._pending_runtime_api_results[normalized_correlation] = future
+        try:
+            await self.client.send_runtime_api_invoke(
+                RuntimeApiInvoke(
+                    delivery_id=delivery_id,
+                    source_event_id=source_event_id,
+                    lease_id=lease_id,
+                    correlation_id=normalized_correlation,
+                    runtime_kind=runtime_kind,
+                    version=version,
+                    bridge_id=bridge_id,
+                    api_id=api_id,
+                    caller_extension_id=caller_extension_id,
+                    arguments=arguments or {},
+                    authorization=authorization,
+                )
+            )
+            result = await asyncio.wait_for(future, timeout=timeout_seconds) if timeout_seconds else await future
+            if not isinstance(result, RuntimeApiResult):
+                raise BridgeRegistrationError("received an unexpected result for a runtime API invocation")
+            return result
+        finally:
+            if self._pending_runtime_api_results.get(normalized_correlation) is future:
+                self._pending_runtime_api_results.pop(normalized_correlation, None)
+
     async def _handle_delivery(self, message: EventMessage) -> None:
         await self.client.send_event_accepted(EventAccepted(delivery_id=message.delivery_id, lease_id=message.lease_id))
         try:
@@ -429,6 +538,44 @@ class BrokerBridgeRunner:
             )
         )
 
+    async def _handle_runtime_api(self, request: RuntimeApiInvoke) -> None:
+        declaration = next(
+            (
+                item
+                for item in self.client.manifest.runtime_apis
+                if item.runtime_kind == request.runtime_kind
+                and item.api_id == request.api_id
+                and runtime_version_matches(request.version, item.version)
+            ),
+            None,
+        )
+        handler = self._runtime_api_handlers.get(request.api_id)
+        if declaration is None or handler is None:
+            outcome = RuntimeApiOutcome(success=False, error_code="RUNTIME_API_NOT_REGISTERED")
+        else:
+            try:
+                Draft202012Validator(dict(declaration.input_schema)).validate(dict(request.arguments))
+            except (TypeError, ValueError, ValidationError):
+                outcome = RuntimeApiOutcome(success=False, error_code="RUNTIME_API_INVALID_ARGUMENTS")
+            else:
+                try:
+                    outcome = await handler(request)
+                    if outcome.success:
+                        Draft202012Validator(dict(declaration.output_schema)).validate(outcome.result)
+                except (TypeError, ValueError, ValidationError):
+                    outcome = RuntimeApiOutcome(success=False, error_code="RUNTIME_API_INVALID_RESULT")
+                except Exception:
+                    outcome = RuntimeApiOutcome(success=False, error_code="RUNTIME_API_HANDLER_FAILED")
+        await self.client.send_runtime_api_result(
+            RuntimeApiResult(
+                invocation_id=request.invocation_id or "",
+                success=outcome.success,
+                result=outcome.result,
+                error_code=outcome.error_code,
+                error_details=outcome.error_details,
+            )
+        )
+
     def _resolve_action_result(self, result: ActionResult) -> None:
         if result.correlation_id is None:
             raise BridgeRegistrationError("broker action result is missing its correlation ID")
@@ -447,6 +594,13 @@ class BrokerBridgeRunner:
         if result.correlation_id is None:
             raise BridgeRegistrationError("bridge control result is missing its correlation ID")
         future = self._pending_control_results.get(result.correlation_id)
+        if future is not None and not future.done():
+            future.set_result(result)
+
+    def _resolve_runtime_api_result(self, result: RuntimeApiResult) -> None:
+        if result.correlation_id is None:
+            raise BridgeRegistrationError("runtime API result is missing its correlation ID")
+        future = self._pending_runtime_api_results.get(result.correlation_id)
         if future is not None and not future.done():
             future.set_result(result)
 

--- a/src/liteyukibot/broker/kernel.py
+++ b/src/liteyukibot/broker/kernel.py
@@ -17,7 +17,7 @@ from .actions import MessageSendPayload, make_message_send_request
 from .host import BrokerBridgeRunner, BrokerDelivery, ControlHandler, ToolOutcome
 from .peer import BridgeClient, BridgeRegistrationError
 from .protocol import AuthorizationContextWire, BridgeAccess, BridgeManifest, BrokerToolDeclaration
-from .routing import BridgeControlResult, ToolInvoke
+from .routing import BridgeControlResult, RuntimeApiResult, ToolInvoke
 
 
 class KernelBridgeError(RuntimeError):
@@ -217,6 +217,39 @@ class KernelBrokerPeer:
             command=command,
             authorization=request.authorization,
             payload=payload,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def request_runtime_api(
+        self,
+        event: EventEnvelope,
+        *,
+        correlation_id: str,
+        runtime_kind: str,
+        version: str,
+        api_id: str,
+        caller_extension_id: str,
+        authorization: AuthorizationContextWire,
+        arguments: Mapping[str, JsonValue] | None = None,
+        bridge_id: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> RuntimeApiResult | None:
+        """Invoke a runtime API while the native event owns a broker delivery."""
+
+        delivery = self._active_deliveries.get(event.id)
+        if delivery is None:
+            return None
+        if authorization.event_id != event.id:
+            raise KernelBridgeError("runtime API authorization does not match the active event")
+        return await delivery.request_runtime_api(
+            correlation_id=correlation_id,
+            runtime_kind=runtime_kind,
+            version=version,
+            bridge_id=bridge_id,
+            api_id=api_id,
+            caller_extension_id=caller_extension_id,
+            authorization=authorization,
+            arguments=arguments,
             timeout_seconds=timeout_seconds,
         )
 

--- a/src/liteyukibot/broker/peer.py
+++ b/src/liteyukibot/broker/peer.py
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
         EventMessage,
         RoutedAction,
         RoutedTool,
+        RuntimeApiInvoke,
+        RuntimeApiResult,
         ToolInvoke,
         ToolResult,
     )
@@ -137,7 +139,7 @@ class BrokerPeerService:
         return tuple(self._sessions_by_bridge.values())
 
     def handle_control(self, peer_identity: bytes, frame: LyipFrame) -> LyipFrame:
-        """Handle one control frame and return a deterministic v6 acknowledgement."""
+        """Handle one control frame and return a deterministic v7 acknowledgement."""
 
         if frame.generation != self.generation:
             return self._reply(
@@ -261,6 +263,8 @@ class BrokerPeerService:
             EventCompleted,
             EventIngress,
             EventMessage,
+            RuntimeApiInvoke,
+            RuntimeApiResult,
             ToolInvoke,
             ToolResult,
         )
@@ -370,6 +374,25 @@ class BrokerPeerService:
                     message=message.model_copy(update={"invocation_id": control_routed.invocation_id}),
                 ),
             )
+        if isinstance(message, RuntimeApiInvoke):
+            if message.invocation_id is not None:
+                raise BrokerAdmissionError(
+                    "unexpected_runtime_api_invocation_id",
+                    "bridges must not assign runtime API invocation IDs",
+                )
+            self._require_frame_lease(frame, message.lease_id)
+            runtime_api_routed = self.ledger.route_runtime_api(session, message, self.sessions)
+            if runtime_api_routed.replayed:
+                runtime_api_result = self.ledger.runtime_api_result(runtime_api_routed.invocation_id, session)
+                if runtime_api_result is None:
+                    return ()
+                return (BusinessDispatch(target=runtime_api_routed.origin, message=runtime_api_result),)
+            return (
+                BusinessDispatch(
+                    target=runtime_api_routed.target,
+                    message=message.model_copy(update={"invocation_id": runtime_api_routed.invocation_id}),
+                ),
+            )
         if isinstance(message, ToolResult):
             tool_routed = self.ledger.tool_route(message.invocation_id)
             tool_result = self.ledger.complete_tool(
@@ -392,6 +415,17 @@ class BrokerPeerService:
                 error_details=message.error_details,
             )
             return (BusinessDispatch(target=control_routed.origin, message=control_result),)
+        if isinstance(message, RuntimeApiResult):
+            runtime_api_routed = self.ledger.runtime_api_route(message.invocation_id)
+            runtime_api_result = self.ledger.complete_runtime_api(
+                session,
+                message.invocation_id,
+                success=message.success,
+                result=message.result,
+                error_code=message.error_code,
+                error_details=message.error_details,
+            )
+            return (BusinessDispatch(target=runtime_api_routed.origin, message=runtime_api_result),)
         if isinstance(message, EventMessage):
             raise BrokerAdmissionError("unexpected_message", "bridges must not send broker event deliveries")
         raise BrokerAdmissionError("unexpected_message", "broker does not accept this business message from a bridge")
@@ -591,7 +625,15 @@ class BrokerPeerServer:
         """Send one catalog message on a target's registered session-bound business stream."""
 
         from .business import encode_business_message
-        from .routing import BridgeControlInvoke, BridgeControlResult, EventMessage, ToolInvoke, ToolResult
+        from .routing import (
+            BridgeControlInvoke,
+            BridgeControlResult,
+            EventMessage,
+            RuntimeApiInvoke,
+            RuntimeApiResult,
+            ToolInvoke,
+            ToolResult,
+        )
 
         if isinstance(message, EventMessage):
             suffix = "delivery"
@@ -599,6 +641,8 @@ class BrokerPeerServer:
             suffix = "tool"
         elif isinstance(message, (BridgeControlInvoke, BridgeControlResult)):
             suffix = "control"
+        elif isinstance(message, (RuntimeApiInvoke, RuntimeApiResult)):
+            suffix = "runtime-api"
         else:
             suffix = "action"
         stream_id = f"bridge:{target.bridge_id}:{target.session_id}:{suffix}"
@@ -731,6 +775,13 @@ class BridgeClient:
 
     async def send_control_result(self, message: BridgeControlResult) -> None:
         await self._send_business(message, suffix="control", lease_id="bridge-business")
+
+    async def send_runtime_api_invoke(self, message: RuntimeApiInvoke) -> None:
+        self._require_delivery_lease(message.delivery_id, message.lease_id)
+        await self._send_business(message, suffix="runtime-api", lease_id=message.lease_id)
+
+    async def send_runtime_api_result(self, message: RuntimeApiResult) -> None:
+        await self._send_business(message, suffix="runtime-api", lease_id="bridge-business")
 
     async def receive_business(self) -> BrokerBusinessMessage:
         """Receive one broker business message and bind offered leases to this live session."""

--- a/src/liteyukibot/broker/protocol.py
+++ b/src/liteyukibot/broker/protocol.py
@@ -1,4 +1,4 @@
-"""Version 6 broker bridge-registration messages carried by LYIP frames."""
+"""Version 7 broker bridge-registration messages carried by LYIP frames."""
 
 from __future__ import annotations
 
@@ -6,12 +6,13 @@ from collections.abc import Mapping
 from enum import StrEnum
 from typing import Annotated, Final, Literal
 
+from jsonschema import Draft202012Validator, SchemaError
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator, model_serializer, model_validator
 
 from ..lyip import LyipError, LyipFrame, LyipLane
 from ..topic_patterns import validate_topic_pattern
 
-BROKER_PROTOCOL_VERSION: Final = 6
+BROKER_PROTOCOL_VERSION: Final = 7
 BROKER_REGISTER_TYPE_ID: Final = 600
 BROKER_REGISTERED_TYPE_ID: Final = 601
 BROKER_REJECTED_TYPE_ID: Final = 602
@@ -26,7 +27,7 @@ BROKER_DIAGNOSTICS_DETAIL_RESULT_TYPE_ID: Final = 610
 
 
 class BrokerWireError(LyipError):
-    """Raised when a LYIP frame does not carry a valid broker v6 message."""
+    """Raised when a LYIP frame does not carry a valid broker v7 message."""
 
 
 class BridgeAccess(StrEnum):
@@ -43,6 +44,25 @@ def _non_blank_identifier(value: str) -> str:
     if not normalized:
         raise ValueError("identifier must be non-empty")
     return normalized
+
+
+def runtime_version_matches(requested: str, offered: str) -> bool:
+    """Match the bounded Alpha8 runtime API caret range syntax."""
+
+    if requested == offered:
+        return True
+    if not requested.startswith("^"):
+        return False
+    raw_requested = requested[1:].split(".")
+    raw_offered = offered.split(".")
+    if len(raw_requested) < 2 or len(raw_offered) < 2:
+        return False
+    try:
+        requested_major, requested_minor = int(raw_requested[0]), int(raw_requested[1])
+        offered_major, offered_minor = int(raw_offered[0]), int(raw_offered[1])
+    except ValueError:
+        return False
+    return offered_major == requested_major and offered_minor >= requested_minor
 
 
 class ActionResourceDeclaration(BrokerWireModel):
@@ -116,6 +136,48 @@ class BrokerToolDeclaration(BrokerWireModel):
         return result
 
 
+class RuntimeApiDeclaration(BrokerWireModel):
+    """One immutable operation exposed by a runtime bridge."""
+
+    runtime_kind: str
+    namespace: str
+    operation: str
+    version: str
+    input_schema: Mapping[str, object]
+    output_schema: Mapping[str, object]
+    capabilities: tuple[str, ...] = ()
+
+    @field_validator("runtime_kind", "namespace", "operation", "version", mode="before")
+    @classmethod
+    def validate_text(cls, value: object) -> str:
+        if not isinstance(value, str):
+            raise TypeError("runtime API declaration fields must be strings")
+        return _non_blank_identifier(value)
+
+    @field_validator("capabilities", mode="before")
+    @classmethod
+    def validate_capabilities(cls, value: object) -> tuple[str, ...]:
+        if not isinstance(value, (list, tuple)):
+            raise TypeError("runtime API capabilities must be an array")
+        result = tuple(_non_blank_identifier(item) for item in value if isinstance(item, str))
+        if len(result) != len(value) or len(result) != len(set(result)):
+            raise ValueError("runtime API capabilities must be unique strings")
+        return result
+
+    @field_validator("input_schema", "output_schema")
+    @classmethod
+    def validate_schema(cls, value: Mapping[str, object]) -> Mapping[str, object]:
+        try:
+            Draft202012Validator.check_schema(dict(value))
+        except SchemaError as error:
+            raise ValueError("runtime API schema must be Draft 2020-12 compatible") from error
+        return dict(value)
+
+    @property
+    def api_id(self) -> str:
+        return f"{self.namespace}.{self.operation}"
+
+
 class AuthorizationContextWire(BrokerWireModel):
     """Only event identity and principal fields may cross the Tool wire."""
 
@@ -143,6 +205,7 @@ class BridgeManifest(BrokerWireModel):
     action_resources: tuple[ActionResourceDeclaration, ...] = ()
     tools: tuple[BrokerToolDeclaration, ...] = ()
     controls: tuple[str, ...] = ()
+    runtime_apis: tuple[RuntimeApiDeclaration, ...] = ()
 
     @field_validator("bridge_id", mode="before")
     @classmethod
@@ -183,12 +246,15 @@ class BridgeManifest(BrokerWireModel):
         tool_ids = tuple(tool.id for tool in self.tools)
         if len(tool_ids) != len(set(tool_ids)):
             raise ValueError("tool declarations must not contain duplicate IDs")
+        api_ids = tuple((api.runtime_kind, api.api_id) for api in self.runtime_apis)
+        if len(api_ids) != len(set(api_ids)):
+            raise ValueError("runtime API declarations must not contain duplicate IDs")
         return self
 
 
 class BridgeRegister(BrokerWireModel):
     type: Literal["bridge.register"] = "bridge.register"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     bridge_id: str
     instance_token: str
     manifest: BridgeManifest
@@ -209,7 +275,7 @@ class BridgeRegister(BrokerWireModel):
 
 class BridgeRegistered(BrokerWireModel):
     type: Literal["bridge.registered"] = "bridge.registered"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     session_id: str
 
     @field_validator("session_id", mode="before")
@@ -222,7 +288,7 @@ class BridgeRegistered(BrokerWireModel):
 
 class BridgeRejected(BrokerWireModel):
     type: Literal["bridge.rejected"] = "bridge.rejected"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     code: str
     message: str
 
@@ -236,7 +302,7 @@ class BridgeRejected(BrokerWireModel):
 
 class BridgeUnregister(BrokerWireModel):
     type: Literal["bridge.unregister"] = "bridge.unregister"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     session_id: str
 
     @field_validator("session_id", mode="before")
@@ -249,7 +315,7 @@ class BridgeUnregister(BrokerWireModel):
 
 class BridgeUnregistered(BrokerWireModel):
     type: Literal["bridge.unregistered"] = "bridge.unregistered"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     session_id: str
 
     @field_validator("session_id", mode="before")
@@ -264,7 +330,7 @@ class BrokerDiagnosticsStatus(BrokerWireModel):
     """Authenticate and request bounded broker diagnostic status."""
 
     type: Literal["broker.diagnostics.status"] = "broker.diagnostics.status"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     token: str
 
     @field_validator("token", mode="before")
@@ -279,7 +345,7 @@ class BrokerDiagnosticsList(BrokerWireModel):
     """Authenticate and request one redacted event-delivery page."""
 
     type: Literal["broker.diagnostics.list"] = "broker.diagnostics.list"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     token: str
     cursor: str | None = None
     limit: int = Field(default=100, ge=1, le=500)
@@ -303,7 +369,7 @@ class BrokerDiagnosticsDetail(BrokerWireModel):
     """Authenticate and request one redacted retained-event timeline."""
 
     type: Literal["broker.diagnostics.detail"] = "broker.diagnostics.detail"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     token: str
     event_id: str
 
@@ -319,7 +385,7 @@ class BrokerDiagnosticsStatusResult(BrokerWireModel):
     """Read-only bounded-retention broker status without business data."""
 
     type: Literal["broker.diagnostics.status.result"] = "broker.diagnostics.status.result"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     generation: int = Field(ge=1)
     active_events: int = Field(ge=0)
     terminal_events: int = Field(ge=0)
@@ -360,7 +426,7 @@ class BrokerDiagnosticsDetailResult(BrokerWireModel):
     """A redacted retained event with its bounded lifecycle timeline."""
 
     type: Literal["broker.diagnostics.detail.result"] = "broker.diagnostics.detail.result"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     event: BrokerDiagnosticsEventRow
     transitions: tuple[BrokerDiagnosticsTransition, ...] = ()
 
@@ -369,7 +435,7 @@ class BrokerDiagnosticsListResult(BrokerWireModel):
     """One opaque-cursor page of redacted retained broker events."""
 
     type: Literal["broker.diagnostics.list.result"] = "broker.diagnostics.list.result"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     events: tuple[BrokerDiagnosticsEventRow, ...] = ()
     next_cursor: str | None = None
 
@@ -414,7 +480,7 @@ def encode_broker_message(
     sequence: int,
     lease_id: str,
 ) -> LyipFrame:
-    """Encode one v6 control-plane message into an existing LYIP frame."""
+    """Encode one v7 control-plane message into an existing LYIP frame."""
 
     return LyipFrame(
         protocol=1,
@@ -429,17 +495,17 @@ def encode_broker_message(
 
 
 def decode_broker_message(frame: LyipFrame) -> BrokerWireMessage:
-    """Decode a v6 broker control message without accepting legacy runtime types."""
+    """Decode a v7 broker control message without accepting legacy runtime types."""
 
     if frame.lane is not LyipLane.CONTROL:
         raise BrokerWireError("broker control message arrived on the wrong LYIP lane")
     message_type = _MESSAGE_TYPES.get(frame.type_id)
     if message_type is None:
-        raise BrokerWireError(f"unknown broker v6 type ID: {frame.type_id}")
+        raise BrokerWireError(f"unknown broker v7 type ID: {frame.type_id}")
     try:
         message = message_type.model_validate_json(frame.payload)
     except ValueError as error:
-        raise BrokerWireError("broker v6 payload is invalid") from error
+        raise BrokerWireError("broker v7 payload is invalid") from error
     if _TYPE_IDS[type(message)] != frame.type_id:
-        raise BrokerWireError("broker v6 type ID does not match payload type")
+        raise BrokerWireError("broker v7 type ID does not match payload type")
     return message  # type: ignore[return-value]

--- a/src/liteyukibot/broker/routing.py
+++ b/src/liteyukibot/broker/routing.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_valid
 from ..events.models import JsonValue
 from ..topic_patterns import topic_pattern_matches
 from .peer import BridgeRegistrationError, BridgeSession
-from .protocol import BROKER_PROTOCOL_VERSION, AuthorizationContextWire, BridgeAccess
+from .protocol import BROKER_PROTOCOL_VERSION, AuthorizationContextWire, BridgeAccess, runtime_version_matches
 
 
 def _validate_json(value: Any, path: str = "payload") -> None:
@@ -65,7 +65,7 @@ class EventIngress(BrokerModel):
     """The only event shape accepted from a bridge business lane."""
 
     type: Literal["event.ingress"] = "event.ingress"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     source_event_id: str = Field(min_length=1)
     topic: str = Field(min_length=1)
     ordering_key: str = Field(min_length=1)
@@ -90,7 +90,7 @@ class EventIngress(BrokerModel):
 class BrokerEvent(BrokerModel):
     """Immutable broker-created event identity and authenticated provenance."""
 
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     kernel_event_id: str = Field(min_length=1)
     source_bridge_id: str = Field(min_length=1)
     source_event_id: str = Field(min_length=1)
@@ -129,7 +129,7 @@ _TERMINAL_STATES = frozenset({DeliveryState.COMPLETED, DeliveryState.FAILED, Del
 
 class ActionRequest(BrokerModel):
     type: Literal["action.request"] = "action.request"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     delivery_id: str = Field(min_length=1)
     lease_id: str = Field(min_length=1)
     correlation_id: str = Field(min_length=1)
@@ -158,7 +158,7 @@ class EventMessage(BrokerModel):
     """Broker-to-bridge event delivery carrying an opaque broker lease."""
 
     type: Literal["event.message"] = "event.message"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     delivery_id: str = Field(min_length=1)
     lease_id: str = Field(min_length=1)
     lease_ttl_ms: int = Field(ge=1)
@@ -170,7 +170,7 @@ class EventAccepted(BrokerModel):
     """Bridge acknowledgement that transitions an offered delivery to active."""
 
     type: Literal["event.accepted"] = "event.accepted"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     delivery_id: str = Field(min_length=1)
     lease_id: str = Field(min_length=1)
 
@@ -179,7 +179,7 @@ class EventCompleted(BrokerModel):
     """Terminal outcome of an active broker event delivery."""
 
     type: Literal["event.completed"] = "event.completed"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     delivery_id: str = Field(min_length=1)
     lease_id: str = Field(min_length=1)
     success: bool
@@ -198,7 +198,7 @@ class ActionResult(BrokerModel):
     """Terminal result returned by the bridge selected for one action."""
 
     type: Literal["action.result"] = "action.result"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     action_id: str = Field(min_length=1)
     # The owner omits this field. The broker fills it from the retained request
     # before forwarding the result to its origin bridge.
@@ -226,7 +226,7 @@ class ToolInvoke(BrokerModel):
     """A lease-bound Tool invocation sent by a caller bridge."""
 
     type: Literal["tool.invoke"] = "tool.invoke"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     delivery_id: str = Field(min_length=1)
     lease_id: str = Field(min_length=1)
     correlation_id: str = Field(min_length=1)
@@ -255,7 +255,7 @@ class ToolResult(BrokerModel):
     """Stable, redacted result returned by a Tool provider."""
 
     type: Literal["tool.result"] = "tool.result"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     invocation_id: str = Field(min_length=1)
     correlation_id: str | None = Field(default=None, min_length=1)
     success: bool
@@ -275,11 +275,80 @@ class ToolResult(BrokerModel):
         return self
 
 
+class RuntimeApiInvoke(BrokerModel):
+    """A lease-bound runtime API invocation sent by a caller bridge."""
+
+    type: Literal["runtime.api.invoke"] = "runtime.api.invoke"
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
+    delivery_id: str = Field(min_length=1)
+    source_event_id: str = Field(min_length=1)
+    lease_id: str = Field(min_length=1)
+    correlation_id: str = Field(min_length=1)
+    runtime_kind: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    bridge_id: str | None = Field(default=None, min_length=1)
+    api_id: str = Field(min_length=1)
+    caller_extension_id: str = Field(min_length=1)
+    arguments: Mapping[str, JsonValue] = Field(default_factory=dict)
+    authorization: AuthorizationContextWire
+    invocation_id: str | None = Field(default=None, min_length=1)
+
+    @field_validator(
+        "source_event_id", "runtime_kind", "version", "api_id", "caller_extension_id", "bridge_id", mode="before"
+    )
+    @classmethod
+    def validate_identifiers(cls, value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value.strip():
+            raise TypeError("runtime API identifiers must be non-empty strings")
+        return value.strip()
+
+    @field_validator("arguments", mode="before")
+    @classmethod
+    def validate_arguments(cls, value: Any) -> Any:
+        _validate_json(value, "runtime API arguments")
+        return value
+
+    @field_validator("arguments", mode="after")
+    @classmethod
+    def freeze_arguments(cls, value: Mapping[str, JsonValue]) -> Mapping[str, JsonValue]:
+        return MappingProxyType({key: _freeze(item) for key, item in value.items()})
+
+    @field_serializer("arguments")
+    def serialize_arguments(self, value: Mapping[str, JsonValue]) -> dict[str, Any]:
+        return {key: _thaw(item) for key, item in value.items()}
+
+
+class RuntimeApiResult(BrokerModel):
+    """Stable result returned by a runtime API provider."""
+
+    type: Literal["runtime.api.result"] = "runtime.api.result"
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
+    invocation_id: str = Field(min_length=1)
+    correlation_id: str | None = Field(default=None, min_length=1)
+    success: bool
+    result: JsonValue = None
+    error_code: str | None = Field(default=None, min_length=1)
+    error_details: Mapping[str, JsonValue] | None = None
+
+    @model_validator(mode="after")
+    def validate_result(self) -> RuntimeApiResult:
+        if self.success and self.error_code is not None:
+            raise ValueError("successful runtime API results cannot contain an error code")
+        if not self.success and self.error_code is None:
+            raise ValueError("failed runtime API results require a stable error code")
+        _validate_json(self.result, "runtime API result")
+        if self.error_details is not None:
+            _validate_json(self.error_details, "runtime API error details")
+        return self
+
+
 class BridgeControlInvoke(BrokerModel):
     """A lease-bound control invocation sent by a caller bridge."""
 
     type: Literal["bridge.control.invoke"] = "bridge.control.invoke"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     delivery_id: str = Field(min_length=1)
     lease_id: str = Field(min_length=1)
     correlation_id: str = Field(min_length=1)
@@ -308,7 +377,7 @@ class BridgeControlResult(BrokerModel):
     """Stable result returned by a bridge control owner."""
 
     type: Literal["bridge.control.result"] = "bridge.control.result"
-    protocol: Literal[6] = BROKER_PROTOCOL_VERSION
+    protocol: Literal[7] = BROKER_PROTOCOL_VERSION
     invocation_id: str = Field(min_length=1)
     correlation_id: str | None = Field(default=None, min_length=1)
     success: bool
@@ -343,6 +412,16 @@ class RoutedControl:
     invocation_id: str
     event_id: str
     request: BridgeControlInvoke
+    target: BridgeSession
+    origin: BridgeSession
+    replayed: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class RoutedRuntimeApi:
+    invocation_id: str
+    event_id: str
+    request: RuntimeApiInvoke
     target: BridgeSession
     origin: BridgeSession
     replayed: bool = False
@@ -424,6 +503,13 @@ class _Control:
     result: BridgeControlResult | None = None
 
 
+@dataclass(slots=True)
+class _RuntimeApi:
+    routed: RoutedRuntimeApi
+    canonical_request: str
+    result: RuntimeApiResult | None = None
+
+
 @dataclass(frozen=True, slots=True)
 class RoutedTool:
     invocation_id: str
@@ -442,6 +528,7 @@ class _EventRecord:
     actions: dict[tuple[str, str], _Action] = field(default_factory=dict)
     tools: dict[tuple[str, str], _Tool] = field(default_factory=dict)
     controls: dict[tuple[str, str], _Control] = field(default_factory=dict)
+    runtime_apis: dict[tuple[str, str], _RuntimeApi] = field(default_factory=dict)
     transitions: list[LedgerTransition] = field(default_factory=list)
     terminal_at: float | None = None
 
@@ -483,6 +570,7 @@ class BrokerLedger:
         self._action_index: dict[str, _Action] = {}
         self._tool_index: dict[str, _Tool] = {}
         self._control_index: dict[str, _Control] = {}
+        self._runtime_api_index: dict[str, _RuntimeApi] = {}
         self._lanes: dict[tuple[str, str, str], deque[str]] = {}
 
     @property
@@ -763,6 +851,84 @@ class BrokerLedger:
         self._record_transition(record, "control.routed", target_bridge_id=owners[0].bridge_id)
         return routed
 
+    def route_runtime_api(
+        self, session: BridgeSession, request: RuntimeApiInvoke, sessions: tuple[BridgeSession, ...]
+    ) -> RoutedRuntimeApi:
+        delivery = self._require_delivery(session, request.delivery_id, request.lease_id, DeliveryState.ACTIVE)
+        record = self._delivery_index[delivery.delivery_id]
+        authorization = request.authorization
+        if authorization.event_id != record.event.kernel_event_id:
+            raise BrokerAdmissionError(
+                "runtime_api_authorization_mismatch",
+                "runtime API authorization does not match the routed event",
+            )
+        if request.source_event_id != record.event.source_event_id:
+            raise BrokerAdmissionError(
+                "runtime_api_source_event_mismatch",
+                "runtime API source event does not match the routed event",
+            )
+        if authorization.runtime_id != record.event.source_bridge_id:
+            raise BrokerAdmissionError(
+                "runtime_api_authorization_mismatch",
+                "runtime API authorization runtime does not match the routed event",
+            )
+        event_payload = record.event.payload
+        if isinstance(event_payload, Mapping):
+            event_bot_id = event_payload.get("bot_id")
+            if isinstance(event_bot_id, str) and authorization.bot_id != event_bot_id:
+                raise BrokerAdmissionError(
+                    "runtime_api_authorization_mismatch",
+                    "runtime API authorization bot does not match the routed event",
+                )
+            event_actor = event_payload.get("actor")
+            if isinstance(event_actor, Mapping):
+                event_actor_id = event_actor.get("id")
+                if isinstance(event_actor_id, str) and authorization.actor_id != event_actor_id:
+                    raise BrokerAdmissionError(
+                        "runtime_api_authorization_mismatch",
+                        "runtime API authorization actor does not match the routed event",
+                    )
+        canonical = json.dumps(
+            request.model_dump(mode="json", exclude_none=True), sort_keys=True, separators=(",", ":")
+        )
+        key = (session.session_id, request.correlation_id)
+        previous = record.runtime_apis.get(key)
+        if previous is not None:
+            if previous.canonical_request != canonical:
+                raise BrokerAdmissionError(
+                    "runtime_api_conflict",
+                    "correlation ID was already used with different runtime API content",
+                )
+            return RoutedRuntimeApi(
+                invocation_id=previous.routed.invocation_id,
+                event_id=previous.routed.event_id,
+                request=previous.routed.request,
+                target=previous.routed.target,
+                origin=previous.routed.origin,
+                replayed=True,
+            )
+        owners = tuple(
+            candidate
+            for candidate in sessions
+            if (request.bridge_id is None or candidate.bridge_id == request.bridge_id)
+            and any(
+                api.runtime_kind == request.runtime_kind
+                and api.api_id == request.api_id
+                and runtime_version_matches(request.version, api.version)
+                for api in candidate.manifest.runtime_apis
+            )
+        )
+        if len(owners) != 1:
+            raise BrokerAdmissionError(
+                "runtime_api_owner_conflict" if owners else "unknown_runtime_api",
+                "runtime API ownership is not unique",
+            )
+        routed = RoutedRuntimeApi(str(uuid4()), record.event.kernel_event_id, request, owners[0], session)
+        record.runtime_apis[key] = _RuntimeApi(routed=routed, canonical_request=canonical)
+        self._runtime_api_index[routed.invocation_id] = record.runtime_apis[key]
+        self._record_transition(record, "runtime_api.routed", target_bridge_id=owners[0].bridge_id)
+        return routed
+
     def complete_tool(
         self,
         session: BridgeSession,
@@ -827,6 +993,43 @@ class BrokerLedger:
             raise BrokerAdmissionError("control_result_conflict", "control result conflicts with retained result")
         return control.result
 
+    def complete_runtime_api(
+        self,
+        session: BridgeSession,
+        invocation_id: str,
+        *,
+        success: bool,
+        result: JsonValue = None,
+        error_code: str | None = None,
+        error_details: Mapping[str, JsonValue] | None = None,
+    ) -> RuntimeApiResult:
+        self.expire()
+        runtime_api = self._runtime_api_index.get(invocation_id)
+        if runtime_api is None:
+            raise BrokerAdmissionError("unknown_runtime_api_invocation", "runtime API invocation is not retained")
+        if runtime_api.routed.target.session_id != session.session_id:
+            raise BrokerAdmissionError("runtime_api_owner_mismatch", "runtime API result owner does not match route")
+        response = RuntimeApiResult(
+            invocation_id=invocation_id,
+            correlation_id=runtime_api.routed.request.correlation_id,
+            success=success,
+            result=result,
+            error_code=error_code,
+            error_details=error_details,
+        )
+        if runtime_api.result is None:
+            runtime_api.result = response
+            record = self._record_for_runtime_api(runtime_api)
+            self._record_transition(
+                record, "runtime_api.completed", target_bridge_id=session.bridge_id, success=success
+            )
+        elif runtime_api.result != response:
+            raise BrokerAdmissionError(
+                "runtime_api_result_conflict",
+                "runtime API result conflicts with retained result",
+            )
+        return runtime_api.result
+
     def tool_route(self, invocation_id: str) -> RoutedTool:
         self.expire()
         tool = self._tool_index.get(invocation_id)
@@ -856,6 +1059,21 @@ class BrokerLedger:
         if control.routed.origin.session_id != session.session_id:
             raise BrokerAdmissionError("control_origin_mismatch", "control replay origin does not match route")
         return control.result
+
+    def runtime_api_route(self, invocation_id: str) -> RoutedRuntimeApi:
+        self.expire()
+        runtime_api = self._runtime_api_index.get(invocation_id)
+        if runtime_api is None:
+            raise BrokerAdmissionError("unknown_runtime_api_invocation", "runtime API invocation is not retained")
+        return runtime_api.routed
+
+    def runtime_api_result(self, invocation_id: str, session: BridgeSession) -> RuntimeApiResult | None:
+        runtime_api = self._runtime_api_index.get(invocation_id)
+        if runtime_api is None:
+            raise BrokerAdmissionError("unknown_runtime_api_invocation", "runtime API invocation is not retained")
+        if runtime_api.routed.origin.session_id != session.session_id:
+            raise BrokerAdmissionError("runtime_api_origin_mismatch", "runtime API replay origin does not match route")
+        return runtime_api.result
 
     def complete_action(
         self,
@@ -959,6 +1177,8 @@ class BrokerLedger:
                 self._tool_index.pop(invocation_id, None)
             for invocation_id in tuple(control.routed.invocation_id for control in record.controls.values()):
                 self._control_index.pop(invocation_id, None)
+            for invocation_id in tuple(api.routed.invocation_id for api in record.runtime_apis.values()):
+                self._runtime_api_index.pop(invocation_id, None)
 
     @staticmethod
     def event_subscribers(event: BrokerEvent, sessions: tuple[BridgeSession, ...]) -> tuple[BridgeSession, ...]:
@@ -1113,6 +1333,15 @@ class BrokerLedger:
         record = self._active.get(control.routed.event_id) or self._terminal.get(control.routed.event_id)
         if record is None:
             raise BrokerAdmissionError("unknown_control_invocation", "control invocation event is not retained")
+        return record
+
+    def _record_for_runtime_api(self, runtime_api: _RuntimeApi) -> _EventRecord:
+        record = self._active.get(runtime_api.routed.event_id) or self._terminal.get(runtime_api.routed.event_id)
+        if record is None:
+            raise BrokerAdmissionError(
+                "unknown_runtime_api_invocation",
+                "runtime API invocation event is not retained",
+            )
         return record
 
     def _record_delivery_transition(

--- a/src/liteyukibot/broker/service.py
+++ b/src/liteyukibot/broker/service.py
@@ -145,6 +145,8 @@ class _AuthoritativePeerService(BrokerPeerService):
         delivery_timeout_seconds: float,
         diagnostics_token: str | None = None,
         dynamic_manifest_bridge_ids: frozenset[str] = frozenset(),
+        dynamic_runtime_api_bridge_ids: frozenset[str] = frozenset(),
+        runtime_kinds: Mapping[str, str] | None = None,
     ) -> None:
         super().__init__(
             instance_tokens=instance_tokens,
@@ -157,13 +159,31 @@ class _AuthoritativePeerService(BrokerPeerService):
         )
         self._manifests = dict(manifests)
         self._dynamic_manifest_bridge_ids = dynamic_manifest_bridge_ids
+        self._dynamic_runtime_api_bridge_ids = dynamic_runtime_api_bridge_ids
+        self._runtime_kinds = dict(runtime_kinds or {})
 
     def _register(self, peer_identity: bytes, frame: LyipFrame, message: BridgeRegister) -> LyipFrame:
         expected = self._manifests.get(message.bridge_id)
-        if message.bridge_id in self._dynamic_manifest_bridge_ids and expected is not None:
-            expected = expected.model_copy(
-                update={"tools": message.manifest.tools, "controls": message.manifest.controls}
-            )
+        if expected is not None:
+            updates: dict[str, object] = {}
+            if message.bridge_id in self._dynamic_manifest_bridge_ids:
+                updates.update(tools=message.manifest.tools, controls=message.manifest.controls)
+            if message.bridge_id in self._dynamic_runtime_api_bridge_ids:
+                expected_kind = self._runtime_kinds.get(message.bridge_id)
+                if expected_kind is not None and any(
+                    api.runtime_kind != expected_kind for api in message.manifest.runtime_apis
+                ):
+                    return self._reply(
+                        peer_identity,
+                        frame,
+                        BridgeRejected(
+                            code="runtime_api_kind_mismatch",
+                            message="runtime API declarations do not match the configured bridge kind",
+                        ),
+                    )
+                updates["runtime_apis"] = message.manifest.runtime_apis
+            if updates:
+                expected = expected.model_copy(update=updates)
         if expected is not None and message.manifest != expected:
             return self._reply(
                 peer_identity,
@@ -215,6 +235,9 @@ class BrokerService:
         dynamic_manifest_bridge_ids = frozenset(
             bridge_id for bridge_id, bridge in settings.broker.bridges.items() if bridge.kind == "kernel"
         )
+        dynamic_runtime_api_bridge_ids = frozenset(
+            bridge_id for bridge_id, bridge in settings.broker.bridges.items() if bridge.kind != "kernel"
+        )
         self._context = zmq.asyncio.Context.instance()
         self.server = BrokerPeerServer(
             context=self._context,
@@ -237,6 +260,8 @@ class BrokerService:
             delivery_timeout_seconds=settings.broker.delivery_timeout_seconds,
             diagnostics_token=diagnostics_token,
             dynamic_manifest_bridge_ids=dynamic_manifest_bridge_ids,
+            dynamic_runtime_api_bridge_ids=dynamic_runtime_api_bridge_ids,
+            runtime_kinds={bridge_id: bridge.kind for bridge_id, bridge in settings.broker.bridges.items()},
         )
 
     @classmethod

--- a/src/liteyukibot/runtime_api.py
+++ b/src/liteyukibot/runtime_api.py
@@ -1,0 +1,310 @@
+"""Protocol-neutral runtime bridge API declarations and invocation helpers."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from functools import wraps
+from importlib import metadata
+from typing import Any, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from .authorization import AuthorizationContext
+from .events import EventEnvelope
+from .events.models import JsonValue
+
+RUNTIME_BINDINGS_ATTRIBUTE = "__liteyuki_runtime_bindings__"
+
+
+def _identifier(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        raise ValueError(f"{field} must be a non-empty trimmed string")
+    return value
+
+
+class RuntimeRequirement(BaseModel):
+    """One extension-level dependency on a runtime API namespace."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    runtime: str
+    api: str
+    version: str = "^1.0"
+    operations: tuple[str, ...]
+    optional: bool = False
+    bridge_id: str | None = None
+
+    @field_validator("runtime", "api", "version")
+    @classmethod
+    def validate_text(cls, value: str, info: Any) -> str:
+        return _identifier(value, info.field_name)
+
+    @field_validator("operations")
+    @classmethod
+    def validate_operations(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        if not value or any(not _identifier(operation, "runtime API operation") for operation in value):
+            raise ValueError("runtime API requirements must declare at least one operation")
+        if len(value) != len(set(value)):
+            raise ValueError("runtime API requirement operations must be unique")
+        return value
+
+    @field_validator("bridge_id")
+    @classmethod
+    def validate_bridge_id(cls, value: str | None) -> str | None:
+        return None if value is None else _identifier(value, "runtime API bridge_id")
+
+    @property
+    def capability_names(self) -> tuple[str, ...]:
+        return tuple(f"runtime.{self.runtime}.{self.api}.{operation}" for operation in self.operations)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeBinding:
+    """Function-level runtime namespace metadata recorded by :func:`runtime`."""
+
+    runtime: str
+    api: str
+    version: str
+    optional: bool
+    alias: str
+    bridge_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCallContext:
+    """The minimal event and extension identity available to a runtime call."""
+
+    extension_id: str
+    event: EventEnvelope
+    authorization: AuthorizationContext
+
+
+class RuntimeApiBackend(Protocol):
+    async def invoke(
+        self,
+        binding: RuntimeBinding,
+        operation: str,
+        arguments: Mapping[str, JsonValue],
+        context: RuntimeCallContext,
+    ) -> JsonValue: ...
+
+
+class RuntimeUnavailable(RuntimeError):
+    """Raised when an optional runtime dependency has no compatible provider."""
+
+    def __init__(self, runtime: str, api: str, reason: str = "unavailable") -> None:
+        self.runtime = runtime
+        self.api = api
+        self.reason = reason
+        super().__init__(f"runtime API {runtime}.{api} is unavailable: {reason}")
+
+
+class RuntimeApiError(RuntimeError):
+    """Raised for a stable provider-side runtime API failure."""
+
+    def __init__(self, runtime: str, api: str, operation: str, code: str, details: JsonValue = None) -> None:
+        self.runtime = runtime
+        self.api = api
+        self.operation = operation
+        self.code = code
+        self.details = details
+        super().__init__(f"runtime API {runtime}.{api}.{operation} failed: {code}")
+
+
+class RuntimeNamespaceProxy:
+    """Generic JSON-safe namespace proxy used by typed runtime SDK facades."""
+
+    def __init__(
+        self,
+        binding: RuntimeBinding,
+        backend: RuntimeApiBackend | None,
+        context: RuntimeCallContext | None,
+        *,
+        reason: str = "unavailable",
+    ) -> None:
+        self.binding = binding
+        self._backend = backend
+        self._context = context
+        self._reason = reason
+
+    @property
+    def available(self) -> bool:
+        return self._backend is not None and self._context is not None
+
+    async def call(self, operation: str, arguments: Mapping[str, JsonValue] | None = None) -> JsonValue:
+        if not self.available:
+            raise RuntimeUnavailable(self.binding.runtime, self.binding.api, self._reason)
+        assert self._backend is not None
+        assert self._context is not None
+        return await self._backend.invoke(self.binding, operation, arguments or {}, self._context)
+
+
+RuntimeApiProxy = RuntimeNamespaceProxy
+
+
+RuntimeResolver = Callable[[RuntimeBinding, RuntimeCallContext], RuntimeNamespaceProxy]
+RuntimeContextFactory = Callable[[tuple[Any, ...], Mapping[str, Any]], RuntimeCallContext]
+RuntimeProxyFactory = Callable[..., RuntimeNamespaceProxy]
+
+
+def create_runtime_proxy(
+    binding: RuntimeBinding,
+    backend: RuntimeApiBackend | None,
+    context: RuntimeCallContext | None,
+    *,
+    reason: str = "unavailable",
+) -> RuntimeNamespaceProxy:
+    """Load an optional typed SDK facade without making it a kernel dependency."""
+
+    candidates = tuple(
+        entry
+        for entry in metadata.entry_points(group="liteyukibot.runtime_api_proxies")
+        if entry.name == f"{binding.runtime}.{binding.api}"
+    )
+    if len(candidates) > 1:
+        names = ", ".join(entry.name for entry in candidates)
+        raise RuntimeError(f"multiple runtime API proxy providers found for {names}")
+    if not candidates:
+        return RuntimeNamespaceProxy(binding, backend, context, reason=reason)
+    factory = candidates[0].load()
+    if not callable(factory):
+        raise RuntimeError(f"runtime API proxy provider {candidates[0].name!r} is not callable")
+    provider = cast(RuntimeProxyFactory, factory)
+    return provider(binding=binding, backend=backend, context=context, reason=reason)
+
+
+def runtime(
+    runtime_name: str,
+    *,
+    api: str,
+    version: str = "^1.0",
+    optional: bool = False,
+    as_: str,
+    bridge_id: str | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Declare and later inject one runtime namespace proxy into a callable."""
+
+    binding = RuntimeBinding(
+        runtime=_identifier(runtime_name, "runtime name"),
+        api=_identifier(api, "runtime API namespace"),
+        version=_identifier(version, "runtime API version"),
+        optional=optional,
+        alias=_identifier(as_, "runtime API alias"),
+        bridge_id=None if bridge_id is None else _identifier(bridge_id, "runtime API bridge_id"),
+    )
+
+    def decorate(function: Callable[..., Any]) -> Callable[..., Any]:
+        if not callable(function):
+            raise TypeError("@runtime can decorate only callables")
+        try:
+            parameter = inspect.signature(function).parameters[binding.alias]
+        except (KeyError, TypeError, ValueError) as error:
+            raise TypeError(f"@runtime requires a parameter named {binding.alias!r}") from error
+        if parameter.kind is not inspect.Parameter.KEYWORD_ONLY:
+            raise TypeError(f"@runtime parameter {binding.alias!r} must be keyword-only")
+        existing = tuple(getattr(function, RUNTIME_BINDINGS_ATTRIBUTE, ()))
+        if any(item.alias == binding.alias for item in existing):
+            raise TypeError(f"@runtime alias {binding.alias!r} is duplicated")
+        setattr(function, RUNTIME_BINDINGS_ATTRIBUTE, (*existing, binding))
+        return function
+
+    return decorate
+
+
+def runtime_bindings(function: Callable[..., Any]) -> tuple[RuntimeBinding, ...]:
+    """Return static runtime metadata without importing a framework SDK."""
+
+    return tuple(getattr(function, RUNTIME_BINDINGS_ATTRIBUTE, ()))
+
+
+def validate_runtime_bindings(
+    function: Callable[..., Any], requirements: tuple[RuntimeRequirement, ...]
+) -> None:
+    """Reject undeclared or ambiguous runtime namespaces at host registration time."""
+
+    for binding in runtime_bindings(function):
+        candidates = [
+            requirement
+            for requirement in requirements
+            if requirement.runtime == binding.runtime
+            and requirement.api == binding.api
+            and requirement.version == binding.version
+            and requirement.optional == binding.optional
+            and (requirement.bridge_id is None or binding.bridge_id in (None, requirement.bridge_id))
+        ]
+        if binding.bridge_id is not None:
+            exact = [item for item in candidates if item.bridge_id == binding.bridge_id]
+            candidates = exact or [item for item in candidates if item.bridge_id is None]
+        if len(candidates) != 1:
+            raise TypeError(
+                f"runtime binding {binding.runtime}.{binding.api} is not uniquely declared by the extension manifest"
+            )
+
+
+async def invoke_with_runtime(
+    function: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: Mapping[str, Any],
+    *,
+    context_factory: RuntimeContextFactory,
+    resolver: RuntimeResolver,
+) -> Any:
+    """Invoke one decorated callable with host-owned namespace proxies."""
+
+    bound_kwargs = dict(kwargs)
+    context = context_factory(args, bound_kwargs)
+    for binding in runtime_bindings(function):
+        bound_kwargs[binding.alias] = resolver(binding, context)
+    result = function(*args, **bound_kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+def runtime_handler(
+    function: Callable[..., Any],
+    *,
+    context_factory: RuntimeContextFactory,
+    resolver: RuntimeResolver,
+) -> Callable[..., Awaitable[Any]]:
+    """Return an async lifecycle wrapper for an existing host callback."""
+
+    if not runtime_bindings(function):
+        async def plain(*args: Any, **kwargs: Any) -> Any:
+            result = function(*args, **kwargs)
+            return await result if inspect.isawaitable(result) else result
+
+        return plain
+
+    @wraps(function)
+    async def wrapped(*args: Any, **kwargs: Any) -> Any:
+        return await invoke_with_runtime(
+            function,
+            args,
+            kwargs,
+            context_factory=context_factory,
+            resolver=resolver,
+        )
+
+    return wrapped
+
+
+__all__ = [
+    "RuntimeApiBackend",
+    "RuntimeApiError",
+    "RuntimeApiProxy",
+    "RuntimeBinding",
+    "RuntimeCallContext",
+    "RuntimeNamespaceProxy",
+    "RuntimeProxyFactory",
+    "RuntimeRequirement",
+    "RuntimeUnavailable",
+    "invoke_with_runtime",
+    "create_runtime_proxy",
+    "runtime",
+    "runtime_bindings",
+    "runtime_handler",
+    "validate_runtime_bindings",
+]

--- a/tests/test_broker_business.py
+++ b/tests/test_broker_business.py
@@ -181,12 +181,12 @@ def test_business_catalog_rejects_wrong_lane_and_type_id() -> None:
         BridgeControlResult(invocation_id="control-invocation-1", success=False, error_code="DENIED"),
     ),
 )
-def test_business_models_emit_protocol_six_and_reject_protocol_five(message: BrokerBusinessMessage) -> None:
-    assert message.protocol == 6
-    assert message.model_dump(mode="json")["protocol"] == 6
+def test_business_models_emit_protocol_seven_and_reject_protocol_six(message: BrokerBusinessMessage) -> None:
+    assert message.protocol == 7
+    assert message.model_dump(mode="json")["protocol"] == 7
 
     with pytest.raises(ValidationError):
-        type(message).model_validate({**message.model_dump(mode="json"), "protocol": 5})
+        type(message).model_validate({**message.model_dump(mode="json"), "protocol": 6})
 
 
 def test_duplicate_action_request_does_not_redispatch_owner_and_replays_retained_result() -> None:

--- a/tests/test_broker_peer.py
+++ b/tests/test_broker_peer.py
@@ -61,6 +61,7 @@ def test_manifest_is_immutable_json_safe_and_rejects_invalid_declarations() -> N
         "action_resources": [{"kind": "message.send", "resource_prefix": "bot:"}],
         "tools": [],
         "controls": [],
+        "runtime_apis": [],
     }
     with pytest.raises(ValidationError, match="duplicates"):
         BridgeManifest(

--- a/tests/test_broker_runtime_api.py
+++ b/tests/test_broker_runtime_api.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+
+import pytest
+import zmq.asyncio
+
+from liteyukibot.broker import (
+    AuthorizationContextWire,
+    BridgeAccess,
+    BridgeClient,
+    BridgeManifest,
+    BridgeSession,
+    BrokerAdmissionError,
+    BrokerBridgeRunner,
+    BrokerDelivery,
+    BrokerLedger,
+    BrokerPeerServer,
+    EventIngress,
+    RuntimeApiDeclaration,
+    RuntimeApiInvoke,
+    RuntimeApiOutcome,
+)
+
+
+def _session(
+    bridge_id: str,
+    *,
+    runtime_apis: tuple[RuntimeApiDeclaration, ...] = (),
+    subscriptions: tuple[str, ...] = (),
+) -> BridgeSession:
+    return BridgeSession(
+        bridge_id=bridge_id,
+        session_id=f"session-{bridge_id}",
+        manifest=BridgeManifest(
+            bridge_id=bridge_id,
+            access=BridgeAccess.LIMITED,
+            subscriptions=subscriptions,
+            runtime_apis=runtime_apis,
+        ),
+        peer_identity=f"{bridge_id}-peer".encode(),
+    )
+
+
+def _declaration(version: str = "1.0") -> RuntimeApiDeclaration:
+    return RuntimeApiDeclaration(
+        runtime_kind="astrbot",
+        namespace="event",
+        operation="snapshot",
+        version=version,
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+
+
+def test_broker_routes_runtime_api_to_the_unique_version_compatible_owner() -> None:
+    ledger = BrokerLedger()
+    source = _session("source")
+    caller = _session("kernel", subscriptions=("message.created",))
+    owner = _session("astrbot", runtime_apis=(_declaration(),))
+    event = ledger.admit_event(
+        source,
+        EventIngress(
+            source_event_id="source-event",
+            topic="message.created",
+            ordering_key="chat:1",
+            payload={"bot_id": "bot-1", "actor": {"id": "actor-1"}},
+        ),
+        (source, caller, owner),
+    )
+    delivery = next(
+        item for item in ledger.offered_deliveries(event.kernel_event_id) if item.target_bridge_id == "kernel"
+    )
+    ledger.accept_delivery(caller, delivery.delivery_id, delivery.lease_id)
+    ledger.activate_delivery(caller, delivery.delivery_id, delivery.lease_id)
+    request = RuntimeApiInvoke(
+        delivery_id=delivery.delivery_id,
+        source_event_id=event.source_event_id,
+        lease_id=delivery.lease_id,
+        correlation_id="runtime-call-1",
+        runtime_kind="astrbot",
+        version="^1.0",
+        api_id="event.snapshot",
+        caller_extension_id="example.runtime",
+        authorization=AuthorizationContextWire(
+            event_id=event.kernel_event_id,
+            runtime_id="source",
+            bot_id="bot-1",
+            actor_id="actor-1",
+        ),
+    )
+
+    routed = ledger.route_runtime_api(caller, request, (source, caller, owner))
+    assert routed.target.bridge_id == "astrbot"
+    with pytest.raises(BrokerAdmissionError, match="runtime API ownership"):
+        ledger.route_runtime_api(
+            caller,
+            request.model_copy(update={"version": "^2.0", "correlation_id": "runtime-call-2"}),
+            (source, caller, owner),
+        )
+
+
+async def _pump_business(server: BrokerPeerServer) -> None:
+    while True:
+        await server.serve_business_once()
+
+
+@pytest.mark.asyncio
+async def test_runtime_api_runner_round_trip_preserves_source_event_identity() -> None:
+    context = zmq.asyncio.Context()
+    server = BrokerPeerServer(
+        context=context,
+        endpoint="inproc://broker-runtime-api",
+        generation=1,
+        instance_tokens={"source": "source-token", "kernel": "kernel-token", "astrbot": "astrbot-token"},
+    )
+    completed = asyncio.Event()
+    received: list[tuple[str, str]] = []
+    broker_task: asyncio.Task[None] | None = None
+    caller_task: asyncio.Task[None] | None = None
+    owner_task: asyncio.Task[None] | None = None
+
+    async def on_delivery(delivery: BrokerDelivery) -> None:
+        result = await delivery.request_runtime_api(
+            correlation_id="runtime-round-trip",
+            runtime_kind="astrbot",
+            version="^1.0",
+            api_id="event.snapshot",
+            caller_extension_id="example.runtime",
+            authorization=AuthorizationContextWire(
+                event_id=delivery.message.event.kernel_event_id,
+                runtime_id="source",
+                bot_id="bot-1",
+                actor_id="actor-1",
+            ),
+        )
+        assert result.success
+        assert isinstance(result.result, Mapping)
+        received.append((str(result.result["source_event_id"]), result.invocation_id))
+        completed.set()
+
+    async def provide(request: RuntimeApiInvoke) -> RuntimeApiOutcome:
+        assert request.source_event_id == "source-event"
+        assert request.version == "^1.0"
+        return RuntimeApiOutcome(success=True, result={"source_event_id": request.source_event_id})
+
+    source = BridgeClient(
+        context=context,
+        endpoints=server.endpoints,
+        generation=1,
+        identity=b"source",
+        manifest=BridgeManifest(bridge_id="source", access=BridgeAccess.LIMITED),
+        instance_token="source-token",
+    )
+    caller = BrokerBridgeRunner(
+        BridgeClient(
+            context=context,
+            endpoints=server.endpoints,
+            generation=1,
+            identity=b"kernel",
+            manifest=BridgeManifest(
+                bridge_id="kernel",
+                access=BridgeAccess.FULL,
+                subscriptions=("message.created",),
+            ),
+            instance_token="kernel-token",
+        ),
+        event_handler=on_delivery,
+    )
+    owner = BrokerBridgeRunner(
+        BridgeClient(
+            context=context,
+            endpoints=server.endpoints,
+            generation=1,
+            identity=b"astrbot",
+            manifest=BridgeManifest(
+                bridge_id="astrbot",
+                access=BridgeAccess.LIMITED,
+                runtime_apis=(_declaration(),),
+            ),
+            instance_token="astrbot-token",
+        ),
+        runtime_api_handlers={"event.snapshot": provide},
+    )
+    try:
+        registration = asyncio.create_task(source.register())
+        await server.serve_control_once()
+        await registration
+        for runner in (caller, owner):
+            start = asyncio.create_task(runner.start())
+            await server.serve_control_once()
+            await start
+        broker_task = asyncio.create_task(_pump_business(server))
+        caller_task = asyncio.create_task(caller.serve_forever())
+        owner_task = asyncio.create_task(owner.serve_forever())
+        await source.send_event_ingress(
+            EventIngress(
+                source_event_id="source-event",
+                topic="message.created",
+                ordering_key="chat:1",
+                payload={"bot_id": "bot-1", "actor": {"id": "actor-1"}},
+            )
+        )
+        await asyncio.wait_for(completed.wait(), timeout=1)
+        assert received and received[0][0] == "source-event"
+    finally:
+        for task in (owner_task, caller_task, broker_task):
+            if task is not None:
+                task.cancel()
+        await asyncio.gather(
+            *(task for task in (owner_task, caller_task, broker_task) if task is not None),
+            return_exceptions=True,
+        )
+        owner.close()
+        caller.close()
+        source.close()
+        server.close()
+        context.term()

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+
+from liteyukibot import (
+    AuthorizationContext,
+    RuntimeBinding,
+    RuntimeCallContext,
+    RuntimeNamespaceProxy,
+    RuntimeRequirement,
+    RuntimeUnavailable,
+    runtime,
+    runtime_bindings,
+    runtime_handler,
+)
+from liteyukibot.events import ConversationRef, EventEnvelope, JsonValue
+from liteyukibot.plugins import ExtensionManifest
+
+
+def _event() -> EventEnvelope:
+    return EventEnvelope(
+        runtime_id="astrbot",
+        adapter="qq",
+        bot_id="bot-1",
+        type="message.created",
+        conversation=ConversationRef(id="chat-1", type="group"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_decorator_injects_one_json_safe_proxy() -> None:
+    event = _event()
+    calls: list[tuple[str, Mapping[str, JsonValue]]] = []
+
+    class Backend:
+        async def invoke(
+            self,
+            binding: RuntimeBinding,
+            operation: str,
+            arguments: Mapping[str, JsonValue],
+            _context: RuntimeCallContext,
+        ) -> dict[str, JsonValue]:
+            calls.append((f"{binding.runtime}.{binding.api}.{operation}", arguments))
+            return {"ok": True}
+
+    binding = RuntimeBinding("astrbot", "event", "^1.0", False, "astrbot")
+
+    @runtime("astrbot", api="event", version="^1.0", as_="astrbot")
+    async def handler(received: EventEnvelope, *, astrbot: RuntimeNamespaceProxy) -> object:
+        assert received is event
+        assert astrbot.available
+        return await astrbot.call("snapshot")
+
+    result = await runtime_handler(
+        handler,
+        context_factory=lambda _args, _kwargs: RuntimeCallContext(
+            "example.plugin",
+            event,
+            AuthorizationContext(event.id, event.runtime_id, event.bot_id),
+        ),
+        resolver=lambda received_binding, context: RuntimeNamespaceProxy(
+            received_binding,
+            Backend(),
+            context,
+        ),
+    )(event)
+
+    assert result == {"ok": True}
+    assert runtime_bindings(handler) == (binding,)
+    assert calls == [("astrbot.event.snapshot", {})]
+
+
+@pytest.mark.asyncio
+async def test_optional_runtime_proxy_fails_closed_when_unavailable() -> None:
+    binding = RuntimeBinding("astrbot", "event", "^1.0", True, "astrbot")
+    context = RuntimeCallContext("example.plugin", _event(), AuthorizationContext("event", "astrbot", "bot-1"))
+    proxy = RuntimeNamespaceProxy(binding, None, context)
+
+    assert not proxy.available
+    with pytest.raises(RuntimeUnavailable, match="astrbot.event"):
+        await proxy.call("snapshot")
+
+
+def test_runtime_requirements_are_explicit_manifest_capabilities() -> None:
+    requirement = RuntimeRequirement(
+        runtime="astrbot",
+        api="event",
+        version="^1.0",
+        operations=("snapshot", "send"),
+    )
+    manifest = ExtensionManifest(
+        id="example.runtime",
+        name="Runtime Example",
+        version="1.0.0",
+        runtime_requirements=(requirement,),
+    )
+
+    assert manifest.runtime_capabilities == frozenset(
+        {
+            "runtime.astrbot.event.snapshot",
+            "runtime.astrbot.event.send",
+        }
+    )
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        ExtensionManifest(
+            id="example.runtime",
+            name="Runtime Example",
+            version="1.0.0",
+            runtime_requirements=(requirement, requirement),
+        )

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -16,7 +16,6 @@ from liteyukibot import (
     runtime_handler,
 )
 from liteyukibot.events import ConversationRef, EventEnvelope, JsonValue
-from liteyukibot.plugins import ExtensionManifest
 
 
 def _event() -> EventEnvelope:
@@ -81,32 +80,3 @@ async def test_optional_runtime_proxy_fails_closed_when_unavailable() -> None:
     assert not proxy.available
     with pytest.raises(RuntimeUnavailable, match="astrbot.event"):
         await proxy.call("snapshot")
-
-
-def test_runtime_requirements_are_explicit_manifest_capabilities() -> None:
-    requirement = RuntimeRequirement(
-        runtime="astrbot",
-        api="event",
-        version="^1.0",
-        operations=("snapshot", "send"),
-    )
-    manifest = ExtensionManifest(
-        id="example.runtime",
-        name="Runtime Example",
-        version="1.0.0",
-        runtime_requirements=(requirement,),
-    )
-
-    assert manifest.runtime_capabilities == frozenset(
-        {
-            "runtime.astrbot.event.snapshot",
-            "runtime.astrbot.event.send",
-        }
-    )
-    with pytest.raises(ValueError, match="must not contain duplicates"):
-        ExtensionManifest(
-            id="example.runtime",
-            name="Runtime Example",
-            version="1.0.0",
-            runtime_requirements=(requirement, requirement),
-        )

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -9,7 +9,6 @@ from liteyukibot import (
     RuntimeBinding,
     RuntimeCallContext,
     RuntimeNamespaceProxy,
-    RuntimeRequirement,
     RuntimeUnavailable,
     runtime,
     runtime_bindings,


### PR DESCRIPTION
## Scope

Alpha8a foundation layer for the v7 runtime bridge API.

- Adds the Broker protocol v7 runtime API catalog and invoke/result messages.
- Adds active-delivery routing with source-event provenance, leases, replay protection, version matching, capability checks, and JSON Schema validation.
- Adds the framework-neutral runtime requirement, decorator, proxy, and unavailable-runtime contract.
- Adds maintained runtime API and v7 IPC specifications.

## Validation

- `uv run pytest tests/test_broker_runtime_api.py tests/test_runtime_api.py packages/runtime-astrbot-api/tests -q`
- `uv run ruff check src tests scripts examples packages`
- `uv run mypy`
- Full external-copy validation in `F:\\tmp\\liteyukibot`: 699 passed, 11 skipped, all package builds passed.

This is the bottom layer of Stack #238. Alpha8b DevCLI and atomic update work is intentionally out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a versioned Runtime API for extensions, including declarations, capability checks, proxy-based calls, and structured errors.
  - Added broker support for routing, validating, and returning Runtime API requests and results.
  - Introduced compatibility matching for Runtime API versions and JSON input/output validation.
- **Documentation**
  - Added Runtime API and Broker IPC v7 specifications.
  - Updated roadmap and specification indexes to reflect the Alpha 8a/8b release gates.
- **Tests**
  - Added coverage for runtime invocation, routing, version compatibility, validation, and unavailable optional APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->