### PR TITLE
feat(runtime): harden Alpha10 bridge identity and ingress

### DIFF
--- a/docs/roadmap/v7-alpha-10-runtime-stability.md
+++ b/docs/roadmap/v7-alpha-10-runtime-stability.md
@@ -1,0 +1,52 @@
+# v7 Alpha 10: Runtime Identity and Ingress Stability
+
+Alpha10 follows Alpha9's runtime facade and provider work. Its first gate is
+correctness hardening for the existing NoneBot and AstrBot bridges; it does not
+add another provider or expand the Runtime API catalog.
+
+## Alpha10.0: Identity and ingress correctness
+
+### Decisions
+
+- The configured bridge ID is the only runtime identity used in a provider's
+  `EventEnvelope.runtime_id`. A provider kind such as `nonebot` or `astrbot`
+  is not an identity fallback at the host boundary.
+- A source event ID is a deterministic, collision-safe composite of bridge ID,
+  provider scope, and upstream event ID. Components are URL-encoded after
+  validation and are prefixed with `v1:`.
+- Provider ingress is best-effort and decoupled from the local framework
+  pipeline. The host uses one bounded FIFO publisher with a 256-item queue and
+  a one-second per-item broker deadline. Queue overflow, conversion errors,
+  broker failures, and timeouts are recorded and do not escape into the local
+  event pipeline.
+- Shutdown stops the ingress publisher before the bridge broker session. Items
+  still waiting in the bounded queue may be dropped; broker delivery has no
+  persistence or exactly-once guarantee.
+
+### Work
+
+- Pass the configured bridge ID explicitly through NoneBot and AstrBot event
+  translation and runtime snapshots.
+- Replace provider-specific source IDs with the shared canonical source ID
+  helper and retain the upstream ID in the provider raw extension where useful.
+- Use the shared bounded ingress publisher in both provider hosts.
+- Test non-default bridge IDs, delimiter collisions, queue overflow, handler
+  failures, timeouts, and shutdown cleanup.
+
+### Exit criteria
+
+- NoneBot and AstrBot ingress payloads pass the authenticated bridge identity
+  check for non-default bridge IDs.
+- Source identity components remain distinct when bridge, provider, or
+  upstream IDs contain separators or overlap across platforms.
+- Broker unavailability, conversion failure, queue overflow, and shutdown do
+  not fail the provider's local event pipeline.
+- Full pytest, Ruff, mypy, workspace build, runtime/API wheel verifiers, and an
+  authorized external workspace test pass.
+
+## Deferred Alpha10.x work
+
+Portable snapshot/result DTO convergence, provider conformance tooling,
+catalog fingerprints, API package CI coverage, and a third-party provider pilot
+remain later Alpha10 gates. They depend on the identity and failure policy
+defined here and are not part of Alpha10.0.

--- a/docs/roadmap/v7-alpha-roadmap.md
+++ b/docs/roadmap/v7-alpha-roadmap.md
@@ -171,6 +171,23 @@ AstrBot and the additional provider pass Native/Cordis proxy, installation,
 disconnect, exact-owner, and framework-object containment tests; and the full
 repository gates pass from built artifacts.
 
+### Alpha 10: Runtime identity and ingress stability
+
+**Goal:** make the existing runtime facade providers reliable under custom
+bridge IDs and temporary broker failure before expanding the ecosystem.
+
+**Work:** implement the [Alpha 10 runtime stability plan]
+(v7-alpha-10-runtime-stability.md): pass configured bridge identity explicitly,
+define collision-safe source event IDs, and use bounded best-effort ingress in
+the NoneBot and AstrBot hosts. Keep portable DTO convergence, catalog
+fingerprints, and new providers for later Alpha10.x gates.
+
+**Exit criteria:** non-default bridge IDs pass provider and kernel identity
+checks; source IDs remain distinct across provider scopes; broker failure,
+conversion failure, queue overflow, and shutdown do not fail local provider
+pipelines; and the full repository gates pass from built artifacts and an
+authorized external workspace.
+
 ## Shared release gates
 
 Every Alpha must pass the complete repository pytest suite, Ruff, Mypy,

--- a/docs/specs/runtime-ipc-v6.md
+++ b/docs/specs/runtime-ipc-v6.md
@@ -108,6 +108,25 @@ JSON-safe payload. It has no kernel event ID and cannot select recipients. The
 broker creates the immutable `kernel_event_id`, attaches the registered source
 bridge ID as provenance, and freezes the admitted event.
 
