### PR TITLE
feat(runtime): converge portable facade DTOs

### DIFF
--- a/docs/roadmap/v7-alpha-10-1-portable-facade.md
+++ b/docs/roadmap/v7-alpha-10-1-portable-facade.md
@@ -1,0 +1,50 @@
+# v7 Alpha 10.1: Portable Facade Convergence
+
+Alpha10.1 freezes the portable Runtime API shape built by Alpha9. It keeps
+NoneBot and AstrBot as the only supported provider facets and does not add new
+operations or providers.
+
+## Canonical DTOs
+
+The kernel owns the JSON-safe DTOs used by both provider API packages:
+
+- `EventSnapshot`: `source_event_id`, `runtime_id`, `adapter`, `bot_id`,
+  `event_type`, `conversation`, `actor`, `message`, and `extensions`.
+- `BotSnapshot`: `bot_id`, `adapter`, `capabilities`, and `extensions`.
+- `SendResult`: `sent`, `result`, and `extensions`.
+
+The portable event `message` is always the kernel `Message` DTO. Provider-only
+values are placed under a provider namespace such as `extensions.astrbot`.
+Extensions are JSON-safe and are not required for portable consumers.
+
+The shared catalog is Runtime API `1.2`. The operation names and input shapes
+remain `event.snapshot`, `event.send`, `bot.snapshot`, and `bot.send`; only the
+canonical result contract is converged.
+
+## Compatibility
+
+The two API packages retain their existing provider class names. NoneBot
+snapshot classes are aliases of the kernel DTOs. AstrBot snapshot classes are
+compatibility subclasses exposing `platform_id`, `platform_name`,
+`session_id`, `message_type`, and related properties from its extension
+namespace.
+
+AstrBot's old `message: str` field is intentionally corrected to the portable
+`Message` value. Consumers that need the former text projection use
+`message_text` or `message.plain_text`; this correction is documented as an
+Alpha migration rather than a framework SDK compatibility promise.
+
+## Exit Criteria
+
+- Both providers register the same version and input/output schema for each
+  portable operation.
+- Provider hosts construct the same kernel DTOs and preserve only explicitly
+  namespaced provider extensions.
+- Typed API proxies return the same `EventSnapshot`, `BotSnapshot`, and
+  `SendResult` semantics.
+- Invalid provider results fail with `RUNTIME_API_INVALID_RESULT`.
+- API package tests, full repository gates, built wheel verifiers, and an
+  authorized external workspace pass.
+
+Catalog fingerprints, isolated API verifier promotion into ordinary CI, B7
+peer examples, and plugin authoring examples are Alpha10.2 work.

--- a/docs/roadmap/v7-alpha-10-runtime-stability.md
+++ b/docs/roadmap/v7-alpha-10-runtime-stability.md
@@ -46,7 +46,8 @@ add another provider or expand the Runtime API catalog.
 
 ## Deferred Alpha10.x work
 
-Portable snapshot/result DTO convergence, provider conformance tooling,
-catalog fingerprints, API package CI coverage, and a third-party provider pilot
-remain later Alpha10 gates. They depend on the identity and failure policy
-defined here and are not part of Alpha10.0.
+Portable snapshot/result DTO convergence is specified in the
+[Alpha10.1 plan](v7-alpha-10-1-portable-facade.md). Provider conformance
+tooling, catalog fingerprints, API package CI coverage, and B7 author examples
+remain Alpha10.2 work. A third-party provider pilot and all Alpha11+ work stay
+outside these Alpha10 gates.

--- a/docs/roadmap/v7-alpha-roadmap.md
+++ b/docs/roadmap/v7-alpha-roadmap.md
@@ -180,7 +180,8 @@ bridge IDs and temporary broker failure before expanding the ecosystem.
 (v7-alpha-10-runtime-stability.md): pass configured bridge identity explicitly,
 define collision-safe source event IDs, and use bounded best-effort ingress in
 the NoneBot and AstrBot hosts. Keep portable DTO convergence, catalog
-fingerprints, and new providers for later Alpha10.x gates.
+fingerprints, and new providers for later Alpha10.x gates. Alpha10.1 converges
+the portable DTOs; Alpha10.2 proves the third-party author and release path.
 
 **Exit criteria:** non-default bridge IDs pass provider and kernel identity
 checks; source IDs remain distinct across provider scopes; broker failure,

--- a/docs/specs/runtime-api-v1.md
+++ b/docs/specs/runtime-api-v1.md
@@ -3,9 +3,10 @@
 ## Status
 
 Applies to the Alpha8a Broker protocol v7 and the Native/Cordis Extension API
-v2 hosts. Alpha9 adds a backward-compatible v1.1 portable facade catalog. This
-is a supported compatibility surface, not a promise to mirror every framework's
-complete public SDK.
+v2 hosts. Alpha9 introduced the v1.1 portable facade catalog; Alpha10.1
+converges its shared result contract as Runtime API v1.2. This is a supported
+compatibility surface, not a promise to mirror every framework's complete
+public SDK.
 
 ## Boundary
 
@@ -77,6 +78,28 @@ unavailable bots return `RUNTIME_EVENT_UNAVAILABLE` or
 `RUNTIME_BOT_UNAVAILABLE`; invalid portable values return
 `RUNTIME_API_INVALID_ARGUMENTS`; provider send failures return
 `RUNTIME_API_SEND_FAILED`.
+
+## Alpha10.1 canonical facade
+
+The v1.2 portable result contract is kernel-owned and shared by the NoneBot and
+AstrBot API packages:
+
+| DTO | Portable fields and defaults |
+| --- | --- |
+| `EventSnapshot` | `source_event_id`, `runtime_id`, `adapter`, `bot_id`, `event_type`, and `conversation` are required; `actor` and `message` are nullable; `extensions` defaults to `{}` |
+| `BotSnapshot` | `bot_id` and `adapter` are required; `capabilities` defaults to `[]`; `extensions` defaults to `{}` |
+| `SendResult` | `sent` is required; `result` defaults to `null`; `extensions` defaults to `{}` |
+
+Every DTO also has JSON-safe `extensions`. Provider-specific fields must be
+under a provider namespace such as `extensions.astrbot`; portable consumers
+must not depend on them. `EventSnapshot.message` is always the portable
+`Message` DTO. AstrBot consumers migrating from the Alpha9 text field should
+use `message_text` or `message.plain_text`.
+
+Both providers register the same v1.2 input/output schemas for the four
+portable operations. The provider API packages retain their old class names as
+aliases or compatibility subclasses, but the kernel DTOs define the wire
+contract.
 
 ## Compatibility and security
 

--- a/packages/runtime-astrbot-api/README.md
+++ b/packages/runtime-astrbot-api/README.md
@@ -1,9 +1,13 @@
 # LiteyukiBot AstrBot Runtime API
 
-This package contains the framework-neutral typed facade used by the Alpha9
-AstrBot runtime API. It deliberately does not depend on AstrBot itself.
+This package contains the framework-neutral typed facade used by the Alpha10.1
+AstrBot runtime API v1.2. It deliberately does not depend on AstrBot itself.
 
 The supported portable surface includes `event.snapshot()`, `event.send()` for
 text or a Liteyuki `Message`, `bot.snapshot()`, and `bot.send(message,
 conversation)`. These methods return JSON-safe DTOs and never expose AstrBot
-objects, native message chains, or arbitrary API passthrough.
+objects, native message chains, or arbitrary API passthrough. Snapshot and send
+result types are kernel-owned portable DTOs; AstrBot platform/session fields
+remain under the `astrbot` extension namespace. The old text projection is
+available as `message_text`; `event.snapshot().message` is now a portable
+`Message`.

