### PR TITLE
feat(runtime): integrate runtime APIs with plugin hosts

### DIFF
--- a/packages/cordis/src/liteyukibot_cordis/core.py
+++ b/packages/cordis/src/liteyukibot_cordis/core.py
@@ -11,6 +11,7 @@ from time import monotonic
 from typing import Protocol, cast
 
 from liteyukibot.events import ActionEnvelope, ActionResult, EventBus, EventEnvelope, HandlerResult, Subscription
+from liteyukibot.runtime_api import RuntimeContextFactory, RuntimeRequirement, RuntimeResolver
 
 from .audit import CordisAuditService
 from .scope import Disposer, RegistrationSink, Scope
@@ -80,12 +81,24 @@ class CordisManager(RegistrationSink):
     """One EventBus subscriber that composes Cordis plugin registrations."""
 
     def __init__(
-        self, events: EventBus, actions: ActionServiceLike, *, audit: CordisAuditService | None = None
+        self,
+        events: EventBus,
+        actions: ActionServiceLike,
+        *,
+        audit: CordisAuditService | None = None,
+        runtime_context_factory: Callable[[str], RuntimeContextFactory] | None = None,
+        runtime_resolver: RuntimeResolver | None = None,
     ) -> None:
         self.events = events
         self.actions = actions
         self.audit = audit or CordisAuditService()
-        self.scope = Scope(plugin_id="liteyukibot.cordis", sink=self, audit=self.audit)
+        self.scope = Scope(
+            plugin_id="liteyukibot.cordis",
+            sink=self,
+            audit=self.audit,
+            runtime_context_factory=runtime_context_factory,
+            runtime_resolver=runtime_resolver,
+        )
         self._registrations: list[_Registration] = []
         self._scheduler_tasks: dict[Scope, set[asyncio.Task[None]]] = {}
         self._plugin_scopes: dict[str, Scope] = {}
@@ -109,10 +122,17 @@ class CordisManager(RegistrationSink):
 
         return tuple(self._plugin_scopes)
 
-    async def activate(self, plugin_id: str, factory: PluginFactory, *, declared_tools: tuple[str, ...] = ()) -> Scope:
+    async def activate(
+        self,
+        plugin_id: str,
+        factory: PluginFactory,
+        *,
+        declared_tools: tuple[str, ...] = (),
+        runtime_requirements: tuple[RuntimeRequirement, ...] = (),
+    ) -> Scope:
         if plugin_id in self._plugin_scopes:
             raise ValueError(f"Cordis plugin {plugin_id!r} is already activated")
-        scope = self.scope.child(plugin_id=plugin_id)
+        scope = self.scope.child(plugin_id=plugin_id, runtime_requirements=runtime_requirements)
         started = monotonic()
         try:
             result = factory(scope)

--- a/packages/cordis/src/liteyukibot_cordis/host.py
+++ b/packages/cordis/src/liteyukibot_cordis/host.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from importlib import metadata
 from inspect import isawaitable
@@ -16,14 +16,18 @@ from liteyukibot.plugins import (
     ExtensionManifest,
     PluginContext,
     PluginDefinition,
+    PluginEventBus,
     PluginHandle,
     PluginPaths,
     PluginServices,
     ToolCallback,
     ToolDeclaration,
+    _default_runtime_context_factory,
     _PluginCleanup,
+    _unavailable_runtime_resolver,
 )
 from liteyukibot.resource_packs import ResourcePackDeclaration
+from liteyukibot.runtime_api import RuntimeContextFactory, RuntimeResolver
 from liteyukibot.services import ServiceKey, ServiceRegistry
 from liteyukibot.tasks import ManagedTasks
 
@@ -71,8 +75,17 @@ class CordisHost:
         services: ServiceRegistry | None = None,
         data_dir: Any = None,
         cache_dir: Any = None,
+        runtime_context_factory: Callable[[str], RuntimeContextFactory] | None = None,
+        runtime_resolver: RuntimeResolver | None = None,
+        runtime_targets: Mapping[str, str] | None = None,
     ) -> None:
-        self.manager = CordisManager(events, actions, audit=CordisAuditService(logger=logger))
+        self.manager = CordisManager(
+            events,
+            actions,
+            audit=CordisAuditService(logger=logger),
+            runtime_context_factory=runtime_context_factory,
+            runtime_resolver=runtime_resolver,
+        )
         self.settings = settings
         self._definitions = discover_cordis_plugins(settings.enabled)
         self._tool_handlers: dict[str, ToolCallback] = {}
@@ -86,6 +99,9 @@ class CordisHost:
             cache_dir=cache_dir,
             access=settings.access,
             function_hosts=self._function_hosts,
+            runtime_context_factory=runtime_context_factory,
+            runtime_resolver=runtime_resolver,
+            runtime_targets=runtime_targets,
         )
         self.manager.scope.provide("liteyukibot.native_adapter", lambda: self._native_adapter)
 
@@ -116,6 +132,14 @@ class CordisHost:
             if definition.manifest is not None and definition.manifest.resource_packs
         }
 
+    @property
+    def runtime_manifests(self) -> Mapping[str, ExtensionManifest]:
+        return {
+            plugin_id: definition.manifest
+            for plugin_id, definition in self._definitions.items()
+            if definition.manifest is not None
+        }
+
     def bind_function_hosts(self, hosts: Mapping[str, FunctionHost]) -> None:
         if self.manager.active_plugin_ids:
             raise RuntimeError("Cordis Function Hosts must be bound before host start")
@@ -134,6 +158,7 @@ class CordisHost:
                 plugin_id,
                 _configured_factory(definition.factory, config, self._function_hosts.get(plugin_id)),
                 declared_tools=definition.tool_ids,
+                runtime_requirements=() if definition.manifest is None else definition.manifest.runtime_requirements,
             )
         await self.manager.start()
 
@@ -181,7 +206,9 @@ def host_factory(
     services: ServiceRegistry | None = None,
     data_dir: Any = None,
     cache_dir: Any = None,
-    **_kwargs: Any,
+    runtime_context_factory: Callable[[str], RuntimeContextFactory] | None = None,
+    runtime_resolver: RuntimeResolver | None = None,
+    runtime_targets: Mapping[str, str] | None = None,
 ) -> CordisHost:
     return CordisHost(
         events,
@@ -191,6 +218,9 @@ def host_factory(
         services=services,
         data_dir=data_dir,
         cache_dir=cache_dir,
+        runtime_context_factory=runtime_context_factory,
+        runtime_resolver=runtime_resolver,
+        runtime_targets=runtime_targets,
     )
 
 
@@ -206,6 +236,9 @@ class _NativeAdapter:
         cache_dir: Any,
         access: Mapping[str, str],
         function_hosts: Mapping[str, FunctionHost] | None = None,
+        runtime_context_factory: Callable[[str], RuntimeContextFactory] | None = None,
+        runtime_resolver: RuntimeResolver | None = None,
+        runtime_targets: Mapping[str, str] | None = None,
     ) -> None:
         self.events = events
         self.actions = actions