+### Alpha10 source identity and provider ingress
+
+The source event ID is provider-owned and must equal the `id` inside the
+`EventEnvelope` carried by the ingress payload. The Alpha10 reference bridges
+use the shared form
+`v1:<bridge-id>:<provider-scope>:<upstream-id>`, with each component URL-encoded
+and validated as a non-empty trimmed string. The bridge ID is the configured
+authenticated bridge ID, not merely the provider kind. This keeps source IDs
+distinct across bridge instances, provider sessions, and upstream ID spaces;
+the broker still assigns the separate `kernel_event_id`.
+
+NoneBot and AstrBot use a bounded FIFO best-effort publisher at their local
+framework boundary. It accepts at most 256 pending items, applies a one-second
+deadline to each broker send, and records queue drops, conversion failures,
+timeouts, and broker failures without propagating them into the provider's
+local event pipeline. Closing a provider stops this publisher before the broker
+session and may discard items still pending in its queue. This is a local
+reliability policy, not a broker persistence or exactly-once guarantee.
+
 ## Event Delivery And Ledger
 
 The broker selects subscribers from registered manifests: `full` bridges

--- a/packages/runtime-astrbot/README.md
+++ b/packages/runtime-astrbot/README.md
@@ -14,6 +14,12 @@ bridge publishes the Alpha9 v1.1 `event.snapshot`, `event.send`,
 `bot.snapshot`, and `bot.send` runtime APIs. Only portable JSON DTOs cross the
 Broker boundary.
 