--- a/packages/runtime-astrbot-api/pyproject.toml
+++ b/packages/runtime-astrbot-api/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "liteyukibot-v7-runtime-astrbot-api"
 version = "7.0.0a9"
-description = "Framework-neutral typed Alpha9 AstrBot runtime API facade."
+description = "Framework-neutral typed Alpha10.1 AstrBot runtime API facade."
 readme = "README.md"
 requires-python = ">=3.14"
 license = "LicenseRef-LSO"

--- a/packages/runtime-astrbot-api/src/liteyukibot_runtime_astrbot_api/__init__.py
+++ b/packages/runtime-astrbot-api/src/liteyukibot_runtime_astrbot_api/__init__.py
@@ -1,47 +1,85 @@
-"""Typed, AstrBot-independent Alpha9 runtime API facade."""
+"""Typed, AstrBot-independent Alpha10.1 runtime API facade."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import cast
 
-from pydantic import BaseModel, ConfigDict
-
 from liteyukibot.events import ConversationRef, JsonValue, Message, Segment
 from liteyukibot.runtime_api import (
+    BotSnapshot,
+    EventSnapshot,
     RuntimeApiBackend,
     RuntimeApiError,
     RuntimeBinding,
     RuntimeCallContext,
     RuntimeNamespaceProxy,
+    SendResult,
 )
 
 
-class AstrBotEventSnapshot(BaseModel):
-    model_config = ConfigDict(frozen=True, extra="forbid")
+class AstrBotEventSnapshot(EventSnapshot):
+    """Canonical snapshot with Alpha9 AstrBot field compatibility properties."""
 
-    platform_id: str
-    platform_name: str
-    bot_id: str
-    session_id: str
-    group_id: str | None = None
-    sender_id: str | None = None
-    message: str
-    message_type: str
-    conversation_id: str | None = None
-    conversation_type: str | None = None
-    actor_name: str | None = None
-    actor_is_bot: bool = False
-    message_segments: tuple[Segment, ...] = ()
+    @property
+    def platform_id(self) -> str:
+        return _extension_text(self, "platform_id")
+
+    @property
+    def platform_name(self) -> str:
+        return _extension_text(self, "platform_name")
+
+    @property
+    def session_id(self) -> str:
+        return _extension_text(self, "session_id")
+
+    @property
+    def group_id(self) -> str | None:
+        return self.conversation.id if self.conversation.type == "group" else None
+
+    @property
+    def sender_id(self) -> str | None:
+        return None if self.actor is None else self.actor.id
+
+    @property
+    def message_text(self) -> str:
+        return "" if self.message is None else self.message.plain_text
+
+    @property
+    def message_type(self) -> str:
+        return _extension_text(self, "message_type")
+
+    @property
+    def conversation_id(self) -> str:
+        return self.conversation.id
+
+    @property
+    def conversation_type(self) -> str:
+        return self.conversation.type
+
+    @property
+    def actor_name(self) -> str | None:
+        return None if self.actor is None else self.actor.display_name
+
+    @property
+    def actor_is_bot(self) -> bool:
+        return False if self.actor is None else self.actor.is_bot
+
+    @property
+    def message_segments(self) -> tuple[Segment, ...]:
+        return () if self.message is None else self.message.segments
 
 
-class AstrBotBotSnapshot(BaseModel):
-    model_config = ConfigDict(frozen=True, extra="forbid")
+class AstrBotBotSnapshot(BotSnapshot):
+    """Canonical bot snapshot with Alpha9 AstrBot field compatibility properties."""
 
-    bot_id: str
-    platform_id: str
-    platform_name: str
-    capabilities: tuple[str, ...] = ()
+    @property
+    def platform_id(self) -> str:
+        return _extension_text(self, "platform_id")
+
+    @property
+    def platform_name(self) -> str:
+        return _extension_text(self, "platform_name")
 
 
 class AstrBotEventProxy(RuntimeNamespaceProxy):
@@ -61,18 +99,18 @@ class AstrBotEventProxy(RuntimeNamespaceProxy):
                 "RUNTIME_API_INVALID_RESULT",
             ) from error
 
-    async def send(self, message: str | Message) -> Mapping[str, JsonValue]:
+    async def send(self, message: str | Message) -> SendResult:
         return await self._send(message)
 
-    async def send_message(self, message: Message) -> Mapping[str, JsonValue]:
+    async def send_message(self, message: Message) -> SendResult:
         return await self._send(message)
 
-    async def _send(self, message: str | Message) -> Mapping[str, JsonValue]:
+    async def _send(self, message: str | Message) -> SendResult:
         argument: JsonValue = message if isinstance(message, str) else cast(
             dict[str, JsonValue], message.model_dump(mode="json")
         )
         value = await self.call("send", {"message": argument})
-        return _mapping_result(self, "send", value)
+        return _send_result(self, "send", value)
 
 
 class AstrBotBotProxy(RuntimeNamespaceProxy):
@@ -92,7 +130,7 @@ class AstrBotBotProxy(RuntimeNamespaceProxy):
                 "RUNTIME_API_INVALID_RESULT",
             ) from error
 
-    async def send(self, message: Message, conversation: ConversationRef) -> Mapping[str, JsonValue]:
+    async def send(self, message: Message, conversation: ConversationRef) -> SendResult:
         arguments = cast(
             Mapping[str, JsonValue],
             {
@@ -101,7 +139,7 @@ class AstrBotBotProxy(RuntimeNamespaceProxy):
             },
         )
         value = await self.call("send", arguments)
-        return _mapping_result(self, "send", value)
+        return _send_result(self, "send", value)
 
 
 def proxy_factory(
@@ -124,10 +162,26 @@ def bot_proxy_factory(
     return AstrBotBotProxy(binding, backend, context, reason=reason)
 
 
-def _mapping_result(proxy: RuntimeNamespaceProxy, operation: str, value: JsonValue) -> Mapping[str, JsonValue]:
-    if not isinstance(value, Mapping) or any(not isinstance(key, str) for key in value):
+def _send_result(proxy: RuntimeNamespaceProxy, operation: str, value: JsonValue) -> SendResult:
+    if not isinstance(value, Mapping):
         raise RuntimeApiError(proxy.binding.runtime, proxy.binding.api, operation, "RUNTIME_API_INVALID_RESULT")
-    return value
+    try:
+        return SendResult.model_validate(value)
+    except ValueError as error:
+        raise RuntimeApiError(
+            proxy.binding.runtime,
+            proxy.binding.api,
+            operation,
+            "RUNTIME_API_INVALID_RESULT",
+        ) from error
+
+
+def _extension_text(snapshot: EventSnapshot | BotSnapshot, key: str) -> str:
+    values = snapshot.extensions.get("astrbot")
+    if not isinstance(values, Mapping):
+        return ""
+    value = values.get(key)
+    return value if isinstance(value, str) else ""
 
 
 __all__ = [
@@ -135,6 +189,7 @@ __all__ = [
     "AstrBotBotSnapshot",
     "AstrBotEventProxy",
     "AstrBotEventSnapshot",
+    "SendResult",
     "bot_proxy_factory",
     "proxy_factory",
 ]

--- a/packages/runtime-astrbot-api/tests/test_proxy.py
+++ b/packages/runtime-astrbot-api/tests/test_proxy.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 import pytest
 from liteyukibot_runtime_astrbot_api import AstrBotBotProxy, AstrBotEventProxy
 
-from liteyukibot import AuthorizationContext, RuntimeBinding, RuntimeCallContext
+from liteyukibot import AuthorizationContext, RuntimeApiError, RuntimeBinding, RuntimeCallContext
 from liteyukibot.events import ConversationRef, EventEnvelope, JsonValue, Message, Segment
 
 
@@ -32,12 +32,20 @@ async def test_typed_event_proxy_maps_alpha9_operations() -> None:
         ) -> JsonValue:
             if binding.api == "event" and operation == "snapshot":
                 return {
-                    "platform_id": "onebot",
-                    "platform_name": "qq",
+                    "source_event_id": "v1:astrbot:onebot:bot-1:event-1",
+                    "runtime_id": "astrbot",
+                    "adapter": "aiocqhttp",
                     "bot_id": "bot-1",
-                    "session_id": "chat-1",
-                    "message": "hello",
-                    "message_type": "group",
+                    "event_type": "message.created",
+                    "conversation": {"id": "chat-1", "type": "group"},
+                    "extensions": {
+                        "astrbot": {
+                            "platform_id": "onebot",
+                            "platform_name": "qq",
+                            "session_id": "chat-1",
+                            "message_type": "group",
+                        }
+                    },
                 }
             if binding.api == "event":
                 assert arguments in (
@@ -49,9 +57,8 @@ async def test_typed_event_proxy_maps_alpha9_operations() -> None:
                 assert arguments == {}
                 return {
                     "bot_id": "bot-1",
-                    "platform_id": "qq",
-                    "platform_name": "aiocqhttp",
-                    "capabilities": (),
+                    "adapter": "aiocqhttp",
+                    "extensions": {"astrbot": {"platform_id": "qq", "platform_name": "aiocqhttp"}},
                 }
             assert arguments == {
                 "message": {"segments": [{"type": "text", "data": {"text": "proactive"}}]},
@@ -80,7 +87,29 @@ async def test_typed_event_proxy_maps_alpha9_operations() -> None:
     )
 
     assert snapshot.session_id == "chat-1"
-    assert sent == {"sent": True}
-    assert portable == {"sent": True}
+    assert sent.sent is True
+    assert portable.sent is True
     assert bot_snapshot.platform_name == "aiocqhttp"
-    assert proactive == {"sent": True}
+    assert proactive.sent is True
+
+
+@pytest.mark.asyncio
+async def test_astrbot_send_rejects_an_invalid_canonical_result() -> None:
+    class Backend:
+        async def invoke(
+            self,
+            _binding: RuntimeBinding,
+            _operation: str,
+            _arguments: Mapping[str, JsonValue],
+            _context: RuntimeCallContext,
+        ) -> JsonValue:
+            return {}
+
+    proxy = AstrBotEventProxy(
+        RuntimeBinding("astrbot", "event", "^1.2", False, "astrbot"),
+        Backend(),
+        _context(),
+    )
+
+    with pytest.raises(RuntimeApiError, match="RUNTIME_API_INVALID_RESULT"):
+        await proxy.send("hello")

--- a/packages/runtime-astrbot/README.md
+++ b/packages/runtime-astrbot/README.md
@@ -10,9 +10,10 @@ owns bridge-scoped `message.send` actions. It never suppresses AstrBot's local
 pipeline or its native replies.
 
 With the separately installed `liteyukibot-v7-runtime-astrbot-api` package, the
-bridge publishes the Alpha9 v1.1 `event.snapshot`, `event.send`,
-`bot.snapshot`, and `bot.send` runtime APIs. Only portable JSON DTOs cross the
-Broker boundary.
+bridge publishes the Alpha10.1 v1.2 `event.snapshot`, `event.send`,
+`bot.snapshot`, and `bot.send` runtime APIs. Only kernel-owned portable JSON
+DTOs cross the Broker boundary; AstrBot platform/session fields are carried in
+the `astrbot` extension namespace.
 
 The configured bridge ID is passed into every translated event and snapshot.
 Source event IDs use the shared `v1:` composite of bridge ID, platform/bot

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
@@ -373,6 +373,7 @@ class AstrBotGateway:
             BotSnapshot(
                 bot_id=bot_id,
                 adapter=platform_name,
+                capabilities=("message.send",),
                 extensions={
                     "astrbot": {
                         "platform_id": platform_id,

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
@@ -20,6 +20,7 @@ import zmq.asyncio
 
 from liteyukibot.broker import (
     MESSAGE_SEND_KIND,
+    PORTABLE_RUNTIME_API_VERSION,
     ActionOutcome,
     ActionRequest,
     ActionResourceDeclaration,
@@ -35,14 +36,18 @@ from liteyukibot.broker import (
     RuntimeApiOperation,
     RuntimeApiOutcome,
     parse_message_send_request,
+    portable_bot_snapshot_schema,
     portable_conversation_schema,
+    portable_event_snapshot_schema,
     portable_message_schema,
+    portable_send_result_schema,
     runtime_api_catalog,
 )
 from liteyukibot.config import AppSettings, LoggingSettings
 from liteyukibot.events import ConversationRef, JsonValue, Message, Segment
 from liteyukibot.logging import configure_logging, get_logger
 from liteyukibot.lyip import LyipLane
+from liteyukibot.runtime_api import BotSnapshot, EventSnapshot, SendResult
 
 from .listener import configure_publisher
 from .translate import to_event_envelope
@@ -223,7 +228,7 @@ class AstrBotGateway:
                 result = await event.send(_to_astr_chain(message))
             except Exception:
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_SEND_FAILED")
-            return RuntimeApiOutcome(success=True, result={"sent": True, "result": _json_result(result)})
+            return RuntimeApiOutcome(success=True, result=_send_result(result))
         if request.api_id == "bot.snapshot":
             if request.arguments:
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_INVALID_ARGUMENTS")
@@ -248,7 +253,7 @@ class AstrBotGateway:
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_INVALID_ARGUMENTS")
             except Exception:
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_SEND_FAILED")
-            return RuntimeApiOutcome(success=True, result={"sent": True, "result": _json_result(result)})
+            return RuntimeApiOutcome(success=True, result=_send_result(result))
         return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_NOT_REGISTERED")
 
     def _spawn_ingress(self, event: Any) -> None:
@@ -334,24 +339,27 @@ class AstrBotGateway:
         )
         message = envelope.message
         assert message is not None
-        return {
-            "platform_id": str(event.get_platform_id()),
-            "platform_name": envelope.adapter,
-            "bot_id": envelope.bot_id,
-            "session_id": str(event.get_session_id()),
-            "group_id": envelope.conversation.id if envelope.conversation.type == "group" else None,
-            "sender_id": None if envelope.actor is None else envelope.actor.id,
-            "message": message.plain_text,
-            "message_type": str(event.get_message_type()),
-            "conversation_id": envelope.conversation.id,
-            "conversation_type": envelope.conversation.type,
-            "actor_name": None if envelope.actor is None else envelope.actor.display_name,
-            "actor_is_bot": False if envelope.actor is None else envelope.actor.is_bot,
-            "message_segments": cast(
-                JsonValue,
-                [segment.model_dump(mode="json") for segment in message.segments],
-            ),
-        }
+        return cast(
+            dict[str, JsonValue],
+            EventSnapshot(
+                source_event_id=envelope.id,
+                runtime_id=envelope.runtime_id,
+                adapter=envelope.adapter,
+                bot_id=envelope.bot_id,
+                event_type=envelope.type,
+                conversation=envelope.conversation,
+                actor=envelope.actor,
+                message=message,
+                extensions={
+                    "astrbot": {
+                        "platform_id": str(event.get_platform_id()),
+                        "platform_name": envelope.adapter,
+                        "session_id": str(event.get_session_id()),
+                        "message_type": str(event.get_message_type()),
+                    }
+                },
+            ).model_dump(mode="json"),
+        )
 
     def _bot_snapshot(self, bot_id: str) -> dict[str, JsonValue]:
         platform_id = self._bot_platforms.get(bot_id)
@@ -359,12 +367,20 @@ class AstrBotGateway:
             raise ValueError("bot has no observed AstrBot platform session")
         platform = self._platform(platform_id)
         meta = platform.meta()
-        return {
-            "bot_id": bot_id,
-            "platform_id": platform_id,
-            "platform_name": str(getattr(meta, "name", platform_id)),
-            "capabilities": cast(JsonValue, []),
-        }
+        platform_name = str(getattr(meta, "name", platform_id))
+        return cast(
+            dict[str, JsonValue],
+            BotSnapshot(
+                bot_id=bot_id,
+                adapter=platform_name,
+                extensions={
+                    "astrbot": {
+                        "platform_id": platform_id,
+                        "platform_name": platform_name,
+                    }
+                },
+            ).model_dump(mode="json"),
+        )
 
     def _install_import_root(self) -> None:
         value = str(self.workspace)
@@ -536,6 +552,13 @@ def _json_result(value: object) -> JsonValue:
     return type(value).__name__
 
 
+def _send_result(value: object) -> dict[str, JsonValue]:
+    return cast(
+        dict[str, JsonValue],
+        SendResult(sent=True, result=_json_result(value)).model_dump(mode="json"),
+    )
+
+
 def _optional_text(value: object) -> str | None:
     rendered = str(value or "").strip()
     return rendered or None
@@ -548,12 +571,14 @@ def _runtime_api_declarations() -> tuple[RuntimeApiDeclaration, ...]:
             RuntimeApiOperation(
                 namespace="event",
                 operation="snapshot",
+                version=PORTABLE_RUNTIME_API_VERSION,
                 input_schema={"type": "object", "additionalProperties": False},
-                output_schema=_event_snapshot_schema(),
+                output_schema=portable_event_snapshot_schema(),
             ),
             RuntimeApiOperation(
                 namespace="event",
                 operation="send",
+                version=PORTABLE_RUNTIME_API_VERSION,
                 input_schema={
                     "type": "object",
                     "properties": {
@@ -567,17 +592,19 @@ def _runtime_api_declarations() -> tuple[RuntimeApiDeclaration, ...]:
                     "required": ["message"],
                     "additionalProperties": False,
                 },
-                output_schema={"type": "object", "additionalProperties": True},
+                output_schema=portable_send_result_schema(),
             ),
             RuntimeApiOperation(
                 namespace="bot",
                 operation="snapshot",
+                version=PORTABLE_RUNTIME_API_VERSION,
                 input_schema={"type": "object", "additionalProperties": False},
-                output_schema=_bot_snapshot_schema(),
+                output_schema=portable_bot_snapshot_schema(),
             ),
             RuntimeApiOperation(
                 namespace="bot",
                 operation="send",
+                version=PORTABLE_RUNTIME_API_VERSION,
                 input_schema={
                     "type": "object",
                     "properties": {
@@ -588,72 +615,10 @@ def _runtime_api_declarations() -> tuple[RuntimeApiDeclaration, ...]:
                     "required": ["bot_id", "message", "conversation"],
                     "additionalProperties": False,
                 },
-                output_schema={"type": "object", "additionalProperties": True},
+                output_schema=portable_send_result_schema(),
             ),
         ),
     )
-
-
-def _bot_snapshot_schema() -> dict[str, object]:
-    return {
-        "type": "object",
-        "properties": {
-            "bot_id": {"type": "string", "minLength": 1},
-            "platform_id": {"type": "string", "minLength": 1},
-            "platform_name": {"type": "string", "minLength": 1},
-            "capabilities": {"type": "array", "items": {"type": "string"}},
-        },
-        "required": ["bot_id", "platform_id", "platform_name", "capabilities"],
-        "additionalProperties": False,
-    }
-
-
-def _event_snapshot_schema() -> dict[str, object]:
-    return {
-        "type": "object",
-        "properties": {
-            "platform_id": {"type": "string", "minLength": 1},
-            "platform_name": {"type": "string", "minLength": 1},
-            "bot_id": {"type": "string", "minLength": 1},
-            "session_id": {"type": "string", "minLength": 1},
-            "group_id": {"type": ["string", "null"]},
-            "sender_id": {"type": ["string", "null"]},
-            "message": {"type": "string"},
-            "message_type": {"type": "string", "minLength": 1},
-            "conversation_id": {"type": "string", "minLength": 1},
-            "conversation_type": {"type": "string", "minLength": 1},
-            "actor_name": {"type": ["string", "null"]},
-            "actor_is_bot": {"type": "boolean"},
-            "message_segments": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "type": {"type": "string", "enum": ["text", "media", "mention", "reply", "adapter"]},
-                        "data": {"type": "object", "additionalProperties": True},
-                    },
-                    "required": ["type", "data"],
-                    "additionalProperties": False,
-                },
-            },
-        },
-        "required": [
-            "platform_id",
-            "platform_name",
-            "bot_id",
-            "session_id",
-            "group_id",
-            "sender_id",
-            "message",
-            "message_type",
-            "conversation_id",
-            "conversation_type",
-            "actor_name",
-            "actor_is_bot",
-            "message_segments",
-        ],
-        "additionalProperties": False,
-    }
 
 
 def _runtime_message(value: object) -> Message:

--- a/packages/runtime-astrbot/tests/test_translate.py
+++ b/packages/runtime-astrbot/tests/test_translate.py
@@ -268,7 +268,7 @@ async def test_astrbot_runtime_api_accepts_portable_message_and_exact_bot_send(
     assert bot_snapshot.result == {
         "bot_id": "bot-1",
         "adapter": "aiocqhttp",
-        "capabilities": [],
+        "capabilities": ["message.send"],
         "extensions": {"astrbot": {"platform_id": "qq", "platform_name": "aiocqhttp"}},
     }
 

--- a/packages/runtime-astrbot/tests/test_translate.py
+++ b/packages/runtime-astrbot/tests/test_translate.py
@@ -108,7 +108,7 @@ def test_astrbot_runtime_catalog_contains_alpha9_portable_operations() -> None:
         ("bot", "snapshot"),
         ("bot", "send"),
     }
-    assert all(item.version == "1.1" for item in declarations)
+    assert all(item.version == "1.2" for item in declarations)
     snapshot_schema = next(item for item in declarations if item.api_id == "event.snapshot").output_schema
     Draft202012Validator(dict(snapshot_schema)).validate(AstrBotGateway._event_snapshot(FakeAstrEvent()))
 
@@ -142,9 +142,19 @@ def test_astrbot_event_identity_uses_the_configured_bridge_id() -> None:
 def test_astrbot_event_snapshot_includes_portable_message_details() -> None:
     snapshot = AstrBotGateway._event_snapshot(FakeAstrEvent())
 
-    assert snapshot["conversation_id"] == "group-1"
-    assert snapshot["conversation_type"] == "group"
-    assert cast(object, snapshot["message_segments"]) == [{"type": "text", "data": {"text": "hello"}}]
+    assert snapshot["source_event_id"] == canonical_source_event_id("astrbot", "qq:bot-1", "message-1")
+    assert snapshot["conversation"] == {"id": "group-1", "type": "group", "parent_id": None}
+    expected_message = cast(JsonValue, {"segments": [{"type": "text", "data": {"text": "hello"}}]})
+    assert snapshot["message"] == expected_message
+    expected_extensions: JsonValue = {
+        "astrbot": {
+            "platform_id": "qq",
+            "platform_name": "aiocqhttp",
+            "session_id": "session-1",
+            "message_type": "group",
+        }
+    }
+    assert snapshot["extensions"] == expected_extensions
 
 
 @pytest.mark.asyncio
@@ -257,9 +267,9 @@ async def test_astrbot_runtime_api_accepts_portable_message_and_exact_bot_send(
     assert bot_snapshot.success is True
     assert bot_snapshot.result == {
         "bot_id": "bot-1",
-        "platform_id": "qq",
-        "platform_name": "aiocqhttp",
+        "adapter": "aiocqhttp",
         "capabilities": [],
+        "extensions": {"astrbot": {"platform_id": "qq", "platform_name": "aiocqhttp"}},
     }
 
     sent_payloads: list[MessageSendPayload] = []

--- a/packages/runtime-nonebot-api/README.md
+++ b/packages/runtime-nonebot-api/README.md
@@ -1,10 +1,12 @@
 # LiteyukiBot NoneBot Runtime API
 
-This package contains the framework-neutral typed facade for the Alpha9
-NoneBot runtime API. It deliberately does not depend on NoneBot or any
+This package contains the framework-neutral typed facade for the Alpha10.1
+NoneBot runtime API v1.2. It deliberately does not depend on NoneBot or any
 NoneBot adapter.
 
 The supported portable surface includes `event.snapshot()`,
 `event.send()` for text or a Liteyuki `Message`, `bot.snapshot()`, and
 `bot.send(message, conversation)`. These methods return JSON-safe DTOs and
 never expose NoneBot objects, adapter objects, or arbitrary API passthrough.
+Snapshot and send result types are kernel-owned portable DTOs; provider-specific
+values are available only under explicit extensions.

--- a/packages/runtime-nonebot-api/src/liteyukibot_runtime_nonebot_api/__init__.py
+++ b/packages/runtime-nonebot-api/src/liteyukibot_runtime_nonebot_api/__init__.py
@@ -5,36 +5,20 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import cast
 
-from pydantic import BaseModel, ConfigDict
-
-from liteyukibot.events import ActorRef, ConversationRef, JsonValue, Message
+from liteyukibot.events import ConversationRef, JsonValue, Message
 from liteyukibot.runtime_api import (
+    BotSnapshot,
+    EventSnapshot,
     RuntimeApiBackend,
     RuntimeApiError,
     RuntimeBinding,
     RuntimeCallContext,
     RuntimeNamespaceProxy,
+    SendResult,
 )
 
-
-class NoneBotEventSnapshot(BaseModel):
-    model_config = ConfigDict(frozen=True, extra="forbid")
-
-    runtime_id: str
-    adapter: str
-    bot_id: str
-    event_type: str
-    conversation: ConversationRef
-    actor: ActorRef | None = None
-    message: Message | None = None
-
-
-class NoneBotBotSnapshot(BaseModel):
-    model_config = ConfigDict(frozen=True, extra="forbid")
-
-    bot_id: str
-    adapter: str
-    capabilities: tuple[str, ...] = ()
+NoneBotEventSnapshot = EventSnapshot
+NoneBotBotSnapshot = BotSnapshot
 
 
 class NoneBotEventProxy(RuntimeNamespaceProxy):
@@ -54,12 +38,12 @@ class NoneBotEventProxy(RuntimeNamespaceProxy):
                 "RUNTIME_API_INVALID_RESULT",
             ) from error
 
-    async def send(self, message: str | Message) -> Mapping[str, JsonValue]:
+    async def send(self, message: str | Message) -> SendResult:
         argument: JsonValue = message if isinstance(message, str) else cast(
             dict[str, JsonValue], message.model_dump(mode="json")
         )
         value = await self.call("send", {"message": argument})
-        return _mapping_result(self, "send", value)
+        return _send_result(self, "send", value)
 
 
 class NoneBotBotProxy(RuntimeNamespaceProxy):
@@ -79,7 +63,7 @@ class NoneBotBotProxy(RuntimeNamespaceProxy):
                 "RUNTIME_API_INVALID_RESULT",
             ) from error
 
-    async def send(self, message: Message, conversation: ConversationRef) -> Mapping[str, JsonValue]:
+    async def send(self, message: Message, conversation: ConversationRef) -> SendResult:
         arguments = cast(
             Mapping[str, JsonValue],
             {
@@ -88,7 +72,7 @@ class NoneBotBotProxy(RuntimeNamespaceProxy):
             },
         )
         value = await self.call("send", arguments)
-        return _mapping_result(self, "send", value)
+        return _send_result(self, "send", value)
 
 
 def event_proxy_factory(
@@ -111,10 +95,18 @@ def bot_proxy_factory(
     return NoneBotBotProxy(binding, backend, context, reason=reason)
 
 
-def _mapping_result(proxy: RuntimeNamespaceProxy, operation: str, value: JsonValue) -> Mapping[str, JsonValue]:
-    if not isinstance(value, Mapping) or any(not isinstance(key, str) for key in value):
+def _send_result(proxy: RuntimeNamespaceProxy, operation: str, value: JsonValue) -> SendResult:
+    if not isinstance(value, Mapping):
         raise RuntimeApiError(proxy.binding.runtime, proxy.binding.api, operation, "RUNTIME_API_INVALID_RESULT")
-    return value
+    try:
+        return SendResult.model_validate(value)
+    except ValueError as error:
+        raise RuntimeApiError(
+            proxy.binding.runtime,
+            proxy.binding.api,
+            operation,
+            "RUNTIME_API_INVALID_RESULT",
+        ) from error
 
 
 __all__ = [
@@ -122,6 +114,7 @@ __all__ = [
     "NoneBotBotSnapshot",
     "NoneBotEventProxy",
     "NoneBotEventSnapshot",
+    "SendResult",
     "bot_proxy_factory",
     "event_proxy_factory",
 ]

--- a/packages/runtime-nonebot-api/tests/test_nonebot_api_proxy.py
+++ b/packages/runtime-nonebot-api/tests/test_nonebot_api_proxy.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 import pytest
 from liteyukibot_runtime_nonebot_api import NoneBotBotProxy, NoneBotEventProxy
 
-from liteyukibot import AuthorizationContext, RuntimeBinding, RuntimeCallContext
+from liteyukibot import AuthorizationContext, RuntimeApiError, RuntimeBinding, RuntimeCallContext
 from liteyukibot.events import ConversationRef, EventEnvelope, JsonValue, Message, Segment
 
 
@@ -32,6 +32,7 @@ async def test_typed_nonebot_facades_map_portable_event_and_bot_operations() -> 
         ) -> JsonValue:
             if binding.api == "event" and operation == "snapshot":
                 return {
+                    "source_event_id": "v1:nonebot:onebot-v11:bot-1:event-1",
                     "runtime_id": "nonebot",
                     "adapter": "onebot-v11",
                     "bot_id": "bot-1",
@@ -66,6 +67,28 @@ async def test_typed_nonebot_facades_map_portable_event_and_bot_operations() -> 
     )
 
     assert snapshot.adapter == "onebot-v11"
-    assert sent == {"sent": True}
+    assert sent.sent is True
     assert bot_snapshot.bot_id == "bot-1"
-    assert proactive == {"sent": True}
+    assert proactive.sent is True
+
+
+@pytest.mark.asyncio
+async def test_nonebot_send_rejects_an_invalid_canonical_result() -> None:
+    class Backend:
+        async def invoke(
+            self,
+            _binding: RuntimeBinding,
+            _operation: str,
+            _arguments: Mapping[str, JsonValue],
+            _context: RuntimeCallContext,
+        ) -> JsonValue:
+            return {}
+
+    proxy = NoneBotEventProxy(
+        RuntimeBinding("nonebot", "event", "^1.2", False, "nonebot"),
+        Backend(),
+        _context(),
+    )
+
+    with pytest.raises(RuntimeApiError, match="RUNTIME_API_INVALID_RESULT"):
+        await proxy.send("hello")

--- a/packages/runtime-nonebot/README.md
+++ b/packages/runtime-nonebot/README.md
@@ -20,9 +20,10 @@ initialization is configured under `broker.bridges.<id>.options` with
 message editing are not part of this bridge contract.
 
 With the separately installed `liteyukibot-v7-runtime-nonebot-api` package, the
-bridge publishes the Alpha9 v1.1 `event.snapshot`, `event.send`,
-`bot.snapshot`, and `bot.send` runtime APIs. Only portable JSON DTOs cross the
-Broker boundary; NoneBot and adapter objects remain local to this process.
+bridge publishes the Alpha10.1 v1.2 `event.snapshot`, `event.send`,
+`bot.snapshot`, and `bot.send` runtime APIs. Only kernel-owned portable JSON
+DTOs cross the Broker boundary; NoneBot and adapter objects remain local to
+this process.
 
 The configured bridge ID is passed into every normalized event. Source event
 IDs use the shared `v1:` composite of bridge ID, adapter/bot scope, and upstream

--- a/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/host.py
+++ b/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/host.py
@@ -14,6 +14,7 @@ import zmq.asyncio
 
 from liteyukibot.broker import (
     MESSAGE_SEND_KIND,
+    PORTABLE_RUNTIME_API_VERSION,
     ActionOutcome,
     ActionRequest,
     ActionResourceDeclaration,
@@ -29,14 +30,18 @@ from liteyukibot.broker import (
     RuntimeApiOperation,
     RuntimeApiOutcome,
     parse_message_send_request,
+    portable_bot_snapshot_schema,
     portable_conversation_schema,
+    portable_event_snapshot_schema,
     portable_message_schema,
+    portable_send_result_schema,
     runtime_api_catalog,
 )
 from liteyukibot.config import AppSettings
 from liteyukibot.events import ConversationRef, EventEnvelope, JsonValue, Message, Segment
 from liteyukibot.logging import get_logger
 from liteyukibot.lyip import LyipLane
+from liteyukibot.runtime_api import BotSnapshot, EventSnapshot, SendResult
 
 from .contracts import AdapterContractError, adapter_id, json_value, normalize_event, send_proactive, to_native_message
 
@@ -188,7 +193,7 @@ class NoneBotHost:
                 result = await bot.send(event, native)
             except Exception:
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_SEND_FAILED")
-            return RuntimeApiOutcome(success=True, result={"sent": True, "result": json_value(result)})
+            return RuntimeApiOutcome(success=True, result=_send_result(result))
         if request.api_id == "bot.snapshot":
             if request.arguments:
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_INVALID_ARGUMENTS")
@@ -212,7 +217,7 @@ class NoneBotHost:
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_INVALID_ARGUMENTS")
             except Exception:
                 return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_SEND_FAILED")
-            return RuntimeApiOutcome(success=True, result={"sent": True, "result": json_value(result)})
+            return RuntimeApiOutcome(success=True, result=_send_result(result))
         return RuntimeApiOutcome(success=False, error_code="RUNTIME_API_NOT_REGISTERED")
 
     async def _send_message(self, payload: MessageSendPayload) -> Any:
@@ -324,23 +329,37 @@ def _portable_send_action(payload: MessageSendPayload) -> Any:
 
 
 def _event_snapshot(envelope: EventEnvelope) -> dict[str, JsonValue]:
-    return {
-        "runtime_id": envelope.runtime_id,
-        "adapter": envelope.adapter,
-        "bot_id": envelope.bot_id,
-        "event_type": envelope.type,
-        "conversation": cast(JsonValue, json_value(envelope.conversation)),
-        "actor": None if envelope.actor is None else cast(JsonValue, json_value(envelope.actor)),
-        "message": None if envelope.message is None else cast(JsonValue, json_value(envelope.message)),
-    }
+    return cast(
+        dict[str, JsonValue],
+        EventSnapshot(
+            source_event_id=envelope.id,
+            runtime_id=envelope.runtime_id,
+            adapter=envelope.adapter,
+            bot_id=envelope.bot_id,
+            event_type=envelope.type,
+            conversation=envelope.conversation,
+            actor=envelope.actor,
+            message=envelope.message,
+        ).model_dump(mode="json"),
+    )
 
 
 def _bot_snapshot(bot: Any) -> dict[str, JsonValue]:
-    return {
-        "bot_id": str(bot.self_id),
-        "adapter": adapter_id(str(bot.adapter.get_name())),
-        "capabilities": cast(JsonValue, ["message.send"]),
-    }
+    return cast(
+        dict[str, JsonValue],
+        BotSnapshot(
+            bot_id=str(bot.self_id),
+            adapter=adapter_id(str(bot.adapter.get_name())),
+            capabilities=("message.send",),
+        ).model_dump(mode="json"),
+    )
+
+
+def _send_result(value: object) -> dict[str, JsonValue]:
+    return cast(
+        dict[str, JsonValue],
+        SendResult(sent=True, result=json_value(value)).model_dump(mode="json"),
+    )
 
 
 def _runtime_message(value: object) -> Message:
@@ -366,12 +385,14 @@ def _runtime_api_declarations() -> tuple[RuntimeApiDeclaration, ...]:
             RuntimeApiOperation(
                 namespace="event",
                 operation="snapshot",
+                version=PORTABLE_RUNTIME_API_VERSION,
                 input_schema={"type": "object", "additionalProperties": False},
-                output_schema=_event_snapshot_schema(),
+                output_schema=portable_event_snapshot_schema(),
             ),
             RuntimeApiOperation(
                 namespace="event",
                 operation="send",
+                version=PORTABLE_RUNTIME_API_VERSION,
                 input_schema={
                     "type": "object",
                     "properties": {
@@ -385,17 +406,19 @@ def _runtime_api_declarations() -> tuple[RuntimeApiDeclaration, ...]:
                     "required": ["message"],
                     "additionalProperties": False,
                 },
-                output_schema={"type": "object", "additionalProperties": True},
+                output_schema=portable_send_result_schema(),
             ),
             RuntimeApiOperation(
                 namespace="bot",
                 operation="snapshot",
+                version=PORTABLE_RUNTIME_API_VERSION,
                 input_schema={"type": "object", "additionalProperties": False},
-                output_schema=_bot_snapshot_schema(),
+                output_schema=portable_bot_snapshot_schema(),
             ),
             RuntimeApiOperation(
                 namespace="bot",
                 operation="send",
+                version=PORTABLE_RUNTIME_API_VERSION,
                 input_schema={
                     "type": "object",
                     "properties": {
@@ -406,53 +429,10 @@ def _runtime_api_declarations() -> tuple[RuntimeApiDeclaration, ...]:
                     "required": ["bot_id", "message", "conversation"],
                     "additionalProperties": False,
                 },
-                output_schema={"type": "object", "additionalProperties": True},
+                output_schema=portable_send_result_schema(),
             ),
         ),
     )
-
-
-def _event_snapshot_schema() -> dict[str, object]:
-    return {
-        "type": "object",
-        "properties": {
-            "runtime_id": {"type": "string", "minLength": 1},
-            "adapter": {"type": "string", "minLength": 1},
-            "bot_id": {"type": "string", "minLength": 1},
-            "event_type": {"type": "string", "minLength": 1},
-            "conversation": portable_conversation_schema(),
-            "actor": {"oneOf": [_actor_schema(), {"type": "null"}]},
-            "message": {"oneOf": [portable_message_schema(), {"type": "null"}]},
-        },
-        "required": ["runtime_id", "adapter", "bot_id", "event_type", "conversation", "actor", "message"],
-        "additionalProperties": False,
-    }
-
-
-def _actor_schema() -> dict[str, object]:
-    return {
-        "type": "object",
-        "properties": {
-            "id": {"type": "string", "minLength": 1},
-            "display_name": {"type": ["string", "null"]},
-            "is_bot": {"type": "boolean"},
-        },
-        "required": ["id"],
-        "additionalProperties": False,
-    }
-
-
-def _bot_snapshot_schema() -> dict[str, object]:
-    return {
-        "type": "object",
-        "properties": {
-            "bot_id": {"type": "string", "minLength": 1},
-            "adapter": {"type": "string", "minLength": 1},
-            "capabilities": {"type": "array", "items": {"type": "string"}},
-        },
-        "required": ["bot_id", "adapter", "capabilities"],
-        "additionalProperties": False,
-    }
 
 
 def _mapping_option(options: Mapping[str, Any], key: str) -> dict[str, Any]:

--- a/packages/runtime-nonebot/tests/test_nonebot_bridge.py
+++ b/packages/runtime-nonebot/tests/test_nonebot_bridge.py
@@ -40,7 +40,7 @@ def test_nonebot_runtime_catalog_contains_alpha9_portable_operations() -> None:
         ("bot", "snapshot"),
         ("bot", "send"),
     }
-    assert all(item.version == "1.1" for item in declarations)
+    assert all(item.version == "1.2" for item in declarations)
 
 
 def test_nonebot_ingress_is_json_safe_and_ordered_by_conversation() -> None:
@@ -274,7 +274,12 @@ async def test_nonebot_runtime_api_uses_portable_dtos_and_exact_bot_identity(
     assert isinstance(snapshot.result, Mapping)
     assert snapshot.result["conversation"] == {"id": "2002", "type": "group", "parent_id": None}
     assert event_send.success is True
-    assert bot_snapshot.result == {"bot_id": "42", "adapter": "onebot-v11", "capabilities": ["message.send"]}
+    assert bot_snapshot.result == {
+        "bot_id": "42",
+        "adapter": "onebot-v11",
+        "capabilities": ["message.send"],
+        "extensions": {},
+    }
 
     sent_payloads: list[MessageSendPayload] = []
 

--- a/src/liteyukibot/__init__.py
+++ b/src/liteyukibot/__init__.py
@@ -56,6 +56,8 @@ from .plugins import (
 )
 from .resource_packs import RESOURCE_CATALOG_SERVICE, ResourceCatalog, ResourcePackDeclaration
 from .runtime_api import (
+    BotSnapshot,
+    EventSnapshot,
     RuntimeApiBackend,
     RuntimeApiError,
     RuntimeApiProxy,
@@ -64,6 +66,7 @@ from .runtime_api import (
     RuntimeNamespaceProxy,
     RuntimeRequirement,
     RuntimeUnavailable,
+    SendResult,
     create_runtime_proxy,
     invoke_with_runtime,
     runtime,
@@ -136,6 +139,8 @@ __all__ = [
     "ResourceCatalog",
     "ResourcePackDeclaration",
     "RuntimeApiBackend",
+    "BotSnapshot",
+    "EventSnapshot",
     "RuntimeApiError",
     "RuntimeApiProxy",
     "RuntimeBinding",
@@ -143,6 +148,7 @@ __all__ = [
     "RuntimeNamespaceProxy",
     "RuntimeRequirement",
     "RuntimeUnavailable",
+    "SendResult",
     "create_runtime_proxy",
     "invoke_with_runtime",
     "runtime",

--- a/src/liteyukibot/broker/__init__.py
+++ b/src/liteyukibot/broker/__init__.py
@@ -84,9 +84,13 @@ from .routing import (
     ToolResult,
 )
 from .runtime_catalog import (
+    PORTABLE_RUNTIME_API_VERSION,
     RuntimeApiOperation,
+    portable_bot_snapshot_schema,
     portable_conversation_schema,
+    portable_event_snapshot_schema,
     portable_message_schema,
+    portable_send_result_schema,
     runtime_api_catalog,
 )
 from .service import (
@@ -131,6 +135,7 @@ __all__ = [
     "BrokerToolDeclaration",
     "RuntimeApiDeclaration",
     "RuntimeApiOperation",
+    "PORTABLE_RUNTIME_API_VERSION",
     "BridgeAccess",
     "BridgeClient",
     "BrokerBridgeRunner",
@@ -178,7 +183,10 @@ __all__ = [
     "RuntimeApiResult",
     "runtime_api_catalog",
     "portable_conversation_schema",
+    "portable_bot_snapshot_schema",
+    "portable_event_snapshot_schema",
     "portable_message_schema",
+    "portable_send_result_schema",
     "decode_broker_message",
     "decode_business_message",
     "encode_business_message",

--- a/src/liteyukibot/broker/runtime_catalog.py
+++ b/src/liteyukibot/broker/runtime_catalog.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import cast
 
+from ..runtime_api_models import BotSnapshot, EventSnapshot, SendResult
 from .protocol import RuntimeApiDeclaration
+
+PORTABLE_RUNTIME_API_VERSION = "1.2"
 
 
 def _identifier(value: str, field: str) -> str:
@@ -110,9 +114,31 @@ def portable_conversation_schema() -> dict[str, object]:
     }
 
 
+def portable_event_snapshot_schema() -> dict[str, object]:
+    """Return the canonical EventSnapshot JSON schema."""
+
+    return cast(dict[str, object], EventSnapshot.model_json_schema())
+
+
+def portable_bot_snapshot_schema() -> dict[str, object]:
+    """Return the canonical BotSnapshot JSON schema."""
+
+    return cast(dict[str, object], BotSnapshot.model_json_schema())
+
+
+def portable_send_result_schema() -> dict[str, object]:
+    """Return the canonical SendResult JSON schema."""
+
+    return cast(dict[str, object], SendResult.model_json_schema())
+
+
 __all__ = [
+    "PORTABLE_RUNTIME_API_VERSION",
     "RuntimeApiOperation",
+    "portable_bot_snapshot_schema",
     "portable_conversation_schema",
+    "portable_event_snapshot_schema",
     "portable_message_schema",
+    "portable_send_result_schema",
     "runtime_api_catalog",
 ]

--- a/src/liteyukibot/runtime_api.py
+++ b/src/liteyukibot/runtime_api.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, field_validator
 from .authorization import AuthorizationContext
 from .events import EventEnvelope
 from .events.models import JsonValue
+from .runtime_api_models import BotSnapshot, EventSnapshot, SendResult
 
 RUNTIME_BINDINGS_ATTRIBUTE = "__liteyuki_runtime_bindings__"
 
@@ -292,6 +293,8 @@ def runtime_handler(
 
 
 __all__ = [
+    "BotSnapshot",
+    "EventSnapshot",
     "RuntimeApiBackend",
     "RuntimeApiError",
     "RuntimeApiProxy",
@@ -301,6 +304,7 @@ __all__ = [
     "RuntimeProxyFactory",
     "RuntimeRequirement",
     "RuntimeUnavailable",
+    "SendResult",
     "invoke_with_runtime",
     "create_runtime_proxy",
     "runtime",

--- a/src/liteyukibot/runtime_api_models.py
+++ b/src/liteyukibot/runtime_api_models.py
@@ -1,0 +1,54 @@
+"""Kernel-owned DTOs for the portable runtime API facade."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .events import ActorRef, ConversationRef, JsonValue, Message
+
+
+class RuntimeApiModel(BaseModel):
+    """Frozen JSON-safe base for values crossing the Runtime API boundary."""
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        allow_inf_nan=False,
+        validate_default=True,
+    )
+
+
+class EventSnapshot(RuntimeApiModel):
+    """Portable identity and content projection of one active source event."""
+
+    source_event_id: str = Field(min_length=1)
+    runtime_id: str = Field(min_length=1)
+    adapter: str = Field(min_length=1)
+    bot_id: str = Field(min_length=1)
+    event_type: str = Field(min_length=1)
+    conversation: ConversationRef
+    actor: ActorRef | None = None
+    message: Message | None = None
+    extensions: Mapping[str, JsonValue] = Field(default_factory=dict)
+
+
+class BotSnapshot(RuntimeApiModel):
+    """Portable identity and capability projection of one provider bot."""
+
+    bot_id: str = Field(min_length=1)
+    adapter: str = Field(min_length=1)
+    capabilities: tuple[str, ...] = ()
+    extensions: Mapping[str, JsonValue] = Field(default_factory=dict)
+
+
+class SendResult(RuntimeApiModel):
+    """Portable result envelope for provider-owned message sends."""
+
+    sent: bool
+    result: JsonValue = None
+    extensions: Mapping[str, JsonValue] = Field(default_factory=dict)
+
+
+__all__ = ["BotSnapshot", "EventSnapshot", "RuntimeApiModel", "SendResult"]