@@ -215,6 +248,11 @@ class _NativeAdapter:
         self.cache_dir = cache_dir
         self.access = access
         self.function_hosts = dict(function_hosts or {})
+        self.runtime_context_factory_factory = runtime_context_factory or (
+            lambda _extension_id: _default_runtime_context_factory
+        )
+        self.runtime_resolver = runtime_resolver or _unavailable_runtime_resolver
+        self.runtime_targets = dict(runtime_targets or {})
 
     async def activate(self, scope: Scope, plugin_id: str) -> None:
         if self.services is None:
@@ -234,13 +272,27 @@ class _NativeAdapter:
         if manifest.id != plugin_id:
             raise RuntimeError(f"Native plugin manifest ID {manifest.id!r} does not match {plugin_id!r}")
         full_access = plugin_id not in self.access
-        if not full_access and manifest.capabilities:
+        requested_capabilities = frozenset((*manifest.capabilities, *manifest.runtime_capabilities))
+        if not full_access and requested_capabilities:
             authorizer = services.get(ServiceKey("liteyukibot.permissions", 2))
             activation_allowed = getattr(authorizer, "activation_allowed", None)
             if not callable(activation_allowed) or not activation_allowed(
-                manifest.id, frozenset(manifest.capabilities)
+                manifest.id, requested_capabilities
             ):
                 raise RuntimeError(f"extension {manifest.id} requested capabilities outside its configured ceiling")
+        missing_runtime_requirements = tuple(
+            requirement
+            for requirement in manifest.runtime_requirements
+            if not requirement.optional
+            and not any(
+                kind == requirement.runtime
+                and (requirement.bridge_id is None or bridge_id == requirement.bridge_id)
+                for bridge_id, kind in self.runtime_targets.items()
+            )
+        )
+        if missing_runtime_requirements:
+            names = ", ".join(f"{item.runtime}.{item.api}" for item in missing_runtime_requirements)
+            raise RuntimeError(f"extension {manifest.id} requires unavailable runtime APIs: {names}")
         plugin_logger = self.logger.bind(plugin=plugin_id, component="cordis-plugin")
         tasks = ManagedTasks(plugin_id)
         paths = None
@@ -252,19 +304,27 @@ class _NativeAdapter:
             paths.cache.mkdir(parents=True, exist_ok=True)
         cleanup = _PluginCleanup()
         tool_handlers: dict[str, ToolCallback] = {}
+        runtime_context_factory = self.runtime_context_factory_factory(plugin_id)
         context = PluginContext(
             id=plugin_id,
             config=scope.config,
             logger=plugin_logger,
             services=PluginServices(manifest, services),
             tasks=tasks,
-            events=self.events,
+            events=PluginEventBus(
+                self.events,
+                context_factory=runtime_context_factory,
+                resolver=self.runtime_resolver,
+                requirements=manifest.runtime_requirements,
+            ),
             actions=self.actions,
             paths=paths,
             function_host=self.function_hosts.get(plugin_id),
             _manifest=manifest,
             _cleanup=cleanup,
             _tool_handlers=tool_handlers,
+            _runtime_context_factory=runtime_context_factory,
+            _runtime_resolver=self.runtime_resolver,
         )
         handle: PluginHandle = PluginHandle()
         try:

--- a/packages/cordis/src/liteyukibot_cordis/scope.py
+++ b/packages/cordis/src/liteyukibot_cordis/scope.py
@@ -9,6 +9,14 @@ from dataclasses import dataclass
 from typing import Any, Protocol, cast
 from uuid import uuid4
 
+from liteyukibot.runtime_api import (
+    RuntimeContextFactory,
+    RuntimeRequirement,
+    RuntimeResolver,
+    runtime_handler,
+    validate_runtime_bindings,
+)
+
 from .audit import CordisAuditService
 
 type Provider = Callable[[Scope], Any] | Callable[[], Any]
@@ -42,6 +50,9 @@ class Scope:
         parent: Scope | None = None,
         sink: RegistrationSink | None = None,
         audit: CordisAuditService | None = None,
+        runtime_context_factory: Callable[[str], RuntimeContextFactory] | None = None,
+        runtime_resolver: RuntimeResolver | None = None,
+        runtime_requirements: tuple[RuntimeRequirement, ...] = (),
     ) -> None:
         self.id = str(uuid4())
         self.plugin_id = plugin_id
@@ -52,6 +63,19 @@ class Scope:
         self._sink: RegistrationSink | None = sink if sink is not None else parent._sink if parent is not None else None
         self._audit: CordisAuditService = (
             audit if audit is not None else parent._audit if parent is not None else CordisAuditService()
+        )
+        self._runtime_context_factory_factory: Callable[[str], RuntimeContextFactory] | None = (
+            runtime_context_factory
+            if runtime_context_factory is not None
+            else parent._runtime_context_factory_factory
+            if parent is not None
+            else None
+        )
+        self._runtime_resolver = runtime_resolver
+        if self._runtime_resolver is None and parent is not None:
+            self._runtime_resolver = parent._runtime_resolver
+        self._runtime_requirements: tuple[RuntimeRequirement, ...] = runtime_requirements or (
+            parent._runtime_requirements if parent is not None else ()
         )
         self._providers: dict[Hashable, Provider] = {}
         self._instances: dict[Hashable, object] = {}
@@ -66,9 +90,20 @@ class Scope:
     def closed(self) -> bool:
         return self._closed
 
-    def child(self, *, plugin_id: str | None = None, config: Mapping[str, object] | None = None) -> Scope:
+    def child(
+        self,
+        *,
+        plugin_id: str | None = None,
+        config: Mapping[str, object] | None = None,
+        runtime_requirements: tuple[RuntimeRequirement, ...] = (),
+    ) -> Scope:
         self._ensure_open()
-        return Scope(plugin_id=plugin_id or self.plugin_id, config=config, parent=self)
+        return Scope(
+            plugin_id=plugin_id or self.plugin_id,
+            config=config,
+            parent=self,
+            runtime_requirements=runtime_requirements,
+        )
 
     def provide(self, key: Hashable, provider: Provider) -> None:
         self._ensure_open()