+The configured bridge ID is passed into every translated event and snapshot.
+Source event IDs use the shared `v1:` composite of bridge ID, platform/bot
+scope, and upstream event ID. Ingress forwarding is bounded and best-effort:
+temporary broker failures or queue overflow do not fail AstrBot's local
+pipeline.
+
 The `experimental` grade is declared by this package's bridge definition. The
 gateway uses AstrBot's public extension surface and does not use the legacy
 Liteyuki child-runtime protocol or runtime event routes.

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
@@ -23,6 +23,7 @@ from liteyukibot.broker import (
     ActionOutcome,
     ActionRequest,
     ActionResourceDeclaration,
+    BoundedIngressPublisher,
     BridgeAccess,
     BridgeClient,
     BridgeManifest,
@@ -108,7 +109,7 @@ class AstrBotGateway:
         self._log_bridge: AstrBotLogBridge | None = None
         self._import_root: str | None = None
         self._ingress_sink: IngressSink | None = None
-        self._ingress_tasks: set[asyncio.Task[None]] = set()
+        self._ingress_publisher: BoundedIngressPublisher[Any] | None = None
         self._reply_events: OrderedDict[str, tuple[str, Any]] = OrderedDict()
         self._events_by_source_id: OrderedDict[str, Any] = OrderedDict()
         self._bot_platforms: dict[str, str] = {}
@@ -131,6 +132,12 @@ class AstrBotGateway:
         try:
             await lifecycle.initialize()
             self._ingress_sink = ingress_sink
+            self._ingress_publisher = BoundedIngressPublisher(
+                self._publish_ingress,
+                on_error=self._report_ingress_error,
+                task_name=f"liteyuki-astrbot-ingress:{self.bridge_id}",
+            )
+            await self._ingress_publisher.start()
             if self._logging_settings is not None:
                 configured = configure_logging(self._logging_settings)
                 self._output = configured.bind(component="astrbot", bridge=self.bridge_id)
@@ -138,6 +145,9 @@ class AstrBotGateway:
             log_bridge.start(astrbot_core.LogManager, astrbot_core.logger)
         except BaseException:
             configure_publisher(None)
+            if self._ingress_publisher is not None:
+                await self._ingress_publisher.close()
+                self._ingress_publisher = None
             if log_bridge is not None:
                 await log_bridge.close()
             self._remove_import_root()
@@ -156,13 +166,10 @@ class AstrBotGateway:
         lifecycle, self._lifecycle = self._lifecycle, None
         lifecycle_task, self._lifecycle_task = self._lifecycle_task, None
         log_bridge, self._log_bridge = self._log_bridge, None
-        ingress_tasks = tuple(self._ingress_tasks)
-        self._ingress_tasks.clear()
-        for task in ingress_tasks:
-            task.cancel()
-        if ingress_tasks:
-            await asyncio.gather(*ingress_tasks, return_exceptions=True)
+        ingress_publisher, self._ingress_publisher = self._ingress_publisher, None
         try:
+            if ingress_publisher is not None:
+                await ingress_publisher.close()
             if lifecycle_task is not None and not lifecycle_task.done():
                 lifecycle_task.cancel()
                 await asyncio.gather(lifecycle_task, return_exceptions=True)
@@ -199,7 +206,10 @@ class AstrBotGateway:
         if request.api_id == "event.snapshot":
             if request.arguments:
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_INVALID_ARGUMENTS")
-            return RuntimeApiOutcome(success=True, result=self._event_snapshot(event))
+            return RuntimeApiOutcome(
+                success=True,
+                result=self._event_snapshot(event, runtime_id=self.bridge_id),
+            )
         if request.api_id == "event.send":
             if request.authorization.bot_id != str(event.get_self_id()):
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_AUTHORIZATION_MISMATCH")
@@ -242,9 +252,15 @@ class AstrBotGateway:
         return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_NOT_REGISTERED")
 
     def _spawn_ingress(self, event: Any) -> None:
-        task = asyncio.create_task(self._publish_ingress(event), name="astrbot-broker-ingress")
-        self._ingress_tasks.add(task)
-        task.add_done_callback(self._ingress_tasks.discard)
+        publisher = self._ingress_publisher
+        if publisher is not None:
+            publisher.submit(event)
+
+    def _report_ingress_error(self, error: Exception) -> None:
+        self._output.bind(runtime=self.bridge_id, component="ingress").warning(
+            "AstrBot broker ingress delivery failed: {}",
+            type(error).__name__,
+        )
 
     async def _publish_ingress(self, event: Any) -> None:
         sink = self._ingress_sink
@@ -256,7 +272,7 @@ class AstrBotGateway:
             self._output.warning("AstrBot event cannot be published without platform and message IDs")
             return
         reply_token = f"{platform_id}:{source_event_id}"
-        envelope = to_event_envelope(event, reply_token=reply_token)
+        envelope = to_event_envelope(event, reply_token=reply_token, runtime_id=self.bridge_id)
         self._reply_events[reply_token] = (envelope.bot_id, event)
         self._events_by_source_id[envelope.id] = event
         self._reply_events.move_to_end(reply_token)
@@ -310,10 +326,11 @@ class AstrBotGateway:
         raise ValueError("AstrBot platform is no longer available")
 
     @staticmethod
-    def _event_snapshot(event: Any) -> dict[str, JsonValue]:
+    def _event_snapshot(event: Any, *, runtime_id: str = "astrbot") -> dict[str, JsonValue]:
         envelope = to_event_envelope(
             event,
             reply_token=f"{event.get_platform_id()}:{getattr(getattr(event, 'message_obj', None), 'message_id', '')}",
+            runtime_id=runtime_id,
         )
         message = envelope.message
         assert message is not None

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/translate.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/translate.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope, Message, Segment
+from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope, Message, Segment, canonical_source_event_id
 
 
-def to_event_envelope(event: Any, *, reply_token: str) -> EventEnvelope:
+def to_event_envelope(event: Any, *, reply_token: str, runtime_id: str = "astrbot") -> EventEnvelope:
     """Project the stable public AstrBot event properties into a portable message."""
 
     message = getattr(event, "message_obj", None)
@@ -22,8 +22,8 @@ def to_event_envelope(event: Any, *, reply_token: str) -> EventEnvelope:
     text = str(event.get_message_str() or "")
     segments = _segments(event.get_messages(), text)
     return EventEnvelope(
-        id=source_event_id,
-        runtime_id="astrbot",
+        id=canonical_source_event_id(runtime_id, f"{platform_id}:{bot_id}", source_event_id),
+        runtime_id=runtime_id,
         adapter=_identifier(event.get_platform_name(), "platform name"),
         bot_id=bot_id,
         type="message.created",
@@ -34,6 +34,7 @@ def to_event_envelope(event: Any, *, reply_token: str) -> EventEnvelope:
         raw={
             "astrbot": {
                 "platform_id": platform_id,
+                "source_event_id": source_event_id,
                 "message_type": str(event.get_message_type()),
             }
         },

--- a/packages/runtime-astrbot/tests/test_translate.py
+++ b/packages/runtime-astrbot/tests/test_translate.py
@@ -24,7 +24,7 @@ from liteyukibot.broker import (
     RuntimeApiInvoke,
 )
 from liteyukibot.config import AppSettings
-from liteyukibot.events import ConversationRef, JsonValue, Message, Segment
+from liteyukibot.events import ConversationRef, JsonValue, Message, Segment, canonical_source_event_id
 
 
 class FakeAstrEvent:
@@ -124,12 +124,19 @@ def test_astrbot_bridge_declares_experimental_package_metadata() -> None:
 def test_astrbot_ingress_projects_native_event_without_suppressing_pipeline() -> None:
     envelope = to_event_envelope(FakeAstrEvent(), reply_token="qq:message-1")
 
-    assert envelope.id == "message-1"
+    assert envelope.id == canonical_source_event_id("astrbot", "qq:bot-1", "message-1")
     assert envelope.runtime_id == "astrbot"
     assert envelope.adapter == "aiocqhttp"
     assert envelope.conversation == ConversationRef(id="group-1", type="group")
     assert envelope.message == Message(segments=(Segment(type="text", data={"text": "hello"}),))
     assert envelope.reply_token == "qq:message-1"
+
+
+def test_astrbot_event_identity_uses_the_configured_bridge_id() -> None:
+    envelope = to_event_envelope(FakeAstrEvent(), reply_token="qq:message-1", runtime_id="astrbot-qq")
+
+    assert envelope.runtime_id == "astrbot-qq"
+    assert envelope.id == canonical_source_event_id("astrbot-qq", "qq:bot-1", "message-1")
 
 
 def test_astrbot_event_snapshot_includes_portable_message_details() -> None:
@@ -147,13 +154,15 @@ async def test_astrbot_gateway_publishes_broker_ingress_and_retains_reply_route(
     async def send(ingress: object) -> None:
         published.append(ingress)
 
-    gateway = AstrBotGateway(Path("workspace"), "astrbot", RecordingLogger())
+    gateway = AstrBotGateway(Path("workspace"), "astrbot-prod", RecordingLogger())
     gateway._ingress_sink = send
     await gateway._publish_ingress(FakeAstrEvent())
 
     ingress = cast(EventIngress, published[0])
     assert ingress.topic == MESSAGE_CREATED_TOPIC
     assert ingress.ordering_key == "group:group-1"
+    assert ingress.source_event_id == canonical_source_event_id("astrbot-prod", "qq:bot-1", "message-1")
+    assert ingress.payload["runtime_id"] == "astrbot-prod"
     assert "qq:message-1" in gateway._reply_events
     assert gateway._bot_platforms == {"bot-1": "qq"}
 

--- a/packages/runtime-nonebot/README.md
+++ b/packages/runtime-nonebot/README.md
@@ -24,6 +24,11 @@ bridge publishes the Alpha9 v1.1 `event.snapshot`, `event.send`,
 `bot.snapshot`, and `bot.send` runtime APIs. Only portable JSON DTOs cross the
 Broker boundary; NoneBot and adapter objects remain local to this process.
 
+The configured bridge ID is passed into every normalized event. Source event
+IDs use the shared `v1:` composite of bridge ID, adapter/bot scope, and upstream
+event ID. Ingress forwarding is bounded and best-effort: temporary broker
+failures or queue overflow do not fail NoneBot's local event pipeline.
+
 The `stable` grade is package metadata on the bridge definition, not a promise
 that the broker wire protocol accepts framework-specific actions. NoneBot SDK
 objects and credentials remain in this package; the kernel never imports them.

--- a/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/contracts.py
+++ b/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/contracts.py
@@ -14,7 +14,15 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
-from liteyukibot.events import ActorRef, ConversationRef, EventEnvelope, Message, Segment, SendMessage
+from liteyukibot.events import (
+    ActorRef,
+    ConversationRef,
+    EventEnvelope,
+    Message,
+    Segment,
+    SendMessage,
+    canonical_source_event_id,
+)
 
 _MESSAGE_MODULES = {
     "onebot-v11": "nonebot.adapters.onebot.v11",
@@ -38,13 +46,17 @@ def adapter_id(display_name: str) -> str:
     return aliases.get(normalized, normalized)
 
 
-def normalize_event(bot: Any, event: Any) -> EventEnvelope:
+def normalize_event(bot: Any, event: Any, *, runtime_id: str | None = None) -> EventEnvelope:
     adapter = adapter_id(str(bot.adapter.get_name()))
     bot_id = str(bot.self_id)
     native_message = _original_message(event)
     timestamp = _event_timestamp(event)
+    raw = _event_raw(event)
+    runtime_name = runtime_id if runtime_id is not None else os.environ.get("LITEYUKI_RUNTIME_ID", "nonebot")
+    upstream_id = _upstream_event_id(raw)
     values: dict[str, Any] = {
-        "runtime_id": os.environ.get("LITEYUKI_RUNTIME_ID", "nonebot"),
+        "id": canonical_source_event_id(runtime_name, f"{adapter}:{bot_id}", upstream_id),
+        "runtime_id": runtime_name,
         "adapter": adapter,
         "bot_id": bot_id,
         "type": _event_name(event),
@@ -52,7 +64,7 @@ def normalize_event(bot: Any, event: Any) -> EventEnvelope:
         "actor": _actor(adapter, bot_id, event),
         "message": _to_portable_message(adapter, native_message) if native_message is not None else None,
         "reply_token": str(uuid4()) if native_message is not None else None,
-        "raw": _event_raw(event),
+        "raw": raw,
     }
     if timestamp is not None:
         values["timestamp"] = timestamp
@@ -599,6 +611,14 @@ def _event_raw(event: Any) -> dict[str, Any]:
         return normalized if isinstance(normalized, dict) else {}
     except AttributeError, TypeError, ValueError:
         return {}
+
+
+def _upstream_event_id(raw: Mapping[str, Any]) -> str:
+    for key in ("message_id", "event_id", "id"):
+        value = raw.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return str(uuid4())
 
 
 def _positive_integer_id(value: str) -> int:

--- a/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/host.py
+++ b/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/host.py
@@ -17,6 +17,7 @@ from liteyukibot.broker import (
     ActionOutcome,
     ActionRequest,
     ActionResourceDeclaration,
+    BoundedIngressPublisher,
     BridgeAccess,
     BridgeClient,
     BridgeManifest,
@@ -60,6 +61,7 @@ class NoneBotHost:
         self.events: OrderedDict[str, tuple[Any, Any]] = OrderedDict()
         self._events_by_source_id: OrderedDict[str, tuple[Any, Any, EventEnvelope]] = OrderedDict()
         self._serve_task: asyncio.Task[None] | None = None
+        self._ingress_publisher: BoundedIngressPublisher[EventIngress] | None = None
 
     def install(self) -> None:
         """Install the fixed B5 ingress and message.send action owner."""
@@ -84,7 +86,7 @@ class NoneBotHost:
                 raise RuntimeError(f"NoneBot plugin directory loaded no plugins: {directory}")
 
         async def forward(bot: Any, event: Any) -> None:
-            envelope = normalize_event(bot, event)
+            envelope = normalize_event(bot, event, runtime_id=self.bridge_id)
             if envelope.reply_token is not None:
                 self.events[envelope.reply_token] = (bot, event)
                 self.events.move_to_end(envelope.reply_token)
@@ -94,7 +96,9 @@ class NoneBotHost:
             self._events_by_source_id.move_to_end(envelope.id)
             while len(self._events_by_source_id) > 2048:
                 self._events_by_source_id.popitem(last=False)
-            await runner.client.send_event_ingress(self.event_ingress(envelope))
+            publisher = self._ingress_publisher
+            if publisher is not None:
+                publisher.submit(self.event_ingress(envelope))
 
         adapters = importlib.import_module("nonebot.adapters")
         forward.__annotations__ = {
@@ -104,8 +108,19 @@ class NoneBotHost:
         }
         importlib.import_module("nonebot.message").event_preprocessor(forward)
 
+        async def send_ingress(ingress: EventIngress) -> None:
+            await runner.client.send_event_ingress(ingress)
+
+        self._ingress_publisher = BoundedIngressPublisher(
+            send_ingress,
+            on_error=self._report_ingress_error,
+            task_name=f"liteyuki-nonebot-ingress:{self.bridge_id}",
+        )
+
         async def on_startup() -> None:
             await runner.start()
+            assert self._ingress_publisher is not None
+            await self._ingress_publisher.start()
             self._serve_task = asyncio.create_task(runner.serve_forever(), name="liteyuki-nonebot-broker")
 
         async def on_shutdown() -> None:
@@ -113,11 +128,21 @@ class NoneBotHost:
                 self._serve_task.cancel()
                 await asyncio.gather(self._serve_task, return_exceptions=True)
                 self._serve_task = None
-            await runner.stop()
-            runner.close()
+            try:
+                if self._ingress_publisher is not None:
+                    await self._ingress_publisher.close()
+            finally:
+                await runner.stop()
+                runner.close()
 
         driver.on_startup(on_startup)
         driver.on_shutdown(on_shutdown)
+
+    def _report_ingress_error(self, error: Exception) -> None:
+        logger.bind(runtime=self.bridge_id, component="ingress").warning(
+            "NoneBot broker ingress delivery failed: {}",
+            type(error).__name__,
+        )
 
     @staticmethod
     def event_ingress(envelope: EventEnvelope) -> EventIngress:

--- a/packages/runtime-nonebot/tests/test_nonebot_adapters.py
+++ b/packages/runtime-nonebot/tests/test_nonebot_adapters.py
@@ -18,7 +18,7 @@ from liteyukibot_runtime_nonebot.contracts import (
 from liteyukibot_runtime_nonebot.host import NoneBotHost
 
 from liteyukibot.broker import MESSAGE_SEND_KIND, ActionRequest, MessageSendPayload, message_send_resource_key
-from liteyukibot.events import ConversationRef, Message, Segment
+from liteyukibot.events import ConversationRef, Message, Segment, canonical_source_event_id
 
 _ADAPTER_MODULES = (
     "nonebot.adapters.onebot.v11",
@@ -286,6 +286,26 @@ def test_onebot_v11_event_uses_group_fifo_key_and_original_segments() -> None:
         "type": "face",
         "data": {"id": "123"},
     }
+
+
+def test_nonebot_event_identity_uses_the_configured_bridge_id() -> None:
+    envelope = normalize_event(
+        FakeBot("42", "OneBot V11"),
+        _onebot_v11_group_event(),
+        runtime_id="nonebot-prod",
+    )
+
+    assert envelope.runtime_id == "nonebot-prod"
+    assert envelope.id == canonical_source_event_id("nonebot-prod", "onebot-v11:42", "7")
+
+
+def test_nonebot_event_identity_rejects_an_empty_explicit_bridge_id() -> None:
+    with pytest.raises(ValueError, match="non-empty trimmed"):
+        normalize_event(
+            FakeBot("42", "OneBot V11"),
+            _onebot_v11_group_event(),
+            runtime_id="",
+        )
 
 
 def test_onebot_v11_private_conversation_is_actor_not_composite_session() -> None:

--- a/packages/runtime-nonebot/tests/test_nonebot_bridge.py
+++ b/packages/runtime-nonebot/tests/test_nonebot_bridge.py
@@ -145,6 +145,74 @@ def test_nonebot_host_wires_bridge_local_options_into_nonebot(monkeypatch: pytes
 
 
 @pytest.mark.asyncio
+async def test_nonebot_host_passes_configured_bridge_id_to_event_normalizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeDriver:
+        def on_startup(self, _callback: Any) -> None:
+            return None
+
+        def on_shutdown(self, _callback: Any) -> None:
+            return None
+
+    class FakeNoneBot:
+        def __init__(self) -> None:
+            self.driver = FakeDriver()
+
+        def init(self, **_options: Any) -> None:
+            return None
+
+        def get_driver(self) -> FakeDriver:
+            return self.driver
+
+        def load_plugin(self, _name: str) -> object:
+            return object()
+
+        def load_plugins(self, _directory: str) -> list[object]:
+            return [object()]
+
+    callbacks: list[Any] = []
+    adapters_module = ModuleType("nonebot.adapters")
+    adapters_module.Bot = object  # type: ignore[attr-defined]
+    adapters_module.Event = object  # type: ignore[attr-defined]
+    message_module = ModuleType("nonebot.message")
+
+    def register_callback(callback: Any) -> Any:
+        callbacks.append(callback)
+        return callback
+
+    message_module.event_preprocessor = register_callback  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "nonebot.adapters", adapters_module)
+    monkeypatch.setitem(sys.modules, "nonebot.message", message_module)
+
+    envelope = EventEnvelope(
+        id="source-event",
+        runtime_id="nonebot-prod",
+        adapter="test",
+        bot_id="bot",
+        type="message.created",
+        conversation=ConversationRef(id="conversation"),
+    )
+    runtime_ids: list[str | None] = []
+
+    def normalize(_bot: object, _event: object, *, runtime_id: str | None = None) -> EventEnvelope:
+        runtime_ids.append(runtime_id)
+        return envelope
+
+    monkeypatch.setattr("liteyukibot_runtime_nonebot.host.normalize_event", normalize)
+    host = NoneBotHost(
+        FakeNoneBot(),
+        cast(Any, SimpleNamespace(client=SimpleNamespace())),
+        "nonebot-prod",
+    )
+    host.install()
+
+    await callbacks[0](object(), object())
+
+    assert runtime_ids == ["nonebot-prod"]
+
+
+@pytest.mark.asyncio
 async def test_nonebot_runtime_api_uses_portable_dtos_and_exact_bot_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/src/liteyukibot/broker/__init__.py
+++ b/src/liteyukibot/broker/__init__.py
@@ -31,6 +31,7 @@ from .business import (
 )
 from .diagnostics import BrokerDiagnosticsClient, BrokerDiagnosticsError
 from .host import ActionOutcome, BrokerBridgeRunner, BrokerDelivery, ControlOutcome, RuntimeApiOutcome, ToolOutcome
+from .ingress import BoundedIngressPublisher, IngressPublisherStats
 from .kernel import KernelBridgeError, KernelBrokerPeer, configured_kernel_bridge
 from .lifecycle import BrokerLifecycleClient, BrokerLifecycleError
 from .peer import (
@@ -118,6 +119,8 @@ __all__ = [
     "ToolOutcome",
     "ControlOutcome",
     "RuntimeApiOutcome",
+    "BoundedIngressPublisher",
+    "IngressPublisherStats",
     "ActionResourceDeclaration",
     "AuthorizationContextWire",
     "ActionResult",

--- a/src/liteyukibot/broker/ingress.py
+++ b/src/liteyukibot/broker/ingress.py
@@ -1,0 +1,129 @@
+"""Bounded best-effort publishers for runtime-originated broker ingress."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+type IngressHandler[T] = Callable[[T], Awaitable[None]]
+type IngressErrorHandler = Callable[[Exception], None]
+
+
+@dataclass(frozen=True, slots=True)
+class IngressPublisherStats:
+    """Counters for one bounded publisher lifetime."""
+
+    accepted: int
+    completed: int
+    failed: int
+    dropped: int
+    pending: int
+
+
+class BoundedIngressPublisher[T]:
+    """Deliver queued items without coupling the producer to broker health."""
+
+    def __init__(
+        self,
+        handler: IngressHandler[T],
+        *,
+        capacity: int = 256,
+        timeout_seconds: float = 1.0,
+        on_error: IngressErrorHandler | None = None,
+        task_name: str = "liteyuki-ingress-publisher",
+    ) -> None:
+        if capacity < 1:
+            raise ValueError("capacity must be at least 1")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        if not callable(handler):
+            raise TypeError("handler must be callable")
+        self._handler = handler
+        self._queue: asyncio.Queue[T] = asyncio.Queue(maxsize=capacity)
+        self._timeout_seconds = timeout_seconds
+        self._on_error = on_error
+        self._task_name = task_name
+        self._task: asyncio.Task[None] | None = None
+        self._closed = False
+        self._accepted = 0
+        self._completed = 0
+        self._failed = 0
+        self._dropped = 0
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def stats(self) -> IngressPublisherStats:
+        return IngressPublisherStats(
+            accepted=self._accepted,
+            completed=self._completed,
+            failed=self._failed,
+            dropped=self._dropped,
+            pending=self._queue.qsize(),
+        )
+
+    async def start(self) -> None:
+        """Start the single FIFO delivery worker."""
+
+        if self._closed:
+            raise RuntimeError("ingress publisher is closed")
+        if self._task is None:
+            self._task = asyncio.create_task(self._run(), name=self._task_name)
+
+    def submit(self, item: T) -> bool:
+        """Queue one item immediately, returning false when it cannot be queued."""
+
+        if self._closed or self._task is None:
+            self._dropped += 1
+            return False
+        try:
+            self._queue.put_nowait(item)
+        except asyncio.QueueFull:
+            self._dropped += 1
+            return False
+        self._accepted += 1
+        return True
+
+    async def close(self) -> None:
+        """Stop delivery and account for items left in the bounded queue."""
+
+        if self._closed:
+            return
+        self._closed = True
+        task, self._task = self._task, None
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        while True:
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            self._dropped += 1
+
+    async def _run(self) -> None:
+        while True:
+            item = await self._queue.get()
+            try:
+                await asyncio.wait_for(self._handler(item), timeout=self._timeout_seconds)
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                self._failed += 1
+                self._report_error(error)
+            else:
+                self._completed += 1
+
+    def _report_error(self, error: Exception) -> None:
+        if self._on_error is None:
+            return
+        try:
+            self._on_error(error)
+        except Exception:
+            return
+
+
+__all__ = ["BoundedIngressPublisher", "IngressPublisherStats"]

--- a/src/liteyukibot/events/__init__.py
+++ b/src/liteyukibot/events/__init__.py
@@ -1,4 +1,5 @@
 from .bus import ActionExecutor, ActionGuard, EventBus, EventHandler, Subscription
+from .identity import canonical_source_event_id
 from .models import (
     Action,
     ActionEnvelope,
@@ -25,6 +26,7 @@ __all__ = [
     "ActionResult",
     "ActorRef",
     "CallApi",
+    "canonical_source_event_id",
     "ConversationRef",
     "DispatchResult",
     "EditMessage",

--- a/src/liteyukibot/events/identity.py
+++ b/src/liteyukibot/events/identity.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from urllib.parse import quote
+
+
+def canonical_source_event_id(bridge_id: str, provider_scope: str, upstream_id: str) -> str:
+    """Build a collision-safe source event ID from one provider identity tuple."""
+
+    parts = (bridge_id, provider_scope, upstream_id)
+    if any(not isinstance(part, str) or not part.strip() or part != part.strip() for part in parts):
+        raise ValueError("source event identity parts must be non-empty trimmed strings")
+    return "v1:" + ":".join(quote(part, safe="") for part in parts)
+
+
+__all__ = ["canonical_source_event_id"]

--- a/tests/test_ingress_publisher.py
+++ b/tests/test_ingress_publisher.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from liteyukibot.broker import BoundedIngressPublisher
+
+
+@pytest.mark.asyncio
+async def test_bounded_ingress_publisher_is_fifo_and_drops_when_full() -> None:
+    first_started = asyncio.Event()
+    completed = asyncio.Event()
+    release = asyncio.Event()
+    received: list[str] = []
+
+    async def handler(value: str) -> None:
+        if value == "first":
+            first_started.set()
+            await release.wait()
+        received.append(value)
+        if value == "second":
+            completed.set()
+
+    publisher = BoundedIngressPublisher(handler, capacity=1, timeout_seconds=0.2)
+    await publisher.start()
+
+    assert publisher.submit("first") is True
+    await asyncio.wait_for(first_started.wait(), timeout=0.2)
+    assert publisher.submit("second") is True
+    assert publisher.submit("third") is False
+
+    release.set()
+    await asyncio.wait_for(completed.wait(), timeout=0.5)
+    await publisher.close()
+
+    assert received == ["first", "second"]
+    assert publisher.stats.accepted == 2
+    assert publisher.stats.completed == 2
+    assert publisher.stats.failed == 0
+    assert publisher.stats.dropped == 1
+    assert publisher.stats.pending == 0
+
+
+@pytest.mark.asyncio
+async def test_bounded_ingress_publisher_isolates_handler_failures_and_timeouts() -> None:
+    completed = asyncio.Event()
+    errors: list[Exception] = []
+
+    async def handler(value: str) -> None:
+        if value == "error":
+            raise RuntimeError("upstream failed")
+        if value == "slow":
+            await asyncio.sleep(1)
+        completed.set()
+
+    def on_error(error: Exception) -> None:
+        errors.append(error)
+        raise RuntimeError("logging must not break the publisher")
+
+    publisher = BoundedIngressPublisher(handler, timeout_seconds=0.01, on_error=on_error)
+    await publisher.start()
+    assert publisher.submit("error") is True
+    assert publisher.submit("slow") is True
+    assert publisher.submit("healthy") is True
+
+    await asyncio.wait_for(completed.wait(), timeout=0.5)
+    await publisher.close()
+
+    assert [type(error) for error in errors] == [RuntimeError, TimeoutError]
+    assert publisher.stats.accepted == 3
+    assert publisher.stats.completed == 1
+    assert publisher.stats.failed == 2
+    assert publisher.stats.dropped == 0
+
+
+@pytest.mark.asyncio
+async def test_bounded_ingress_publisher_close_drops_pending_items() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(_value: str) -> None:
+        started.set()
+        await release.wait()
+
+    publisher = BoundedIngressPublisher(handler, capacity=2)
+    assert publisher.submit("before-start") is False
+    await publisher.start()
+    assert publisher.submit("active") is True
+    await asyncio.wait_for(started.wait(), timeout=0.2)
+    assert publisher.submit("pending-1") is True
+    assert publisher.submit("pending-2") is True
+
+    await publisher.close()
+
+    assert publisher.closed is True
+    assert publisher.stats.dropped == 3
+    release.set()

--- a/tests/test_source_identity.py
+++ b/tests/test_source_identity.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from liteyukibot.events import canonical_source_event_id
+
+
+def test_canonical_source_event_id_encodes_each_identity_part() -> None:
+    assert canonical_source_event_id("bridge:prod", "onebot/42", "message:7") == (
+        "v1:bridge%3Aprod:onebot%2F42:message%3A7"
+    )
+
+
+def test_canonical_source_event_id_is_deterministic_and_tuple_scoped() -> None:
+    source = canonical_source_event_id("bridge", "adapter:bot", "event")
+
+    assert source == canonical_source_event_id("bridge", "adapter:bot", "event")
+    assert len(
+        {
+            source,
+            canonical_source_event_id("other-bridge", "adapter:bot", "event"),
+            canonical_source_event_id("bridge", "other:bot", "event"),
+            canonical_source_event_id("bridge", "adapter:bot", "other-event"),
+        }
+    ) == 4
+
+
+@pytest.mark.parametrize("parts", [("", "adapter", "event"), ("bridge", " ", "event"), ("bridge", "adapter", "")])
+def test_canonical_source_event_id_rejects_blank_parts(parts: tuple[str, str, str]) -> None:
+    with pytest.raises(ValueError, match="non-empty trimmed"):
+        canonical_source_event_id(*parts)
+
+
+def test_canonical_source_event_id_rejects_untrimmed_parts() -> None:
+    with pytest.raises(ValueError, match="non-empty trimmed"):
+        canonical_source_event_id("bridge ", "adapter", "event")


### PR DESCRIPTION
## Summary

- pass the authenticated bridge ID explicitly through the NoneBot and AstrBot event paths
- define collision-safe `v1:` source event IDs from bridge, provider scope, and upstream ID
- add a shared bounded FIFO ingress publisher with per-item timeout and failure isolation
- document Alpha10.0 identity and best-effort ingress contracts

## Validation

- `uv run pytest`: 734 passed, 11 skipped, 26 warnings
- `uv run ruff check src tests scripts examples packages`
- `uv run mypy`
- `uv build --all-packages --out-dir dist/workspace --clear`
- NoneBot and AstrBot runtime wheel install verifiers
- NoneBot and AstrBot API wheel install verifiers
- external workspace `F:\\tmp\\liteyukibot`: 734 passed, 11 skipped, 26 warnings

`liteyuki check` was not a green gate in either workspace: the source checkout has no `liteyuki.toml`, while the external workspace has a v5 configuration that requires the repository's manual v6 migration step. No configuration was created or modified for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent, collision-resistant event IDs that include the configured bridge identity.
  * Added bounded, FIFO event forwarding with capacity limits, timeout handling, and delivery statistics.
  * NoneBot and AstrBot now support best-effort ingress that prevents temporary broker issues from disrupting local event processing.
* **Documentation**
  * Added Alpha 10 runtime stability roadmap guidance and documented identity, ingress, and shutdown behavior.
* **Tests**
  * Added coverage for event identity, queue limits, failures, timeouts, and shutdown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->