--- a/tests/test_runtime_facade_contract.py
+++ b/tests/test_runtime_facade_contract.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from liteyukibot_runtime_astrbot.host import _runtime_api_declarations as astrbot_declarations
+from liteyukibot_runtime_astrbot_api import AstrBotBotSnapshot, AstrBotEventSnapshot
+from liteyukibot_runtime_nonebot.host import _runtime_api_declarations as nonebot_declarations
+from liteyukibot_runtime_nonebot_api import NoneBotBotSnapshot, NoneBotEventSnapshot
+from pydantic import ValidationError
+
+from liteyukibot.broker import PORTABLE_RUNTIME_API_VERSION
+from liteyukibot.events import ActorRef, ConversationRef, JsonValue, Message, Segment
+from liteyukibot.runtime_api import BotSnapshot, EventSnapshot, SendResult
+
+
+def _event_snapshot() -> EventSnapshot:
+    return EventSnapshot(
+        source_event_id="v1:bridge:adapter%3Abot:event",
+        runtime_id="bridge",
+        adapter="adapter",
+        bot_id="bot",
+        event_type="message.created",
+        conversation=ConversationRef(id="chat", type="group"),
+        actor=ActorRef(id="user", display_name="User"),
+        message=Message(segments=(Segment(type="text", data={"text": "hello"}),)),
+    )
+
+
+def test_runtime_facade_models_are_json_safe_and_round_trip() -> None:
+    event = _event_snapshot()
+    bot = BotSnapshot(bot_id="bot", adapter="adapter", capabilities=("message.send",))
+    result = SendResult(sent=True, result={"message_id": "sent"})
+
+    assert EventSnapshot.model_validate_json(event.model_dump_json()) == event
+    assert BotSnapshot.model_validate_json(bot.model_dump_json()) == bot
+    assert SendResult.model_validate_json(result.model_dump_json()) == result
+    dumped = cast(dict[str, JsonValue], event.model_dump(mode="json"))
+    assert dumped["extensions"] == {}
+
+
+def test_runtime_facade_rejects_non_json_send_results() -> None:
+    with pytest.raises(ValidationError, match="Input should be a valid"):
+        SendResult(sent=True, result=cast(Any, {"bad": object()}))
+
+
+def test_provider_catalogs_share_the_canonical_portable_contract() -> None:
+    nonebot = {item.api_id: item for item in nonebot_declarations()}
+    astrbot = {item.api_id: item for item in astrbot_declarations()}
+
+    assert set(nonebot) == {"event.snapshot", "event.send", "bot.snapshot", "bot.send"}
+    assert set(astrbot) == set(nonebot)
+    for api_id in nonebot:
+        assert nonebot[api_id].version == PORTABLE_RUNTIME_API_VERSION
+        assert astrbot[api_id].version == PORTABLE_RUNTIME_API_VERSION
+        assert astrbot[api_id].input_schema == nonebot[api_id].input_schema
+        assert astrbot[api_id].output_schema == nonebot[api_id].output_schema
+
+
+def test_provider_snapshot_names_are_compatibility_views_of_kernel_models() -> None:
+    event = _event_snapshot().model_dump(mode="json")
+    event["extensions"] = {
+        "astrbot": {
+            "platform_id": "qq",
+            "platform_name": "aiocqhttp",
+            "session_id": "session-1",
+            "message_type": "group",
+        }
+    }
+    astrbot_event = AstrBotEventSnapshot.model_validate(event)
+    astrbot_bot = AstrBotBotSnapshot.model_validate(
+        {
+            "bot_id": "bot",
+            "adapter": "aiocqhttp",
+            "extensions": {"astrbot": {"platform_id": "qq", "platform_name": "aiocqhttp"}},
+        }
+    )
+
+    assert isinstance(astrbot_event, EventSnapshot)
+    assert astrbot_event.message is not None
+    assert astrbot_event.message_text == "hello"
+    assert astrbot_event.platform_id == "qq"
+    assert astrbot_event.session_id == "session-1"
+    assert astrbot_event.message_segments[0].type == "text"
+    assert astrbot_bot.platform_id == "qq"
+    assert astrbot_bot.platform_name == "aiocqhttp"
+    assert NoneBotEventSnapshot is EventSnapshot
+    assert NoneBotBotSnapshot is BotSnapshot