@@ -136,21 +171,21 @@ class Scope:
         self.own(self._sink.register(self, kind, value))
 
     def on(self, handler: object, *, order: int = 0) -> None:
-        self._register("ordered", (order, handler))
+        self._register("ordered", (order, self._wrap_handler(handler)))
 
     def parallel(self, handler: object) -> None:
-        self._register("parallel", handler)
+        self._register("parallel", self._wrap_handler(handler))
 
     def middleware(self, handler: object) -> None:
-        self._register("waterfall", handler)
+        self._register("waterfall", self._wrap_handler(handler))
 
     def route(self, name: str, predicate: object, handler: object) -> None:
         if not name:
             raise ValueError("route name must not be empty")
-        self._register("route", (name, predicate, handler))
+        self._register("route", (name, self._wrap_handler(predicate), self._wrap_handler(handler)))
 
     def schedule(self, scheduler: object) -> None:
-        self._register("scheduler", scheduler)
+        self._register("scheduler", self._wrap_handler(scheduler))
 
     def tool(self, tool_id: str, handler: object) -> None:
         """Register exactly one handler for a declared Extension API v2 Tool."""
@@ -159,7 +194,17 @@ class Scope:
             raise ValueError("Tool ID must be non-empty")
         if not callable(handler):
             raise TypeError("Tool handler must be callable")
-        self._register("tool", (tool_id, handler))
+        self._register("tool", (tool_id, self._wrap_handler(handler)))
+
+    def _wrap_handler(self, handler: object) -> object:
+        if self._runtime_context_factory_factory is None or self._runtime_resolver is None or not callable(handler):
+            return handler
+        validate_runtime_bindings(handler, self._runtime_requirements)
+        return runtime_handler(
+            handler,
+            context_factory=self._runtime_context_factory_factory(self.plugin_id),
+            resolver=self._runtime_resolver,
+        )
 
     async def aclose(self) -> None:
         if self._closed:

--- a/packages/runtime-astrbot-api/README.md
+++ b/packages/runtime-astrbot-api/README.md
@@ -1,0 +1,7 @@
+# LiteyukiBot AstrBot Runtime API
+
+This package contains the framework-neutral typed facade used by the Alpha8
+AstrBot runtime API proof. It deliberately does not depend on AstrBot itself.
+
+Alpha8 exposes only `event.snapshot()` and `event.send(message)`. The broader
+AstrBot facade is deferred to Alpha9.

--- a/packages/runtime-astrbot-api/pyproject.toml
+++ b/packages/runtime-astrbot-api/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "liteyukibot-v7-runtime-astrbot-api"
+version = "7.0.0a3"
+description = "Framework-neutral typed Alpha8 AstrBot runtime API facade."
+readme = "README.md"
+requires-python = ">=3.14"
+license = "LicenseRef-LSO"
+authors = [{ name = "LiteyukiStudio" }]
+dependencies = [
+    "liteyukibot-v7==7.0.0a3",
+]
+
+[project.entry-points."liteyukibot.runtime_api_proxies"]
+"astrbot.event" = "liteyukibot_runtime_astrbot_api:proxy_factory"
+
+[build-system]
+requires = ["uv_build>=0.11.32,<0.12"]
+build-backend = "uv_build"
+
+[tool.uv.sources]
+liteyukibot-v7 = { workspace = true }
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "liteyukibot_runtime_astrbot_api"

--- a/packages/runtime-astrbot-api/src/liteyukibot_runtime_astrbot_api/__init__.py
+++ b/packages/runtime-astrbot-api/src/liteyukibot_runtime_astrbot_api/__init__.py
@@ -1,0 +1,66 @@
+"""Typed, AstrBot-independent Alpha8 runtime API facade."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from pydantic import BaseModel, ConfigDict
+
+from liteyukibot.events import JsonValue
+from liteyukibot.runtime_api import (
+    RuntimeApiBackend,
+    RuntimeApiError,
+    RuntimeBinding,
+    RuntimeCallContext,
+    RuntimeNamespaceProxy,
+)
+
+
+class AstrBotEventSnapshot(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    platform_id: str
+    platform_name: str
+    bot_id: str
+    session_id: str
+    group_id: str | None = None
+    sender_id: str | None = None
+    message: str
+    message_type: str
+
+
+class AstrBotEventProxy(RuntimeNamespaceProxy):
+    """Typed facade for the Alpha8-safe subset of AstrBot's current event."""
+
+    async def snapshot(self) -> AstrBotEventSnapshot:
+        value = await self.call("snapshot")
+        if not isinstance(value, Mapping):
+            raise RuntimeApiError(self.binding.runtime, self.binding.api, "snapshot", "RUNTIME_API_INVALID_RESULT")
+        try:
+            return AstrBotEventSnapshot.model_validate(value)
+        except ValueError as error:
+            raise RuntimeApiError(
+                self.binding.runtime,
+                self.binding.api,
+                "snapshot",
+                "RUNTIME_API_INVALID_RESULT",
+            ) from error
+
+    async def send(self, message: str) -> Mapping[str, JsonValue]:
+        value = await self.call("send", {"message": message})
+        if not isinstance(value, Mapping):
+            raise RuntimeApiError(self.binding.runtime, self.binding.api, "send", "RUNTIME_API_INVALID_RESULT")
+        return value
+
+
+def proxy_factory(
+    *,
+    binding: RuntimeBinding,
+    backend: RuntimeApiBackend | None,
+    context: RuntimeCallContext | None,
+    reason: str = "unavailable",
+) -> AstrBotEventProxy:
+    return AstrBotEventProxy(binding, backend, context, reason=reason)
+
+
+__all__ = ["AstrBotEventProxy", "AstrBotEventSnapshot", "proxy_factory"]

--- a/packages/runtime-astrbot-api/tests/test_proxy.py
+++ b/packages/runtime-astrbot-api/tests/test_proxy.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pytest
+from liteyukibot_runtime_astrbot_api import AstrBotEventProxy
+
+from liteyukibot import AuthorizationContext, RuntimeBinding, RuntimeCallContext
+from liteyukibot.events import ConversationRef, EventEnvelope, JsonValue
+
+
+def _context() -> RuntimeCallContext:
+    event = EventEnvelope(
+        runtime_id="astrbot",
+        adapter="qq",
+        bot_id="bot-1",
+        type="message.created",
+        conversation=ConversationRef(id="chat-1", type="group"),
+    )
+    return RuntimeCallContext("example.plugin", event, AuthorizationContext(event.id, "astrbot", "bot-1"))
+
+
+@pytest.mark.asyncio
+async def test_typed_event_proxy_maps_alpha8_operations() -> None:
+    class Backend:
+        async def invoke(
+            self,
+            _binding: RuntimeBinding,
+            operation: str,
+            arguments: Mapping[str, JsonValue],
+            _context: RuntimeCallContext,
+        ) -> JsonValue:
+            if operation == "snapshot":
+                return {
+                    "platform_id": "onebot",
+                    "platform_name": "qq",
+                    "bot_id": "bot-1",
+                    "session_id": "chat-1",
+                    "message": "hello",
+                    "message_type": "group",
+                }
+            assert arguments == {"message": "pong"}
+            return {"sent": True}
+
+    proxy = AstrBotEventProxy(
+        RuntimeBinding("astrbot", "event", "^1.0", False, "astrbot"),
+        Backend(),
+        _context(),
+    )
+    snapshot = await proxy.snapshot()
+    sent = await proxy.send("pong")
+
+    assert snapshot.session_id == "chat-1"
+    assert sent == {"sent": True}

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
@@ -29,10 +29,13 @@ from liteyukibot.broker import (
     BrokerBridgeRunner,
     EventIngress,
     MessageSendPayload,
+    RuntimeApiDeclaration,
+    RuntimeApiInvoke,
+    RuntimeApiOutcome,
     parse_message_send_request,
 )
 from liteyukibot.config import AppSettings, LoggingSettings
-from liteyukibot.events import JsonValue, Message
+from liteyukibot.events import JsonValue, Message, Segment
 from liteyukibot.logging import configure_logging, get_logger
 from liteyukibot.lyip import LyipLane
 
@@ -103,6 +106,7 @@ class AstrBotGateway:
         self._ingress_sink: IngressSink | None = None
         self._ingress_tasks: set[asyncio.Task[None]] = set()
         self._reply_events: OrderedDict[str, tuple[str, Any]] = OrderedDict()
+        self._events_by_source_id: OrderedDict[str, Any] = OrderedDict()
         self._bot_platforms: dict[str, str] = {}
 
     async def start(self, ingress_sink: IngressSink, *, start_pipeline: bool = True) -> None:
@@ -169,6 +173,7 @@ class AstrBotGateway:
                     await _dispose_astrbot_global_database(self._output)
                 finally:
                     self._reply_events.clear()
+                    self._events_by_source_id.clear()
                     self._bot_platforms.clear()
                     configure_publisher(None)
                     self._remove_import_root()
@@ -182,6 +187,27 @@ class AstrBotGateway:
         except (KeyError, ValueError) as error:
             return ActionOutcome(success=False, payload={"error": "message_send_failed", "message": str(error)})
         return ActionOutcome(success=True, payload=_json_result(result))
+
+    async def execute_runtime_api(self, request: RuntimeApiInvoke) -> RuntimeApiOutcome:
+        event = self._events_by_source_id.get(request.source_event_id)
+        if event is None:
+            return RuntimeApiOutcome(success=False, error_code="RUNTIME_EVENT_UNAVAILABLE")
+        if request.api_id == "event.snapshot":
+            if request.arguments:
+                return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_INVALID_ARGUMENTS")
+            return RuntimeApiOutcome(success=True, result=self._event_snapshot(event))
+        if request.api_id == "event.send":
+            message = request.arguments.get("message")
+            if not isinstance(message, str) or not message.strip() or set(request.arguments) != {"message"}:
+                return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_INVALID_ARGUMENTS")
+            try:
+                result = await event.send(
+                    _to_astr_chain(Message(segments=(Segment(type="text", data={"text": message}),)))
+                )
+            except Exception:
+                return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_SEND_FAILED")
+            return RuntimeApiOutcome(success=True, result={"sent": True, "result": _json_result(result)})
+        return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_NOT_REGISTERED")
 
     def _spawn_ingress(self, event: Any) -> None:
         task = asyncio.create_task(self._publish_ingress(event), name="astrbot-broker-ingress")
@@ -200,9 +226,13 @@ class AstrBotGateway:
         reply_token = f"{platform_id}:{source_event_id}"
         envelope = to_event_envelope(event, reply_token=reply_token)
         self._reply_events[reply_token] = (envelope.bot_id, event)
+        self._events_by_source_id[envelope.id] = event
         self._reply_events.move_to_end(reply_token)
+        self._events_by_source_id.move_to_end(envelope.id)
         while len(self._reply_events) > 2_048:
             self._reply_events.popitem(last=False)
+        while len(self._events_by_source_id) > 2_048:
+            self._events_by_source_id.popitem(last=False)
         self._bot_platforms[envelope.bot_id] = platform_id
         await sink(
             EventIngress(
@@ -246,6 +276,19 @@ class AstrBotGateway:
             if str(platform.meta().id) == platform_id:
                 return platform
         raise ValueError("AstrBot platform is no longer available")
+
+    @staticmethod
+    def _event_snapshot(event: Any) -> dict[str, JsonValue]:
+        return {
+            "platform_id": str(event.get_platform_id()),
+            "platform_name": str(event.get_platform_name()),
+            "bot_id": str(event.get_self_id()),
+            "session_id": str(event.get_session_id()),
+            "group_id": _optional_text(event.get_group_id()),
+            "sender_id": _optional_text(event.get_sender_id()),
+            "message": str(event.get_message_str() or ""),
+            "message_type": str(event.get_message_type()),
+        }
 
     def _install_import_root(self) -> None:
         value = str(self.workspace)
@@ -294,6 +337,7 @@ async def launch(settings: AppSettings, bridge_id: str, token: str) -> None:
             )
             for item in bridge.action_resources
         ),
+        runtime_apis=_runtime_api_declarations(),
     )
     client = BridgeClient(
         context=zmq.asyncio.Context.instance(),
@@ -309,7 +353,14 @@ async def launch(settings: AppSettings, bridge_id: str, token: str) -> None:
         logger,
         settings.logging,
     )
-    runner = BrokerBridgeRunner(client, action_handlers={MESSAGE_SEND_KIND: gateway.execute_message_send})
+    runner = BrokerBridgeRunner(
+        client,
+        action_handlers={MESSAGE_SEND_KIND: gateway.execute_message_send},
+        runtime_api_handlers={
+            "event.snapshot": gateway.execute_runtime_api,
+            "event.send": gateway.execute_runtime_api,
+        },
+    )
     serving: asyncio.Task[None] | None = None
     try:
         await runner.start()
@@ -405,6 +456,39 @@ def _json_result(value: object) -> JsonValue:
     if isinstance(value, (list, tuple)):
         return tuple(_json_result(item) for item in value)
     return type(value).__name__