### PR DESCRIPTION
## Summary

- add kernel-owned `EventSnapshot`, `BotSnapshot`, and `SendResult` DTOs with shared Runtime API v1.2 schemas
- converge NoneBot and AstrBot bridge catalogs, host projections, and typed API facades
- preserve provider-specific compatibility fields under namespaced extensions and document the AstrBot message migration
- add cross-provider conformance tests and Alpha10.1 contract documentation

## Validation

- `uv run pytest` -> 740 passed, 11 skipped
- `uv run ruff check src tests scripts examples packages`
- `uv run mypy`
- `uv build --all-packages --out-dir dist/workspace --clear`
- NoneBot/AstrBot runtime install verifiers
- isolated NoneBot/AstrBot API wheel verifiers
- external `F:\\tmp\\liteyukibot`: locked sync, full pytest, and both runtime install verifiers

`uv run liteyuki check` is not applicable at the repository root because it has no project `liteyuki.toml`. The external workspace retains its existing v5 configuration and reports the pre-existing manual v5-to-v6 migration requirement.

Alpha11 and later remain out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Runtime API v1.2 with standardized event, bot, and send-result data.
  - Added portable, JSON-safe snapshots and typed send results across NoneBot and AstrBot integrations.
  - Added support for provider-specific metadata through explicit extensions.

- **Bug Fixes**
  - Invalid or non-JSON send results are now rejected with clear runtime errors.

- **Documentation**
  - Updated API references and roadmap documentation for Alpha 10.1 and planned follow-up work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->