+
+
+def _optional_text(value: object) -> str | None:
+    rendered = str(value or "").strip()
+    return rendered or None
+
+
+def _runtime_api_declarations() -> tuple[RuntimeApiDeclaration, ...]:
+    return (
+        RuntimeApiDeclaration(
+            runtime_kind="astrbot",
+            namespace="event",
+            operation="snapshot",
+            version="1.0",
+            input_schema={"type": "object", "additionalProperties": False},
+            output_schema={"type": "object", "additionalProperties": True},
+            capabilities=("runtime.astrbot.event.snapshot",),
+        ),
+        RuntimeApiDeclaration(
+            runtime_kind="astrbot",
+            namespace="event",
+            operation="send",
+            version="1.0",
+            input_schema={
+                "type": "object",
+                "properties": {"message": {"type": "string", "minLength": 1}},
+                "required": ["message"],
+                "additionalProperties": False,
+            },
+            output_schema={"type": "object", "additionalProperties": True},
+            capabilities=("runtime.astrbot.event.send",),
+        ),
+    )
 
 
 async def _dispose_astrbot_global_database(output: Any) -> None:

--- a/src/liteyukibot/app.py
+++ b/src/liteyukibot/app.py
@@ -6,6 +6,7 @@ import asyncio
 import math
 import os
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import replace
 from enum import StrEnum
 from pathlib import Path
 from time import monotonic
@@ -63,7 +64,7 @@ from .management import (
 )
 from .operations import ManagementPrincipal, OperationRequest, PrincipalKind
 from .plugin_store import RuntimeGenerationStore
-from .plugins import PluginDefinition, PluginManager, ToolCallback, ToolDeclaration
+from .plugins import ExtensionManifest, PluginDefinition, PluginManager, ToolCallback, ToolDeclaration
 from .resource_packs import RESOURCE_CATALOG_SERVICE, ResourceCatalog, ResourcePackDeclaration
 from .runtime import (
     ActionProvenance,
@@ -73,6 +74,16 @@ from .runtime import (
     RuntimeSpec,
     RuntimeSupervisor,
     json_value,
+)
+from .runtime_api import (
+    RuntimeApiError,
+    RuntimeBinding,
+    RuntimeCallContext,
+    RuntimeContextFactory,
+    RuntimeNamespaceProxy,
+    RuntimeRequirement,
+    RuntimeUnavailable,
+    create_runtime_proxy,
 )
 from .services import ServiceKey, ServiceRegistry
 from .status import KERNEL_STATUS_SERVICE, KernelStatusSnapshot
@@ -158,6 +169,77 @@ class _AgentHistoryProvider:
         return await self._app._clear_agent_history(event)
 
 
+class _ApplicationRuntimeApiBackend:
+    """Authorize and route one plugin runtime call through the active broker lease."""
+
+    def __init__(self, app: LiteyukiApp) -> None:
+        self._app = app
+
+    async def invoke(
+        self,
+        binding: RuntimeBinding,
+        operation: str,
+        arguments: Mapping[str, EventJsonValue],
+        context: RuntimeCallContext,
+    ) -> EventJsonValue:
+        requirement = self._app._find_runtime_requirement(context.extension_id, binding)
+        if requirement is None:
+            raise RuntimeApiError(
+                binding.runtime,
+                binding.api,
+                operation,
+                "RUNTIME_API_NOT_DECLARED",
+            )
+        if operation not in requirement.operations:
+            raise RuntimeApiError(
+                binding.runtime,
+                binding.api,
+                operation,
+                "RUNTIME_API_OPERATION_NOT_DECLARED",
+            )
+        permissions = _permission_service(self._app.services)
+        allows_extension = getattr(permissions, "allows_extension", None)
+        capability = f"runtime.{binding.runtime}.{binding.api}.{operation}"
+        if not callable(allows_extension) or not allows_extension(
+            context.authorization,
+            context.extension_id,
+            capability,
+            full=False,
+        ):
+            raise RuntimeApiError(binding.runtime, binding.api, operation, "RUNTIME_API_PERMISSION_DENIED")
+        peer = self._app._kernel_broker_peer
+        if peer is None:
+            raise RuntimeUnavailable(binding.runtime, binding.api, "kernel broker is unavailable")
+        response = await peer.request_runtime_api(
+            context.event,
+            correlation_id=str(uuid4()),
+            runtime_kind=binding.runtime,
+            version=binding.version,
+            api_id=f"{binding.api}.{operation}",
+            caller_extension_id=context.extension_id,
+            authorization=AuthorizationContextWire(
+                event_id=context.authorization.event_id,
+                runtime_id=context.authorization.runtime_id,
+                bot_id=context.authorization.bot_id,
+                actor_id=context.authorization.actor_id,
+            ),
+            arguments=arguments,
+            bridge_id=binding.bridge_id,
+            timeout_seconds=self._app.settings.broker.delivery_timeout_seconds,
+        )
+        if response is None:
+            raise RuntimeUnavailable(binding.runtime, binding.api, "no active broker delivery")
+        if not response.success:
+            raise RuntimeApiError(
+                binding.runtime,
+                binding.api,
+                operation,
+                response.error_code or "RUNTIME_API_FAILED",
+                response.error_details,
+            )
+        return response.result
+
+
 class LiteyukiApp:
     """Own all v7 services and enforce deterministic startup and shutdown."""
 
@@ -196,6 +278,13 @@ class LiteyukiApp:
         self._kernel_broker_peer: KernelBrokerPeer | None = None
         self._cordis_host: CordisHost | None = None
         self._configured_kernel_bridge = configured_kernel_bridge(settings)
+        self._runtime_targets = {
+            bridge_id: bridge.kind
+            for bridge_id, bridge in settings.broker.bridges.items()
+            if bridge.kind != "kernel"
+        }
+        self._runtime_manifests: dict[str, ExtensionManifest] = {}
+        self._runtime_backend = _ApplicationRuntimeApiBackend(self)
         self._runtime_secrets = dict(runtime_secrets or {})
         self.plugins = PluginManager(
             services=self.services,
@@ -204,6 +293,9 @@ class LiteyukiApp:
             logger=self.logger,
             data_dir=core.data_dir,
             cache_dir=core.cache_dir,
+            runtime_context_factory=self._runtime_context_factory,
+            runtime_resolver=self._resolve_runtime_proxy,
+            runtime_targets=self._runtime_targets,
         )
         self.management = KernelManagement(self, self.resource_workspace, self._request_stop)
         self.control = ControlServer(
@@ -334,6 +426,88 @@ class LiteyukiApp:
         """Bind the host-owned shutdown signal used by the management console."""
 
         self._stop_callback = callback
+
+    def _find_runtime_requirement(
+        self, extension_id: str, binding: RuntimeBinding
+    ) -> RuntimeRequirement | None:
+        manifest = self._runtime_manifests.get(extension_id)
+        if manifest is None:
+            loaded = self.plugins.loaded.get(extension_id)
+            manifest = None if loaded is None else loaded.definition.manifest
+        if manifest is None:
+            return None
+        candidates = [
+            requirement
+            for requirement in manifest.runtime_requirements
+            if requirement.runtime == binding.runtime
+            and requirement.api == binding.api
+            and requirement.version == binding.version
+            and requirement.optional == binding.optional
+            and (requirement.bridge_id is None or binding.bridge_id in (None, requirement.bridge_id))
+        ]
+        if binding.bridge_id is not None:
+            exact = [item for item in candidates if item.bridge_id == binding.bridge_id]
+            candidates = exact or [item for item in candidates if item.bridge_id is None]
+        if len(candidates) != 1:
+            return None
+        return candidates[0]
+
+    def _resolve_runtime_proxy(self, binding: RuntimeBinding, context: RuntimeCallContext) -> RuntimeNamespaceProxy:
+        requirement = self._find_runtime_requirement(context.extension_id, binding)
+        if requirement is None:
+            return create_runtime_proxy(binding, None, context, reason="runtime API is not declared")
+        effective_binding = binding
+        if binding.bridge_id is None and requirement.bridge_id is not None:
+            effective_binding = replace(binding, bridge_id=requirement.bridge_id)
+        targets = tuple(
+            bridge_id
+            for bridge_id, kind in self._runtime_targets.items()
+            if kind == effective_binding.runtime
+            and (effective_binding.bridge_id is None or bridge_id == effective_binding.bridge_id)
+        )
+        if len(targets) != 1:
+            reason = "runtime bridge is not configured" if not targets else "runtime bridge is ambiguous"
+            return create_runtime_proxy(effective_binding, None, context, reason=reason)
+        return create_runtime_proxy(effective_binding, self._runtime_backend, context)
+
+    def _runtime_context_factory(self, extension_id: str) -> RuntimeContextFactory:
+        def create(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> RuntimeCallContext:
+            values = (*args, *kwargs.values())
+            event: EventEnvelope | None = None
+            authorization: AuthorizationContext | None = None
+            for value in values:
+                if isinstance(value, EventEnvelope):
+                    event = value
+                elif isinstance(value, AuthorizationContext):
+                    authorization = value
+                else:
+                    envelope = getattr(value, "envelope", None)
+                    if isinstance(envelope, EventEnvelope):
+                        event = envelope
+                    wrapped_event = getattr(value, "event", None)
+                    envelope = getattr(wrapped_event, "envelope", None)
+                    if isinstance(envelope, EventEnvelope):
+                        event = envelope
+            if event is None and authorization is not None and self._kernel_broker_peer is not None:
+                event = self._kernel_broker_peer.active_event(authorization.event_id)
+            if event is None:
+                raise RuntimeError("runtime API calls require an active broker event")
+            if authorization is None:
+                authorization = AuthorizationContext(
+                    event_id=event.id,
+                    runtime_id=event.runtime_id,
+                    bot_id=event.bot_id,
+                    actor_id=None if event.actor is None else event.actor.id,
+                )
+            elif (
+                authorization.event_id != event.id
+                or authorization.runtime_id != event.runtime_id
+                or authorization.bot_id != event.bot_id
+            ):
+                raise RuntimeError("runtime API authorization does not match the active event")
+            return RuntimeCallContext(extension_id=extension_id, event=event, authorization=authorization)
+
+        return create
 
     def _request_stop(self) -> None:
         if self._stop_callback is None:
@@ -709,7 +883,15 @@ class LiteyukiApp:
                 services=self.services,
                 data_dir=self.settings.core.data_dir,
                 cache_dir=self.settings.core.cache_dir,
+                runtime_context_factory=self._runtime_context_factory,
+                runtime_resolver=self._resolve_runtime_proxy,
+                runtime_targets=self._runtime_targets,
             )
+            self._runtime_manifests = {
+                definition.manifest.id: definition.manifest for definition in definitions.values()
+            }
+            if self._cordis_host is not None:
+                self._runtime_manifests.update(getattr(self._cordis_host, "runtime_manifests", {}))
             validate_extension_topology(
                 self.plugins.identities(definitions),
                 self._cordis_host.plugin_identities if self._cordis_host is not None else (),

--- a/src/liteyukibot/cordis_host.py
+++ b/src/liteyukibot/cordis_host.py
@@ -17,6 +17,7 @@ from .exceptions import PluginError
 from .functions import FunctionHost
 from .plugins import ExtensionCoexistence, ExtensionIdentity, ToolCallback, ToolDeclaration
 from .resource_packs import ResourcePackDeclaration
+from .runtime_api import RuntimeContextFactory, RuntimeResolver
 from .services import ServiceRegistry
 
 if TYPE_CHECKING:
@@ -47,6 +48,9 @@ class CordisHost(Protocol):
     def tool_handlers(self) -> Mapping[str, ToolCallback]: ...
 
     def bind_function_hosts(self, hosts: Mapping[str, FunctionHost]) -> None: ...
+
+    @property
+    def runtime_manifests(self) -> Mapping[str, object]: ...
 
     @property
     def function_resource_packs(self) -> Mapping[str, tuple[ResourcePackDeclaration, ...]]: ...
@@ -98,6 +102,9 @@ def discover_cordis_host(
     services: ServiceRegistry | None = None,
     data_dir: object | None = None,
     cache_dir: object | None = None,
+    runtime_context_factory: Callable[[str], RuntimeContextFactory] | None = None,
+    runtime_resolver: RuntimeResolver | None = None,
+    runtime_targets: Mapping[str, str] | None = None,
 ) -> CordisHost | None:
     """Resolve the one configured host without importing optional packages eagerly."""
 
@@ -126,6 +133,9 @@ def discover_cordis_host(
             "actions": actions,
             "settings": settings,
             "logger": logger,
+            "runtime_context_factory": runtime_context_factory,
+            "runtime_resolver": runtime_resolver,
+            "runtime_targets": runtime_targets,
         }
         if services is not None:
             factory_kwargs.update(services=services, data_dir=data_dir, cache_dir=cache_dir)

--- a/src/liteyukibot/plugins.py
+++ b/src/liteyukibot/plugins.py
@@ -24,6 +24,15 @@ from .events import ActionEnvelope, ActionResult, EventBus, EventEnvelope
 from .exceptions import PluginError, ServiceError
 from .init_specs import PluginInitSpec
 from .resource_packs import ResourcePackDeclaration
+from .runtime_api import (
+    RuntimeCallContext,
+    RuntimeContextFactory,
+    RuntimeNamespaceProxy,
+    RuntimeRequirement,
+    RuntimeResolver,
+    runtime_handler,
+    validate_runtime_bindings,
+)
 from .services import ServiceKey, ServiceRegistry, ServiceRequirement
 from .tasks import ManagedTasks
 
@@ -375,6 +384,7 @@ class ExtensionManifest(BaseModel):
     storage: Literal["none", "private"] = "none"
     resource_packs: tuple[ResourcePackDeclaration, ...] = ()
     capabilities: tuple[str, ...] = ()
+    runtime_requirements: tuple[RuntimeRequirement, ...] = ()
     tools: tuple[ToolDeclaration, ...] = ()
     webui: WebUiContributionManifest | None = None
 
@@ -399,6 +409,14 @@ class ExtensionManifest(BaseModel):
             _validate_capability(capability)
         return value
 
+    @field_validator("runtime_requirements")
+    @classmethod
+    def validate_runtime_requirements(cls, value: tuple[RuntimeRequirement, ...]) -> tuple[RuntimeRequirement, ...]:
+        keys = tuple((item.runtime, item.api, item.bridge_id) for item in value)
+        if len(keys) != len(set(keys)):
+            raise ValueError("extension runtime requirements must not contain duplicates")
+        return value
+
     @field_validator("tools")
     @classmethod
     def validate_tools(cls, value: tuple[ToolDeclaration, ...], info: Any) -> tuple[ToolDeclaration, ...]:
@@ -411,6 +429,14 @@ class ExtensionManifest(BaseModel):
         if any(not tool.id.startswith(prefix) for tool in value):
             raise ValueError("tool IDs must be prefixed by their extension ID")
         return value
+
+    @property
+    def runtime_capabilities(self) -> frozenset[str]:
+        return frozenset(
+            capability
+            for requirement in self.runtime_requirements
+            for capability in requirement.capability_names
+        )
 
 
 # Deprecated source alias. It constructs Extension API v2 values, while an
@@ -454,6 +480,68 @@ def _validate_capability(value: str) -> str:
 
 PluginCallback = Callable[[], Awaitable[None]]
 type CleanupCallback = Callable[[], object]
+
+
+def _default_runtime_context_factory(args: tuple[Any, ...], kwargs: Mapping[str, Any]) -> RuntimeCallContext:
+    values = (*args, *kwargs.values())
+    event = next((value for value in values if isinstance(value, EventEnvelope)), None)
+    if event is None:
+        raise RuntimeError("runtime API calls require an active EventEnvelope")
+    authorization = next((value for value in values if isinstance(value, AuthorizationContext)), None)
+    if authorization is None:
+        authorization = AuthorizationContext(
+            event_id=event.id,
+            runtime_id=event.runtime_id,
+            bot_id=event.bot_id,
+            actor_id=None if event.actor is None else event.actor.id,
+        )
+    elif authorization.event_id != event.id:
+        raise RuntimeError("runtime API authorization does not match the active event")
+    return RuntimeCallContext(extension_id="unknown", event=event, authorization=authorization)
+
+
+def _unavailable_runtime_resolver(binding: Any, context: RuntimeCallContext) -> RuntimeNamespaceProxy:
+    return RuntimeNamespaceProxy(binding, None, context, reason="runtime bridge is not configured")
+
+
+class PluginEventBus:
+    """Plugin-owned EventBus facade that injects declared runtime proxies."""
+
+    def __init__(
+        self,
+        events: EventBus,
+        *,
+        context_factory: RuntimeContextFactory,
+        resolver: RuntimeResolver,
+        requirements: tuple[RuntimeRequirement, ...] = (),
+    ) -> None:
+        self._events = events
+        self._context_factory = context_factory
+        self._resolver = resolver
+        self._requirements = requirements
+
+    @property
+    def closed(self) -> bool:
+        return self._events.closed
+
+    @property
+    def outstanding(self) -> int:
+        return self._events.outstanding
+
+    def subscribe(self, handler: Callable[..., Any], *, order: int = 0, name: str | None = None) -> Any:
+        validate_runtime_bindings(handler, self._requirements)
+        wrapped = runtime_handler(
+            handler,
+            context_factory=self._context_factory,
+            resolver=self._resolver,
+        )
+        return self._events.subscribe(cast(Any, wrapped), order=order, name=name)
+
+    def unsubscribe(self, subscription: Any) -> bool:
+        return self._events.unsubscribe(subscription)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._events, name)
 
 
 class _PluginCleanup:
@@ -554,12 +642,16 @@ class PluginContext:
     logger: LoggerLike
     services: PluginServices
     tasks: ManagedTasks
-    events: EventBus
+    events: PluginEventBus
     actions: ActionServiceLike
     paths: PluginPaths | None
     function_host: FunctionHost | None
     _manifest: ExtensionManifest = field(repr=False, compare=False)
     _cleanup: _PluginCleanup = field(repr=False, compare=False)
+    _runtime_context_factory: RuntimeContextFactory = field(
+        default=_default_runtime_context_factory, repr=False, compare=False
+    )
+    _runtime_resolver: RuntimeResolver = field(default=_unavailable_runtime_resolver, repr=False, compare=False)
     _tool_handlers: MutableMapping[str, ToolCallback] = field(default_factory=dict, repr=False, compare=False)
 
     def defer_cleanup(self, callback: CleanupCallback) -> None:
@@ -578,7 +670,15 @@ class PluginContext:
         del declaration
         if tool_id in self._tool_handlers:
             raise PluginError(f"extension {self.id} registered Tool {tool_id!r} more than once")
-        self._tool_handlers[tool_id] = handler
+        validate_runtime_bindings(handler, self._manifest.runtime_requirements)
+        self._tool_handlers[tool_id] = cast(
+            ToolCallback,
+            runtime_handler(
+                handler,
+                context_factory=self._runtime_context_factory,
+                resolver=self._runtime_resolver,
+            ),
+        )
 
 
 class PluginState(StrEnum):
@@ -609,6 +709,9 @@ class PluginManager:
         logger: LoggerLike,
         data_dir: Path,
         cache_dir: Path,
+        runtime_context_factory: Callable[[str], RuntimeContextFactory] | None = None,
+        runtime_resolver: RuntimeResolver | None = None,
+        runtime_targets: Mapping[str, str] | None = None,
     ) -> None:
         self.services = services
         self.events = events
@@ -621,6 +724,11 @@ class PluginManager:
         self._webui_diagnostics: dict[str, WebUiDiagnostic] = {}
         self._webui_generation = 0
         self._tool_handlers: dict[str, tuple[str, ToolDeclaration, ToolCallback]] = {}
+        self._runtime_context_factory_factory = runtime_context_factory or (
+            lambda _extension_id: _default_runtime_context_factory
+        )
+        self._runtime_resolver = runtime_resolver or _unavailable_runtime_resolver
+        self._runtime_targets = dict(runtime_targets or {})
 
     @property
     def tool_handlers(self) -> Mapping[str, tuple[str, ToolDeclaration, ToolCallback]]:
@@ -841,11 +949,27 @@ class PluginManager:
         for plugin_id in self.resolve_order(definitions):
             definition = definitions[plugin_id]
             manifest = definition.manifest
+            missing_runtime_requirements = tuple(
+                requirement
+                for requirement in manifest.runtime_requirements
+                if not requirement.optional
+                and not any(
+                    kind == requirement.runtime
+                    and (requirement.bridge_id is None or bridge_id == requirement.bridge_id)
+                    for bridge_id, kind in self._runtime_targets.items()
+                )
+            )
+            if missing_runtime_requirements:
+                names = ", ".join(
+                    f"{item.runtime}.{item.api}" for item in missing_runtime_requirements
+                )
+                raise PluginError(f"extension {manifest.id} requires unavailable runtime APIs: {names}")
             authorizer = self.services.get(ServiceKey("liteyukibot.permissions", 2))
             activation_allowed = getattr(authorizer, "activation_allowed", None)
-            if manifest.capabilities and (
+            requested_capabilities = frozenset((*manifest.capabilities, *manifest.runtime_capabilities))
+            if requested_capabilities and (
                 not callable(activation_allowed)
-                or not activation_allowed(manifest.id, frozenset(manifest.capabilities))
+                or not activation_allowed(manifest.id, requested_capabilities)
             ):
                 raise PluginError(f"extension {manifest.id} requested capabilities outside its configured ceiling")
             logger = self.logger.bind(plugin=plugin_id, component="plugin")
@@ -857,19 +981,27 @@ class PluginManager:
             plugin_services = PluginServices(manifest, self.services)
             cleanup = _PluginCleanup()
             tool_handlers: dict[str, ToolCallback] = {}
+            runtime_context_factory = self._runtime_context_factory_factory(manifest.id)
             context = PluginContext(
                 id=plugin_id,
                 config=MappingProxyType(dict(configs.get(plugin_id, {}))),
                 logger=logger,
                 services=plugin_services,
                 tasks=tasks,
-                events=self.events,
+                events=PluginEventBus(
+                    self.events,
+                    context_factory=runtime_context_factory,
+                    resolver=self._runtime_resolver,
+                    requirements=manifest.runtime_requirements,
+                ),
                 actions=self.actions,
                 paths=paths,
                 function_host=None if function_hosts is None else function_hosts.get(manifest.id),
                 _manifest=manifest,
                 _cleanup=cleanup,
                 _tool_handlers=tool_handlers,
+                _runtime_context_factory=runtime_context_factory,
+                _runtime_resolver=self._runtime_resolver,
             )
             handle = PluginHandle()
             try:

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -15,6 +15,7 @@ from liteyukibot import (
     runtime_handler,
 )
 from liteyukibot.events import ConversationRef, EventEnvelope, JsonValue
+from liteyukibot.plugins import ExtensionManifest
 
 
 def _event() -> EventEnvelope:
@@ -79,3 +80,32 @@ async def test_optional_runtime_proxy_fails_closed_when_unavailable() -> None:
     assert not proxy.available
     with pytest.raises(RuntimeUnavailable, match="astrbot.event"):
         await proxy.call("snapshot")
+
+
+def test_runtime_requirements_are_explicit_manifest_capabilities() -> None:
+    requirement = RuntimeRequirement(
+        runtime="astrbot",
+        api="event",
+        version="^1.0",
+        operations=("snapshot", "send"),
+    )
+    manifest = ExtensionManifest(
+        id="example.runtime",
+        name="Runtime Example",
+        version="1.0.0",
+        runtime_requirements=(requirement,),
+    )
+
+    assert manifest.runtime_capabilities == frozenset(
+        {
+            "runtime.astrbot.event.snapshot",
+            "runtime.astrbot.event.send",
+        }
+    )
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        ExtensionManifest(
+            id="example.runtime",
+            name="Runtime Example",
+            version="1.0.0",
+            runtime_requirements=(requirement, requirement),
+        )

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -9,6 +9,7 @@ from liteyukibot import (
     RuntimeBinding,
     RuntimeCallContext,
     RuntimeNamespaceProxy,
+    RuntimeRequirement,
     RuntimeUnavailable,
     runtime,
     runtime_bindings,

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ members = [
     "liteyukibot-v7-resources",
     "liteyukibot-v7-runtime-adapter",
     "liteyukibot-v7-runtime-astrbot",
+    "liteyukibot-v7-runtime-astrbot-api",
     "liteyukibot-v7-runtime-mofox",
     "liteyukibot-v7-runtime-nonebot",
     "liteyukibot-v7-runtime-v6",
@@ -1626,6 +1627,17 @@ requires-dist = [
     { name = "astrbot", specifier = "==4.27.2" },
     { name = "liteyukibot-v7", editable = "." },
 ]
+
+[[package]]
+name = "liteyukibot-v7-runtime-astrbot-api"
+version = "7.0.0a3"
+source = { editable = "packages/runtime-astrbot-api" }
+dependencies = [
+    { name = "liteyukibot-v7" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "liteyukibot-v7", editable = "." }]
 
 [[package]]
 name = "liteyukibot-v7-runtime-mofox"


### PR DESCRIPTION
## Scope

Alpha8a integration layer on top of PR #236.

- Injects runtime proxies into Native and Cordis plugin lifecycle and callback contexts.
- Adds host-aware runtime target resolution and runtime capability permission checks.
- Adds the independent AstrBot runtime SDK package without an AstrBot dependency.
- Implements the first AstrBot bridge proof for `event.snapshot` and `event.send`.

## Validation

- `uv run pytest tests/test_broker_runtime_api.py tests/test_runtime_api.py packages/runtime-astrbot-api/tests -q`
- `uv run ruff check src tests scripts examples packages`
- `uv run mypy`
- Full external-copy validation in `F:\\tmp\\liteyukibot`: 699 passed, 11 skipped, all package builds passed.

This is the top layer of Stack #238 and depends on PR #236. Alpha8b DevCLI and atomic update work is intentionally out of scope.