### PR TITLE
[Alpha10.2] Prove ecosystem runtime contracts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,11 @@ jobs:
           uv run python -m scripts.run_astrbot_runtime_install
           uv run python -m scripts.run_mofox_runtime_install
           uv run python -m scripts.run_webui_install
+          uv run python scripts/run_isolated_install.py --with dist/workspace/liteyukibot_v7-7.0.0a9-py3-none-any.whl --with dist/workspace/liteyukibot_v7_runtime_nonebot_api-7.0.0a9-py3-none-any.whl --verifier scripts/verify_nonebot_api_install.py -- --expected-version 7.0.0a9
+          uv run python scripts/run_isolated_install.py --with dist/workspace/liteyukibot_v7-7.0.0a9-py3-none-any.whl --with dist/workspace/liteyukibot_v7_runtime_astrbot_api-7.0.0a9-py3-none-any.whl --verifier scripts/verify_astrbot_api_install.py -- --expected-version 7.0.0a9
+          uv build --project examples/broker-peer --out-dir dist/examples
+          uv run python scripts/run_isolated_install.py --with dist/workspace/liteyukibot_v7-7.0.0a9-py3-none-any.whl --with dist/examples/liteyukibot_example_broker_peer-0.1.0-py3-none-any.whl --verifier scripts/verify_broker_peer_example.py
+          uv run python scripts/run_isolated_install.py --with dist/workspace/liteyukibot_v7-7.0.0a9-py3-none-any.whl --with dist/examples/liteyukibot_example_plugin-0.1.0-py3-none-any.whl --verifier scripts/verify_native_plugin_example.py
       - name: Run WebUI browser checks
         if: matrix.os == 'ubuntu-latest'
         working-directory: LiteyukiBot

--- a/README.md
+++ b/README.md
@@ -15,15 +15,17 @@
 ## About
 
 LiteyukiBot v7 is a CPython 3.14 chatbot kernel. It owns configuration,
-native-plugin lifecycle, routing, permissions, logging, and local runtime IPC.
-Framework integrations run as separately installed supervised child runtimes;
-they exchange frozen Event and Action models with the kernel rather than SDK
-objects.
+native-plugin lifecycle, routing, permissions, logging, and broker-peer IPC.
+Framework integrations run as separately installed B7 broker bridges and
+exchange frozen protocol-neutral models with the kernel rather than SDK
+objects. The supervised child-runtime path remains only as historical
+compatibility support.
 
 The default branch is the maintained LiteyukiBot v7 line. The prior v6 line is
-preserved on the `v6` branch. The current source is the `7.0.0a2` Alpha bundle
-baseline; it is not a PyPI release. The earlier `7.0.0b2` B7 package is
-historical release evidence.
+preserved on the `v6` branch. The current source pre-release is the `7.0.0a9`
+Alpha lockstep baseline; it is not a PyPI release. Alpha10.1 freezes the
+portable runtime facade, and Alpha10.2 proves the broker-peer and wheel-
+contributor path.
 
 ## Features
 
@@ -33,14 +35,14 @@ historical release evidence.
   material for configuration upgrades;
 - native plugins with explicit entry points, lifecycle hooks, services,
   managed tasks, private storage, resource packs, and localized text;
-- authenticated loopback IPC, child-runtime supervision, per-conversation
-  event ordering, bounded concurrency, and routed protocol-neutral actions;
+- authenticated B7 broker-peer IPC, per-conversation event ordering, bounded
+  concurrency, lease-bound deliveries, and routed protocol-neutral actions;
 - retained and verifiable runtime plugin generations with source indexes,
   rollback, disable/enable, and garbage collection commands;
 - first-party command, permission, resource, profile, essential-command, and
   agent packages;
 - bounded LiteyukiBot v6 compatibility and separate NoneBot2, native OneBot
-  v11, AstrBot, and Neo-MoFox runtime packages.
+  v11, AstrBot, and Neo-MoFox bridge packages.
 
 ## Install And Run
 
@@ -88,14 +90,16 @@ enabled in `liteyuki.toml`.
 | `liteyukibot-v7-profile` | Persistent per-bot nickname and language profiles. |
 | `liteyukibot-v7-essentials` | Help and protected status commands. |
 | `liteyukibot-v7-functions` | v6 `.lyf`, `.lyfunction`, and `.mcfunction` executor. |
-| `liteyukibot-v7-runtime-nonebot` | Supervised NoneBot2 runtime host. |
-| `liteyukibot-v7-runtime-adapter` | Supervised Python platform-adapter host. |
+| `liteyukibot-v7-runtime-nonebot` | B7 NoneBot2 broker bridge. |
+| `liteyukibot-v7-runtime-nonebot-api` | NoneBot-independent typed Runtime API v1.2 facade. |
+| `liteyukibot-v7-runtime-adapter` | Python platform-adapter broker bridge. |
 | `liteyukibot-v7-adapter-onebot` | Native OneBot v11 HTTP Post and HTTP API adapter. |
 | `liteyukibot-v7-runtime-v6` | Bounded LiteyukiBot v6 compatibility runtime. |
 | `liteyukibot-v7-agent-resolver` | Declarative agent module and tool resolver. |
 | `liteyukibot-v7-agent` | OpenAI-compatible native agent runtime. |
-| `liteyukibot-v7-runtime-astrbot` | Headless AstrBot agent runtime. |
-| `liteyukibot-v7-runtime-mofox` | Headless Neo-MoFox agent runtime. |
+| `liteyukibot-v7-runtime-astrbot` | AstrBot B7 platform gateway. |
+| `liteyukibot-v7-runtime-astrbot-api` | AstrBot-independent typed Runtime API v1.2 facade. |
+| `liteyukibot-v7-runtime-mofox` | Headless Neo-MoFox agent bridge. |
 
 Read the package README in [`packages/`](packages/README.md) before enabling a
 package. The kernel does not install framework integrations implicitly.
@@ -130,6 +134,7 @@ tokens, or message payloads in public reports.
 - [v6 compatibility](docs/migration-v6.md)
 - [Native plugin development](docs/development/native-plugins.md)
 - [Custom runtime development](docs/development/custom-runtimes.md)
+- [Runtime API and provider conformance](docs/development/runtime-api-conformance.md)
 - [Contributor guide](CONTRIBUTING.md)
 - [Release procedure](docs/development/releasing.md)
 

--- a/docs/development/custom-runtimes.md
+++ b/docs/development/custom-runtimes.md
@@ -53,6 +53,38 @@ that action only while dispatching the matching active broker delivery. `CallApi
 message editing, and a generic function/decorator DSL are deferred to later
 version planning.
 
+The installable [B7 broker-peer example](../../examples/broker-peer) runs this
+lifecycle over the real ZMQ transport, including registration, ingress, a
+lease-bound experimental runtime API, completion, unregister, and shutdown.
+Use it as a protocol smoke test, not as a framework adapter template.
+
+## Runtime API facade for plugins
+
+Native and Cordis extensions share the kernel-owned `RuntimeRequirement` and
+`@runtime` declarations. A provider facade is an optional dependency of the
+extension, not a kernel import:
+
+```python
+from typing import Any
+
+from liteyukibot import runtime
+
+
+@runtime("astrbot", api="event", version="^1.2", optional=True, as_="astrbot")
+async def handler(event: object, *, astrbot: Any) -> None:
+    if not astrbot.available:
+        return
+    snapshot = getattr(astrbot, "snapshot", None)
+    if callable(snapshot):
+        await snapshot()
+```
+
+The manifest must contain the same runtime, API, version, optional flag, and
+operation list. Use `bridge_id` on both declarations when targeting one named
+bridge. The full portable operation set, catalog fingerprint rule, provider
+checklist, and failure guide are in
+[`runtime-api-conformance.md`](runtime-api-conformance.md).
+
 The v6 and MoFox compatibility packages are limited bridge examples. v6 keeps
 its matcher/session compatibility process-local and loads only configured
 `liteyukibot.v6_plugins` entry points. MoFox loads only a configured isolated

--- a/docs/development/runtime-api-conformance.md
+++ b/docs/development/runtime-api-conformance.md
@@ -1,0 +1,123 @@
+# Runtime API and provider conformance
+
+This guide is the Alpha10.2 contributor gate for the B7 broker bridge and the
+Native/Cordis runtime facade. Alpha11 provider expansion is outside this page.
+
+## Portable catalog
+
+Runtime API v1.2 has exactly four stable portable operations:
+
+| Operation | Capability | Result |
+| --- | --- | --- |
+| `event.snapshot` | `runtime.<kind>.event.snapshot` | `EventSnapshot` |
+| `event.send` | `runtime.<kind>.event.send` | `SendResult` |
+| `bot.snapshot` | `runtime.<kind>.bot.snapshot` | `BotSnapshot` |
+| `bot.send` | `runtime.<kind>.bot.send` | `SendResult` |
+
+Use `portable_runtime_api_catalog(runtime_kind)` from the kernel broker API to
+bind this catalog to a provider. Do not duplicate its schemas in a provider
+host. Every non-empty `BridgeManifest.runtime_apis` catalog has a deterministic
+SHA-256 `runtime_api_fingerprint`; a supplied fingerprint must match the
+declarations exactly.
+
+Provider-specific values belong under a namespace such as
+`extensions["astrbot"]`. Stable portable consumers must not depend on those
+values. New provider-only operations use an `experimental` namespace until a
+future contract explicitly promotes them.
+
+## Plugin declaration
+
+The decorator binding and manifest requirement must agree exactly:
+
+```python
+from typing import Any
+
+from liteyukibot import RuntimeRequirement, runtime
+
+
+requirements = (
+    RuntimeRequirement(
+        runtime="astrbot",
+        api="event",
+        version="^1.2",
+        operations=("snapshot",),
+        optional=True,
+        bridge_id="astrbot-prod",
+    ),
+)
+
+
+@runtime(
+    "astrbot",
+    api="event",
+    version="^1.2",
+    optional=True,
+    as_="astrbot",
+    bridge_id="astrbot-prod",
+)
+async def handler(event: object, *, astrbot: Any) -> None:
+    if not astrbot.available:
+        return
+    snapshot = getattr(astrbot, "snapshot", None)
+    if callable(snapshot):
+        await snapshot()
+```
+
+Optional providers must treat `available == False` and `RuntimeUnavailable` as
+normal paths. Required providers fail registration when the declared runtime
+requirement cannot be resolved. Provider send failures and invalid results
+must remain stable `RUNTIME_*` errors; do not leak framework exception types.
+Runtime requirements also contribute activation capabilities, so the host's
+Permission v2 ceiling must explicitly allow the requested runtime capability.
+
+## Provider checklist
+
+- Keep framework imports and native conversion inside the provider package.
+- Bind the configured bridge ID into runtime identity and source event IDs.
+- Use `BridgeClient` and retain the broker delivery lease until completion.
+- Declare only owned subscriptions, action resources, controls, tools, and
+  runtime APIs in the manifest.
+- Use the kernel portable catalog helper for the four stable operations.
+- Keep provider values in a named extension namespace.
+- Reject cross-bot calls and return bounded unavailable, invalid-argument,
+  invalid-result, and send-failure codes.
+- Add non-default bridge ID, disconnect, duplicate source ID, and wheel import
+  tests.
+- Run the full repository checks and the package's isolated wheel verifier.
+
+## Release verification
+
+Build from the repository root, then verify from a clean non-project directory:
+
+```bash
+uv build --all-packages --out-dir dist/workspace --clear
+uv build --project examples/broker-peer --out-dir dist/examples
+uv run python scripts/run_isolated_install.py \
+  --with dist/workspace/liteyukibot_v7-7.0.0a9-py3-none-any.whl \
+  --with dist/workspace/liteyukibot_v7_runtime_nonebot_api-7.0.0a9-py3-none-any.whl \
+  --verifier scripts/verify_nonebot_api_install.py \
+  -- --expected-version 7.0.0a9
+uv run python scripts/run_isolated_install.py \
+  --with dist/workspace/liteyukibot_v7-7.0.0a9-py3-none-any.whl \
+  --with dist/examples/liteyukibot_example_broker_peer-0.1.0-py3-none-any.whl \
+  --verifier scripts/verify_broker_peer_example.py
+```
+
+The AstrBot API verifier uses the analogous AstrBot wheel. A verifier must
+not succeed because `src/` is on `PYTHONPATH`; `run_isolated_install.py`
+removes project environment variables before starting it.
+
+## Troubleshooting
+
+- `manifest_mismatch`: compare configured bridge access, subscriptions,
+  action resources, and the catalog fingerprint; the broker configuration is
+  authoritative.
+- `RUNTIME_API_NOT_REGISTERED`: confirm the requested runtime kind, API ID,
+  version range, and active delivery lease.
+- `RUNTIME_API_INVALID_ARGUMENTS`: validate against the declaration's Draft
+  2020-12 input schema before calling the provider.
+- `RUNTIME_API_INVALID_RESULT`: the provider returned a value outside its
+  declared output schema or typed DTO.
+- `RuntimeUnavailable`: the optional facade has no compatible provider or the
+  selected `bridge_id` is offline; do not turn this into a successful empty
+  result.

--- a/docs/roadmap/v7-alpha-10-2-ecosystem-proof.md
+++ b/docs/roadmap/v7-alpha-10-2-ecosystem-proof.md
@@ -1,0 +1,44 @@
+# v7 Alpha 10.2: Ecosystem and Release Proof
+
+Alpha10.2 proves the Alpha10.1 portable facade and B7 bridge boundary from
+installable artifacts. It improves contributor and release evidence without
+adding a provider, a portable operation, or an Alpha11 qualification gate.
+
+## Work
+
+- Generate the four stable Runtime API v1.2 operations from the kernel-owned
+  catalog helper and record a deterministic SHA-256 catalog fingerprint in
+  non-empty `BridgeManifest` values.
+- Extend the NoneBot and AstrBot API wheel verifiers to import proxy factories,
+  construct kernel DTOs, and exercise unavailable proxy behavior.
+- Run both API wheel verifiers and the example wheel verifiers in ordinary CI,
+  not only in the Alpha bundle workflow.
+- Provide an installable B7 broker-peer example that completes registration,
+  ingress, a lease-bound experimental runtime API call, completion, unregister,
+  and shutdown over real ZMQ.
+- Update the Native/Cordis plugin example and contributor documentation with
+  optional `RuntimeRequirement`/`@runtime` facade usage, provider conformance,
+  stable errors, and troubleshooting.
+
+## Boundaries
+
+Stable portable operations remain `event.snapshot`, `event.send`,
+`bot.snapshot`, and `bot.send`. Provider-only operations belong in an
+`experimental` namespace. Framework SDKs, credentials, and native message
+objects remain outside the kernel and portable examples. The historical v5
+supervised child-runtime documentation remains available for compatibility but
+is not the new bridge development path.
+
+## Exit criteria
+
+- Provider hosts use the shared portable catalog and their manifests expose a
+  matching catalog fingerprint.
+- Fingerprint mismatch is rejected before a bridge registration is accepted.
+- API and example wheel verifiers pass from clean non-project directories with
+  no source-tree import dependency.
+- A contributor can find the B7 peer, plugin facade, conformance checklist,
+  and stable error guidance from the root documentation.
+- Full pytest, Ruff, mypy, workspace/example builds, install verifiers, and the
+  authorized external workspace pass.
+
+Alpha11 and later provider expansion remain outside this phase.

--- a/docs/roadmap/v7-alpha-10-runtime-stability.md
+++ b/docs/roadmap/v7-alpha-10-runtime-stability.md
@@ -49,5 +49,6 @@ add another provider or expand the Runtime API catalog.
 Portable snapshot/result DTO convergence is specified in the
 [Alpha10.1 plan](v7-alpha-10-1-portable-facade.md). Provider conformance
 tooling, catalog fingerprints, API package CI coverage, and B7 author examples
-remain Alpha10.2 work. A third-party provider pilot and all Alpha11+ work stay
-outside these Alpha10 gates.
+are specified in the [Alpha10.2 plan](v7-alpha-10-2-ecosystem-proof.md). A
+third-party provider pilot and all Alpha11+ work stay outside these Alpha10
+gates.

--- a/docs/roadmap/v7-alpha-roadmap.md
+++ b/docs/roadmap/v7-alpha-roadmap.md
@@ -181,7 +181,8 @@ bridge IDs and temporary broker failure before expanding the ecosystem.
 define collision-safe source event IDs, and use bounded best-effort ingress in
 the NoneBot and AstrBot hosts. Keep portable DTO convergence, catalog
 fingerprints, and new providers for later Alpha10.x gates. Alpha10.1 converges
-the portable DTOs; Alpha10.2 proves the third-party author and release path.
+the portable DTOs; [Alpha10.2](v7-alpha-10-2-ecosystem-proof.md) proves the
+third-party author and release path.
 
 **Exit criteria:** non-default bridge IDs pass provider and kernel identity
 checks; source IDs remain distinct across provider scopes; broker failure,

--- a/docs/specs/runtime-ipc-v6.md
+++ b/docs/specs/runtime-ipc-v6.md
@@ -41,6 +41,12 @@ instance token, and immutable manifest. The manifest declares an access class
 declarations `(kind, resource)` or `(kind, resource_prefix)`. A declaration
 must select exactly one matching mode.
 
+The manifest may also declare Runtime API operations. When `runtime_apis` is
+non-empty, `runtime_api_fingerprint` records the SHA-256 digest of the
+canonical sorted declarations; the broker rejects a supplied digest that does
+not match. Stable Alpha10.1 providers use the kernel-owned v1.2 portable
+catalog, while provider-only operations remain explicitly experimental.
+
 The broker authenticates the token, binds the ZMQ peer identity, and returns a
 broker-generated session ID in `bridge.registered`. Unknown bridges, invalid
 tokens, already-live bridge IDs, identity rebinding, malformed messages, and

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,16 +4,19 @@ Examples are small installable packages that exercise public extension points.
 They are not templates copied into production unchanged.
 
 - `native-plugin/` demonstrates a native plugin entry point, EventBus cleanup,
-  and protocol-neutral replies.
+  protocol-neutral replies, and the optional Native/Cordis runtime facade.
+- `broker-peer/` demonstrates a real B7 `BridgeClient` registration, event
+  lease, experimental runtime API call, completion, and shutdown.
 - `custom-runtime/` preserves a protocol-v5 child-runtime example using the
   shared `RuntimeClient` and supervisor-owned lifecycle. It is not a B5 broker
-  peer example; a broker-peer integration has not been implemented yet.
+  peer example and is retained as historical compatibility evidence.
 
 Keep examples minimal, dependency-bounded, and aligned with the public guides
 in `docs/development/`. Build them from the repository root:
 
 ```bash
 uv build --project examples/native-plugin --out-dir dist/examples
+uv build --project examples/broker-peer --out-dir dist/examples
 uv build --project examples/custom-runtime --out-dir dist/examples
 ```
 

--- a/examples/broker-peer/README.md
+++ b/examples/broker-peer/README.md
@@ -1,0 +1,16 @@
+# B7 broker-peer example
+
+This installable example uses the public `BrokerPeerServer` and `BridgeClient`
+APIs. Its self-test completes bridge registration, an event ingress and lease,
+an `experimental.echo` runtime API call, event completion, unregister, and
+shutdown over the real ZMQ transport.
+
+Build it from the repository root:
+
+```bash
+uv build --project examples/broker-peer --out-dir dist/examples
+```
+
+The example does not create bridge IDs, session IDs, kernel event IDs, leases,
+or delivery recipients. It is intentionally a protocol sample, not a process
+supervisor or a framework adapter.

--- a/examples/broker-peer/pyproject.toml
+++ b/examples/broker-peer/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "liteyukibot-example-broker-peer"
+version = "0.1.0"
+description = "Minimal installable LiteyukiBot v7 B7 broker-peer example."
+readme = "README.md"
+requires-python = ">=3.14"
+dependencies = [
+    "liteyukibot-v7>=7.0.0a9,<8",
+]
+
+[project.scripts]
+liteyuki-example-broker-peer = "liteyukibot_example_broker_peer:main"
+
+[build-system]
+requires = ["uv_build>=0.11.32,<0.12"]
+build-backend = "uv_build"
+
+[tool.uv.sources]
+liteyukibot-v7 = { workspace = true }
+
+[tool.uv.build-backend]
+module-root = "src"
+module-name = "liteyukibot_example_broker_peer"

--- a/examples/broker-peer/src/liteyukibot_example_broker_peer/__init__.py
+++ b/examples/broker-peer/src/liteyukibot_example_broker_peer/__init__.py
@@ -1,0 +1,167 @@
+"""Minimal installable B7 broker-peer example."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+
+import zmq.asyncio
+
+from liteyukibot.broker import (
+    AuthorizationContextWire,
+    BridgeAccess,
+    BridgeClient,
+    BridgeManifest,
+    BrokerPeerServer,
+    EventAccepted,
+    EventCompleted,
+    EventIngress,
+    RuntimeApiDeclaration,
+    RuntimeApiInvoke,
+    RuntimeApiResult,
+)
+
+BRIDGE_ID = "example.peer"
+INSTANCE_TOKEN = "example-peer-token"
+API_ID = "experimental.echo"
+
+
+def build_manifest() -> BridgeManifest:
+    """Build the complete manifest owned by this example peer."""
+
+    return BridgeManifest(
+        bridge_id=BRIDGE_ID,
+        access=BridgeAccess.LIMITED,
+        subscriptions=("message.created",),
+        runtime_apis=(
+            RuntimeApiDeclaration(
+                runtime_kind=BRIDGE_ID,
+                namespace="experimental",
+                operation="echo",
+                version="1.0",
+                input_schema={
+                    "type": "object",
+                    "properties": {"value": {"type": "string", "minLength": 1}},
+                    "required": ["value"],
+                    "additionalProperties": False,
+                },
+                output_schema={
+                    "type": "object",
+                    "properties": {"echo": {"type": "string"}},
+                    "required": ["echo"],
+                    "additionalProperties": False,
+                },
+            ),
+        ),
+    )
+
+
+async def _serve_control(server: BrokerPeerServer) -> None:
+    await server.serve_control_once()
+
+
+async def _serve_business(server: BrokerPeerServer) -> None:
+    await server.serve_business_once()
+
+
+async def run_demo() -> Mapping[str, str]:
+    """Run the complete peer lifecycle and return small verification facts."""
+
+    context = zmq.asyncio.Context()
+    server = BrokerPeerServer(
+        context=context,
+        endpoint="tcp://127.0.0.1:*",
+        generation=1,
+        instance_tokens={BRIDGE_ID: INSTANCE_TOKEN},
+    )
+    client = BridgeClient(
+        context=context,
+        endpoints=server.endpoints,
+        generation=1,
+        identity=b"example-peer",
+        manifest=build_manifest(),
+        instance_token=INSTANCE_TOKEN,
+    )
+    try:
+        registration = asyncio.create_task(_serve_control(server))
+        session_id = await client.register()
+        await registration
+
+        ingress = EventIngress(
+            source_event_id="example-source-event",
+            topic="message.created",
+            ordering_key="group:example",
+            payload={"bot_id": "bot-1", "message": "hello"},
+        )
+        business = asyncio.create_task(_serve_business(server))
+        await client.send_event_ingress(ingress)
+        await business
+        delivery = await client.receive_event_message()
+        if delivery.event.source_event_id != ingress.source_event_id:
+            raise RuntimeError("broker changed the source event identity")
+
+        await client.send_event_accepted(
+            EventAccepted(delivery_id=delivery.delivery_id, lease_id=delivery.lease_id)
+        )
+        await _serve_business(server)
+
+        request = RuntimeApiInvoke(
+            delivery_id=delivery.delivery_id,
+            source_event_id=delivery.event.source_event_id,
+            lease_id=delivery.lease_id,
+            correlation_id="example-runtime-call",
+            runtime_kind=BRIDGE_ID,
+            version="^1.0",
+            api_id=API_ID,
+            caller_extension_id="example.plugin",
+            arguments={"value": "hello"},
+            authorization=AuthorizationContextWire(
+                event_id=delivery.event.kernel_event_id,
+                runtime_id=BRIDGE_ID,
+                bot_id="bot-1",
+                actor_id="user-1",
+            ),
+        )
+        business = asyncio.create_task(_serve_business(server))
+        await client.send_runtime_api_invoke(request)
+        await business
+        routed_request = await client.receive_business()
+        if not isinstance(routed_request, RuntimeApiInvoke) or routed_request.invocation_id is None:
+            raise RuntimeError("broker did not route the runtime API invocation")
+
+        result = RuntimeApiResult(
+            invocation_id=routed_request.invocation_id,
+            correlation_id=routed_request.correlation_id,
+            success=True,
+            result={"echo": routed_request.arguments["value"]},
+        )
+        business = asyncio.create_task(_serve_business(server))
+        await client.send_runtime_api_result(result)
+        await business
+        returned_result = await client.receive_business()
+        if not isinstance(returned_result, RuntimeApiResult) or returned_result.result != {"echo": "hello"}:
+            raise RuntimeError("broker did not return the runtime API result")
+
+        business = asyncio.create_task(_serve_business(server))
+        await client.send_event_completed(
+            EventCompleted(delivery_id=delivery.delivery_id, lease_id=delivery.lease_id, success=True)
+        )
+        await business
+
+        unregistration = asyncio.create_task(_serve_control(server))
+        await client.unregister()
+        await unregistration
+        return {"session_id": session_id, "runtime_result": "hello", "shutdown": "true"}
+    finally:
+        client.close()
+        server.close()
+        context.term()
+
+
+def main() -> int:
+    print(json.dumps(asyncio.run(run_demo()), sort_keys=True))
+    return 0
+
+
+__all__ = ["API_ID", "BRIDGE_ID", "build_manifest", "main", "run_demo"]

--- a/examples/broker-peer/src/liteyukibot_example_broker_peer/__main__.py
+++ b/examples/broker-peer/src/liteyukibot_example_broker_peer/__main__.py
@@ -1,0 +1,3 @@
+from . import main
+
+raise SystemExit(main())

--- a/examples/native-plugin/README.md
+++ b/examples/native-plugin/README.md
@@ -1,9 +1,30 @@
-# Native plugin example
+# Native/Cordis plugin example
 
-This package exposes `example.echo` through the `liteyukibot.plugins` entry
-point. Its handler replies to message events through protocol-neutral v7 Event
-and Action models. The plugin explicitly removes its EventBus subscription in
-the stop callback.
+This package exposes `example.echo` and `example.runtime` through the
+`liteyukibot.plugins` entry point. The echo handler replies to message events
+through protocol-neutral v7 Event and Action models. The runtime facade is a
+separate optional plugin so the basic echo example keeps no-provider startup
+semantics.
+
+It also demonstrates the shared Native/Cordis runtime facade contract. The
+`RuntimeRequirement` and `@runtime` declaration request the optional AstrBot
+`event.snapshot` API v1.2. The handler checks `available` and tolerates an
+uninstalled or disconnected provider; it never imports AstrBot.
+
+```python
+@runtime("astrbot", api="event", version="^1.2", optional=True, as_="astrbot")
+async def observe(event: EventEnvelope, *, astrbot: AstrBotEventProxy) -> HandlerResult | None:
+    if not astrbot.available:
+        return None
+    await astrbot.snapshot()
+    return None
+```
+
+Install `liteyukibot-v7-runtime-astrbot-api` separately when the typed
+`AstrBotEventProxy` facade is desired. The plugin remains framework-neutral.
+Runtime requirements are activation capabilities, so the host permission
+ceiling must allow `runtime.astrbot.event.snapshot` even when the provider is
+optional.
 
 ```bash
 uv build

--- a/examples/native-plugin/pyproject.toml
+++ b/examples/native-plugin/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
 
 [project.entry-points."liteyukibot.plugins"]
 "example.echo" = "liteyukibot_example_plugin:plugin"
+"example.runtime" = "liteyukibot_example_plugin:runtime_facade_plugin"
 
 [build-system]
 requires = ["uv_build>=0.11.32,<0.12"]

--- a/examples/native-plugin/src/liteyukibot_example_plugin/__init__.py
+++ b/examples/native-plugin/src/liteyukibot_example_plugin/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from liteyukibot import PluginContext, PluginDefinition, PluginManifest
+from typing import Any
+
+from liteyukibot import PluginContext, PluginDefinition, PluginManifest, RuntimeRequirement, RuntimeUnavailable, runtime
 from liteyukibot.events import (
     ActionEnvelope,
     EventEnvelope,
@@ -11,6 +13,20 @@ from liteyukibot.events import (
     Segment,
     SendMessage,
 )
+
+
+@runtime("astrbot", api="event", version="^1.2", optional=True, as_="astrbot")
+async def observe_provider_event(event: EventEnvelope, *, astrbot: Any) -> HandlerResult | None:
+    if not getattr(astrbot, "available", False):
+        return None
+    snapshot = getattr(astrbot, "snapshot", None)
+    if not callable(snapshot):
+        return None
+    try:
+        await snapshot()
+    except RuntimeUnavailable:
+        return None
+    return None
 
 
 async def setup(context: PluginContext) -> None:
@@ -39,6 +55,11 @@ async def setup(context: PluginContext) -> None:
     context.defer_cleanup(lambda: context.events.unsubscribe(subscription))
 
 
+async def setup_runtime_facade(context: PluginContext) -> None:
+    subscription = context.events.subscribe(observe_provider_event, name="example.runtime_probe")
+    context.defer_cleanup(lambda: context.events.unsubscribe(subscription))
+
+
 plugin = PluginDefinition(
     manifest=PluginManifest(
         id="example.echo",
@@ -49,4 +70,22 @@ plugin = PluginDefinition(
     setup=setup,
 )
 
-__all__ = ["plugin"]
+runtime_facade_plugin = PluginDefinition(
+    manifest=PluginManifest(
+        id="example.runtime",
+        name="Runtime facade example",
+        version="0.1.0",
+        runtime_requirements=(
+            RuntimeRequirement(
+                runtime="astrbot",
+                api="event",
+                version="^1.2",
+                operations=("snapshot",),
+                optional=True,
+            ),
+        ),
+    ),
+    setup=setup_runtime_facade,
+)
+
+__all__ = ["observe_provider_event", "plugin", "runtime_facade_plugin"]

--- a/packages/runtime-astrbot-api/README.md
+++ b/packages/runtime-astrbot-api/README.md
@@ -11,3 +11,9 @@ result types are kernel-owned portable DTOs; AstrBot platform/session fields
 remain under the `astrbot` extension namespace. The old text projection is
 available as `message_text`; `event.snapshot().message` is now a portable
 `Message`.
+
+Native/Cordis extensions declare a matching `RuntimeRequirement` and use the
+kernel `@runtime` decorator. Keep the requirement optional when AstrBot is an
+enhancement; check `proxy.available` before calling it and handle
+`RuntimeUnavailable` or stable `RUNTIME_*` errors. The installed facade keeps
+AstrBot-specific values under `extensions["astrbot"]`.

--- a/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
+++ b/packages/runtime-astrbot/src/liteyukibot_runtime_astrbot/host.py
@@ -20,7 +20,6 @@ import zmq.asyncio
 
 from liteyukibot.broker import (
     MESSAGE_SEND_KIND,
-    PORTABLE_RUNTIME_API_VERSION,
     ActionOutcome,
     ActionRequest,
     ActionResourceDeclaration,
@@ -33,15 +32,9 @@ from liteyukibot.broker import (
     MessageSendPayload,
     RuntimeApiDeclaration,
     RuntimeApiInvoke,
-    RuntimeApiOperation,
     RuntimeApiOutcome,
     parse_message_send_request,
-    portable_bot_snapshot_schema,
-    portable_conversation_schema,
-    portable_event_snapshot_schema,
-    portable_message_schema,
-    portable_send_result_schema,
-    runtime_api_catalog,
+    portable_runtime_api_catalog,
 )
 from liteyukibot.config import AppSettings, LoggingSettings
 from liteyukibot.events import ConversationRef, JsonValue, Message, Segment
@@ -566,60 +559,7 @@ def _optional_text(value: object) -> str | None:
 
 
 def _runtime_api_declarations() -> tuple[RuntimeApiDeclaration, ...]:
-    return runtime_api_catalog(
-        "astrbot",
-        (
-            RuntimeApiOperation(
-                namespace="event",
-                operation="snapshot",
-                version=PORTABLE_RUNTIME_API_VERSION,
-                input_schema={"type": "object", "additionalProperties": False},
-                output_schema=portable_event_snapshot_schema(),
-            ),
-            RuntimeApiOperation(
-                namespace="event",
-                operation="send",
-                version=PORTABLE_RUNTIME_API_VERSION,
-                input_schema={
-                    "type": "object",
-                    "properties": {
-                        "message": {
-                            "oneOf": [
-                                {"type": "string", "minLength": 1},
-                                portable_message_schema(),
-                            ]
-                        }
-                    },
-                    "required": ["message"],
-                    "additionalProperties": False,
-                },
-                output_schema=portable_send_result_schema(),
-            ),
-            RuntimeApiOperation(
-                namespace="bot",
-                operation="snapshot",
-                version=PORTABLE_RUNTIME_API_VERSION,
-                input_schema={"type": "object", "additionalProperties": False},
-                output_schema=portable_bot_snapshot_schema(),
-            ),
-            RuntimeApiOperation(
-                namespace="bot",
-                operation="send",
-                version=PORTABLE_RUNTIME_API_VERSION,
-                input_schema={
-                    "type": "object",
-                    "properties": {
-                        "bot_id": {"type": "string", "minLength": 1},
-                        "message": portable_message_schema(),
-                        "conversation": portable_conversation_schema(),
-                    },
-                    "required": ["bot_id", "message", "conversation"],
-                    "additionalProperties": False,
-                },
-                output_schema=portable_send_result_schema(),
-            ),
-        ),
-    )
+    return portable_runtime_api_catalog("astrbot")
 
 
 def _runtime_message(value: object) -> Message:

--- a/packages/runtime-nonebot-api/README.md
+++ b/packages/runtime-nonebot-api/README.md
@@ -10,3 +10,9 @@ The supported portable surface includes `event.snapshot()`,
 never expose NoneBot objects, adapter objects, or arbitrary API passthrough.
 Snapshot and send result types are kernel-owned portable DTOs; provider-specific
 values are available only under explicit extensions.
+
+Native/Cordis extensions declare a matching `RuntimeRequirement` and use the
+kernel `@runtime` decorator. Keep the requirement optional when the provider
+is an enhancement; check `proxy.available` before calling it and handle
+`RuntimeUnavailable` or stable `RUNTIME_*` errors. The isolated API verifier
+is the reference for the installed entry-point and DTO boundary.

--- a/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/host.py
+++ b/packages/runtime-nonebot/src/liteyukibot_runtime_nonebot/host.py
@@ -14,7 +14,6 @@ import zmq.asyncio
 
 from liteyukibot.broker import (
     MESSAGE_SEND_KIND,
-    PORTABLE_RUNTIME_API_VERSION,
     ActionOutcome,
     ActionRequest,
     ActionResourceDeclaration,
@@ -27,15 +26,9 @@ from liteyukibot.broker import (
     MessageSendPayload,
     RuntimeApiDeclaration,
     RuntimeApiInvoke,
-    RuntimeApiOperation,
     RuntimeApiOutcome,
     parse_message_send_request,
-    portable_bot_snapshot_schema,
-    portable_conversation_schema,
-    portable_event_snapshot_schema,
-    portable_message_schema,
-    portable_send_result_schema,
-    runtime_api_catalog,
+    portable_runtime_api_catalog,
 )
 from liteyukibot.config import AppSettings
 from liteyukibot.events import ConversationRef, EventEnvelope, JsonValue, Message, Segment
@@ -379,60 +372,7 @@ def _runtime_conversation(value: object) -> ConversationRef:
 
 
 def _runtime_api_declarations() -> tuple[RuntimeApiDeclaration, ...]:
-    return runtime_api_catalog(
-        "nonebot",
-        (
-            RuntimeApiOperation(
-                namespace="event",
-                operation="snapshot",
-                version=PORTABLE_RUNTIME_API_VERSION,
-                input_schema={"type": "object", "additionalProperties": False},
-                output_schema=portable_event_snapshot_schema(),
-            ),
-            RuntimeApiOperation(
-                namespace="event",
-                operation="send",
-                version=PORTABLE_RUNTIME_API_VERSION,
-                input_schema={
-                    "type": "object",
-                    "properties": {
-                        "message": {
-                            "oneOf": [
-                                {"type": "string", "minLength": 1},
-                                portable_message_schema(),
-                            ]
-                        }
-                    },
-                    "required": ["message"],
-                    "additionalProperties": False,
-                },
-                output_schema=portable_send_result_schema(),
-            ),
-            RuntimeApiOperation(
-                namespace="bot",
-                operation="snapshot",
-                version=PORTABLE_RUNTIME_API_VERSION,
-                input_schema={"type": "object", "additionalProperties": False},
-                output_schema=portable_bot_snapshot_schema(),
-            ),
-            RuntimeApiOperation(
-                namespace="bot",
-                operation="send",
-                version=PORTABLE_RUNTIME_API_VERSION,
-                input_schema={
-                    "type": "object",
-                    "properties": {
-                        "bot_id": {"type": "string", "minLength": 1},
-                        "message": portable_message_schema(),
-                        "conversation": portable_conversation_schema(),
-                    },
-                    "required": ["bot_id", "message", "conversation"],
-                    "additionalProperties": False,
-                },
-                output_schema=portable_send_result_schema(),
-            ),
-        ),
-    )
+    return portable_runtime_api_catalog("nonebot")
 
 
 def _mapping_option(options: Mapping[str, Any], key: str) -> dict[str, Any]:

--- a/scripts/verify_astrbot_api_install.py
+++ b/scripts/verify_astrbot_api_install.py
@@ -5,6 +5,17 @@ from __future__ import annotations
 import argparse
 import importlib.metadata
 
+from liteyukibot_runtime_astrbot_api import (
+    AstrBotBotProxy,
+    AstrBotBotSnapshot,
+    AstrBotEventProxy,
+    AstrBotEventSnapshot,
+    bot_proxy_factory,
+    proxy_factory,
+)
+
+from liteyukibot.runtime_api import BotSnapshot, EventSnapshot, RuntimeBinding, SendResult
+
 
 def main() -> int:
     parser = argparse.ArgumentParser()
@@ -24,6 +35,44 @@ def main() -> int:
     }
     if entry_points != expected:
         raise RuntimeError(f"unexpected AstrBot API facade entry points: {entry_points!r}")
+    event = AstrBotEventSnapshot.model_validate(
+        {
+            "source_event_id": "source-event",
+            "runtime_id": "astrbot",
+            "adapter": "aiocqhttp",
+            "bot_id": "bot-1",
+            "event_type": "message.created",
+            "conversation": {"id": "chat-1", "type": "group"},
+            "extensions": {"astrbot": {"platform_id": "qq", "session_id": "session-1"}},
+        }
+    )
+    bot = AstrBotBotSnapshot.model_validate(
+        {
+            "bot_id": "bot-1",
+            "adapter": "aiocqhttp",
+            "extensions": {"astrbot": {"platform_id": "qq", "platform_name": "aiocqhttp"}},
+        }
+    )
+    if not isinstance(event, EventSnapshot) or not isinstance(bot, BotSnapshot):
+        raise RuntimeError("AstrBot snapshots do not use kernel-owned DTOs")
+    if event.platform_id != "qq" or bot.platform_name != "aiocqhttp":
+        raise RuntimeError("AstrBot compatibility properties did not read extensions")
+    if not SendResult(sent=True).sent:
+        raise RuntimeError("AstrBot SendResult is not usable")
+    event_proxy = proxy_factory(
+        binding=RuntimeBinding("astrbot", "event", "^1.2", True, "astrbot_event"),
+        backend=None,
+        context=None,
+    )
+    bot_proxy = bot_proxy_factory(
+        binding=RuntimeBinding("astrbot", "bot", "^1.2", True, "astrbot_bot"),
+        backend=None,
+        context=None,
+    )
+    if not isinstance(event_proxy, AstrBotEventProxy) or not isinstance(bot_proxy, AstrBotBotProxy):
+        raise RuntimeError("AstrBot proxy entry points returned the wrong facade type")
+    if event_proxy.available or bot_proxy.available:
+        raise RuntimeError("unavailable AstrBot runtime proxies reported availability")
     return 0
 
 

--- a/scripts/verify_broker_peer_example.py
+++ b/scripts/verify_broker_peer_example.py
@@ -1,0 +1,19 @@
+"""Run the installable B7 broker-peer example from an isolated wheel environment."""
+
+from __future__ import annotations
+
+import asyncio
+
+from liteyukibot_example_broker_peer import run_demo
+
+
+def main() -> int:
+    result = asyncio.run(run_demo())
+    expected = {"runtime_result": "hello", "shutdown": "true"}
+    if any(result.get(key) != value for key, value in expected.items()):
+        raise RuntimeError(f"unexpected B7 example result: {result!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_native_plugin_example.py
+++ b/scripts/verify_native_plugin_example.py
@@ -1,0 +1,30 @@
+"""Verify the installable Native/Cordis runtime facade example."""
+
+from __future__ import annotations
+
+from liteyukibot_example_plugin import observe_provider_event, runtime_facade_plugin
+
+from liteyukibot import runtime_bindings
+
+
+def main() -> int:
+    requirements = runtime_facade_plugin.manifest.runtime_requirements
+    bindings = runtime_bindings(observe_provider_event)
+    if len(requirements) != 1 or len(bindings) != 1:
+        raise RuntimeError("native plugin example did not declare one runtime facade")
+    requirement = requirements[0]
+    binding = bindings[0]
+    if (requirement.runtime, requirement.api, requirement.version, requirement.optional) != (
+        binding.runtime,
+        binding.api,
+        binding.version,
+        binding.optional,
+    ):
+        raise RuntimeError("native plugin runtime declaration and manifest requirement do not match")
+    if requirement.operations != ("snapshot",):
+        raise RuntimeError(f"unexpected native plugin runtime operations: {requirement.operations!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_nonebot_api_install.py
+++ b/scripts/verify_nonebot_api_install.py
@@ -5,6 +5,18 @@ from __future__ import annotations
 import argparse
 import importlib.metadata
 
+from liteyukibot_runtime_nonebot_api import (
+    NoneBotBotProxy,
+    NoneBotBotSnapshot,
+    NoneBotEventProxy,
+    NoneBotEventSnapshot,
+    bot_proxy_factory,
+    event_proxy_factory,
+)
+
+from liteyukibot.events import ConversationRef
+from liteyukibot.runtime_api import BotSnapshot, EventSnapshot, RuntimeBinding, SendResult
+
 
 def main() -> int:
     parser = argparse.ArgumentParser()
@@ -25,6 +37,37 @@ def main() -> int:
     }
     if entry_points != expected:
         raise RuntimeError(f"unexpected NoneBot API facade entry points: {entry_points!r}")
+    event = NoneBotEventSnapshot.model_validate(
+        {
+            "source_event_id": "source-event",
+            "runtime_id": "nonebot",
+            "adapter": "onebot-v11",
+            "bot_id": "bot-1",
+            "event_type": "message.created",
+            "conversation": {"id": "chat-1", "type": "group"},
+        }
+    )
+    bot = NoneBotBotSnapshot.model_validate({"bot_id": "bot-1", "adapter": "onebot-v11"})
+    if not isinstance(event, EventSnapshot) or not isinstance(bot, BotSnapshot):
+        raise RuntimeError("NoneBot snapshots do not use kernel-owned DTOs")
+    if not SendResult(sent=True).sent:
+        raise RuntimeError("NoneBot SendResult is not usable")
+    event_proxy = event_proxy_factory(
+        binding=RuntimeBinding("nonebot", "event", "^1.2", True, "nonebot_event"),
+        backend=None,
+        context=None,
+    )
+    bot_proxy = bot_proxy_factory(
+        binding=RuntimeBinding("nonebot", "bot", "^1.2", True, "nonebot_bot"),
+        backend=None,
+        context=None,
+    )
+    if not isinstance(event_proxy, NoneBotEventProxy) or not isinstance(bot_proxy, NoneBotBotProxy):
+        raise RuntimeError("NoneBot proxy entry points returned the wrong facade type")
+    if event_proxy.available or bot_proxy.available:
+        raise RuntimeError("unavailable NoneBot runtime proxies reported availability")
+    if event.conversation != ConversationRef(id="chat-1", type="group"):
+        raise RuntimeError("NoneBot snapshot conversation DTO did not round-trip")
     return 0
 
 

--- a/src/liteyukibot/broker/__init__.py
+++ b/src/liteyukibot/broker/__init__.py
@@ -58,6 +58,7 @@ from .protocol import (
     RuntimeApiDeclaration,
     decode_broker_message,
     encode_broker_message,
+    runtime_api_catalog_fingerprint,
 )
 from .routing import (
     ActionRequest,
@@ -90,6 +91,9 @@ from .runtime_catalog import (
     portable_conversation_schema,
     portable_event_snapshot_schema,
     portable_message_schema,
+    portable_runtime_api_catalog,
+    portable_runtime_api_catalog_fingerprint,
+    portable_runtime_api_operations,
     portable_send_result_schema,
     runtime_api_catalog,
 )
@@ -134,6 +138,7 @@ __all__ = [
     "BridgeControlResult",
     "BrokerToolDeclaration",
     "RuntimeApiDeclaration",
+    "runtime_api_catalog_fingerprint",
     "RuntimeApiOperation",
     "PORTABLE_RUNTIME_API_VERSION",
     "BridgeAccess",
@@ -186,6 +191,9 @@ __all__ = [
     "portable_bot_snapshot_schema",
     "portable_event_snapshot_schema",
     "portable_message_schema",
+    "portable_runtime_api_catalog",
+    "portable_runtime_api_catalog_fingerprint",
+    "portable_runtime_api_operations",
     "portable_send_result_schema",
     "decode_broker_message",
     "decode_business_message",

--- a/src/liteyukibot/broker/protocol.py
+++ b/src/liteyukibot/broker/protocol.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import Annotated, Final, Literal
 
@@ -182,6 +184,19 @@ class RuntimeApiDeclaration(BrokerWireModel):
         return f"{self.namespace}.{self.operation}"
 
 
+def runtime_api_catalog_fingerprint(declarations: Sequence[RuntimeApiDeclaration]) -> str:
+    """Return a deterministic digest for one runtime API catalog."""
+
+    serialized = [declaration.model_dump(mode="json") for declaration in declarations]
+    serialized.sort(
+        key=lambda value: tuple(
+            str(value[field]) for field in ("runtime_kind", "namespace", "operation", "version")
+        )
+    )
+    payload = json.dumps(serialized, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
 class AuthorizationContextWire(BrokerWireModel):
     """Only event identity and principal fields may cross the Tool wire."""
 
@@ -210,6 +225,12 @@ class BridgeManifest(BrokerWireModel):
     tools: tuple[BrokerToolDeclaration, ...] = ()
     controls: tuple[str, ...] = ()
     runtime_apis: tuple[RuntimeApiDeclaration, ...] = ()
+    runtime_api_fingerprint: str | None = Field(
+        default=None,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-f]{64}$",
+    )
 
     @field_validator("bridge_id", mode="before")
     @classmethod
@@ -253,6 +274,14 @@ class BridgeManifest(BrokerWireModel):
         api_ids = tuple((api.runtime_kind, api.api_id) for api in self.runtime_apis)
         if len(api_ids) != len(set(api_ids)):
             raise ValueError("runtime API declarations must not contain duplicate IDs")
+        if self.runtime_apis:
+            expected_fingerprint = runtime_api_catalog_fingerprint(self.runtime_apis)
+            if self.runtime_api_fingerprint is None:
+                object.__setattr__(self, "runtime_api_fingerprint", expected_fingerprint)
+            elif self.runtime_api_fingerprint != expected_fingerprint:
+                raise ValueError("runtime API catalog fingerprint does not match its declarations")
+        elif self.runtime_api_fingerprint is not None:
+            raise ValueError("runtime API catalog fingerprint requires runtime API declarations")
         return self
 
 

--- a/src/liteyukibot/broker/runtime_catalog.py
+++ b/src/liteyukibot/broker/runtime_catalog.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import cast
 
 from ..runtime_api_models import BotSnapshot, EventSnapshot, SendResult
-from .protocol import RuntimeApiDeclaration
+from .protocol import RuntimeApiDeclaration, runtime_api_catalog_fingerprint
 
 PORTABLE_RUNTIME_API_VERSION = "1.2"
 
@@ -132,6 +132,77 @@ def portable_send_result_schema() -> dict[str, object]:
     return cast(dict[str, object], SendResult.model_json_schema())
 
 
+def portable_runtime_api_operations() -> tuple[RuntimeApiOperation, ...]:
+    """Build the complete Alpha10.1 portable operation catalog."""
+
+    empty_input = {"type": "object", "additionalProperties": False}
+    message_input = {
+        "type": "object",
+        "properties": {
+            "message": {
+                "oneOf": [
+                    {"type": "string", "minLength": 1},
+                    portable_message_schema(),
+                ]
+            }
+        },
+        "required": ["message"],
+        "additionalProperties": False,
+    }
+    bot_send_input = {
+        "type": "object",
+        "properties": {
+            "bot_id": {"type": "string", "minLength": 1},
+            "message": portable_message_schema(),
+            "conversation": portable_conversation_schema(),
+        },
+        "required": ["bot_id", "message", "conversation"],
+        "additionalProperties": False,
+    }
+    return (
+        RuntimeApiOperation(
+            namespace="event",
+            operation="snapshot",
+            version=PORTABLE_RUNTIME_API_VERSION,
+            input_schema=empty_input,
+            output_schema=portable_event_snapshot_schema(),
+        ),
+        RuntimeApiOperation(
+            namespace="event",
+            operation="send",
+            version=PORTABLE_RUNTIME_API_VERSION,
+            input_schema=message_input,
+            output_schema=portable_send_result_schema(),
+        ),
+        RuntimeApiOperation(
+            namespace="bot",
+            operation="snapshot",
+            version=PORTABLE_RUNTIME_API_VERSION,
+            input_schema=empty_input,
+            output_schema=portable_bot_snapshot_schema(),
+        ),
+        RuntimeApiOperation(
+            namespace="bot",
+            operation="send",
+            version=PORTABLE_RUNTIME_API_VERSION,
+            input_schema=bot_send_input,
+            output_schema=portable_send_result_schema(),
+        ),
+    )
+
+
+def portable_runtime_api_catalog(runtime_kind: str) -> tuple[RuntimeApiDeclaration, ...]:
+    """Bind the complete portable catalog to one provider runtime kind."""
+
+    return runtime_api_catalog(runtime_kind, portable_runtime_api_operations())
+
+
+def portable_runtime_api_catalog_fingerprint(runtime_kind: str) -> str:
+    """Return the fingerprint for one provider's complete portable catalog."""
+
+    return runtime_api_catalog_fingerprint(portable_runtime_api_catalog(runtime_kind))
+
+
 __all__ = [
     "PORTABLE_RUNTIME_API_VERSION",
     "RuntimeApiOperation",
@@ -139,6 +210,9 @@ __all__ = [
     "portable_conversation_schema",
     "portable_event_snapshot_schema",
     "portable_message_schema",
+    "portable_runtime_api_catalog",
+    "portable_runtime_api_catalog_fingerprint",
+    "portable_runtime_api_operations",
     "portable_send_result_schema",
     "runtime_api_catalog",
 ]

--- a/src/liteyukibot/broker/service.py
+++ b/src/liteyukibot/broker/service.py
@@ -184,6 +184,7 @@ class _AuthoritativePeerService(BrokerPeerService):
                         ),
                     )
                 updates["runtime_apis"] = message.manifest.runtime_apis
+                updates["runtime_api_fingerprint"] = message.manifest.runtime_api_fingerprint
             if updates:
                 expected = expected.model_copy(update=updates)
         if expected is not None and message.manifest != expected:

--- a/tests/test_broker_peer.py
+++ b/tests/test_broker_peer.py
@@ -20,8 +20,10 @@ from liteyukibot.broker import (
     BrokerPeerServer,
     BrokerPeerService,
     BrokerWireError,
+    RuntimeApiDeclaration,
     decode_broker_message,
     encode_broker_message,
+    runtime_api_catalog_fingerprint,
 )
 from liteyukibot.lyip import LyipError, LyipFrame, LyipLane, LyipOfferResult, ZmqLyipDealer
 
@@ -62,6 +64,7 @@ def test_manifest_is_immutable_json_safe_and_rejects_invalid_declarations() -> N
         "tools": [],
         "controls": [],
         "runtime_apis": [],
+        "runtime_api_fingerprint": None,
     }
     with pytest.raises(ValidationError, match="duplicates"):
         BridgeManifest(
@@ -71,6 +74,31 @@ def test_manifest_is_immutable_json_safe_and_rejects_invalid_declarations() -> N
         )
     with pytest.raises(ValidationError, match="non-empty"):
         BridgeManifest(bridge_id=" ", access=BridgeAccess.LIMITED)
+
+
+def test_manifest_records_and_validates_runtime_api_catalog_fingerprint() -> None:
+    declaration = RuntimeApiDeclaration(
+        runtime_kind="example",
+        namespace="experimental",
+        operation="echo",
+        version="1.0",
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+    manifest = BridgeManifest(
+        bridge_id="example",
+        access=BridgeAccess.LIMITED,
+        runtime_apis=(declaration,),
+    )
+
+    assert manifest.runtime_api_fingerprint == runtime_api_catalog_fingerprint((declaration,))
+    with pytest.raises(ValidationError, match="fingerprint"):
+        BridgeManifest(
+            bridge_id="example",
+            access=BridgeAccess.LIMITED,
+            runtime_apis=(declaration,),
+            runtime_api_fingerprint="0" * 64,
+        )
 
 
 def test_event_ledger_defaults_are_consistent_across_broker_hosts() -> None:

--- a/tests/test_broker_service.py
+++ b/tests/test_broker_service.py
@@ -18,6 +18,7 @@ from liteyukibot.broker.protocol import (
     BridgeRegister,
     BridgeRegistered,
     BridgeRejected,
+    RuntimeApiDeclaration,
     decode_broker_message,
     encode_broker_message,
 )
@@ -209,6 +210,49 @@ def test_authoritative_service_rejects_token_matched_manifest_mismatch() -> None
 
     assert isinstance(reply, BridgeRejected)
     assert reply.code == "manifest_mismatch"
+
+
+def test_authoritative_service_preserves_dynamic_runtime_catalog_fingerprint() -> None:
+    configured = BridgeManifest(
+        bridge_id="provider",
+        access=BridgeAccess.LIMITED,
+    )
+    declaration = RuntimeApiDeclaration(
+        runtime_kind="example",
+        namespace="experimental",
+        operation="echo",
+        version="1.0",
+        input_schema={"type": "object"},
+        output_schema={"type": "object"},
+    )
+    service = _AuthoritativePeerService(
+        manifests={"provider": configured},
+        instance_tokens={"provider": "secret"},
+        generation=1,
+        active_capacity=1024,
+        terminal_capacity=16384,
+        terminal_ttl_seconds=3600,
+        delivery_timeout_seconds=30,
+        dynamic_runtime_api_bridge_ids=frozenset({"provider"}),
+        runtime_kinds={"provider": "example"},
+    )
+    manifest = BridgeManifest(
+        bridge_id="provider",
+        access=BridgeAccess.LIMITED,
+        runtime_apis=(declaration,),
+    )
+    frame = encode_broker_message(
+        BridgeRegister(bridge_id="provider", instance_token="secret", manifest=manifest),
+        generation=1,
+        stream_id="bridge:provider:control",
+        sequence=0,
+        lease_id="registration",
+    )
+
+    reply = decode_broker_message(service.handle_control(b"provider-peer", frame))
+
+    assert isinstance(reply, BridgeRegistered)
+    assert service.sessions[0].manifest.runtime_api_fingerprint == manifest.runtime_api_fingerprint
 
 
 def test_authoritative_service_allows_only_dynamic_kernel_tool_and_control_fields() -> None:

--- a/tests/test_runtime_catalog.py
+++ b/tests/test_runtime_catalog.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from liteyukibot.broker import RuntimeApiOperation, runtime_api_catalog
+from liteyukibot.broker import (
+    RuntimeApiOperation,
+    portable_runtime_api_catalog,
+    portable_runtime_api_catalog_fingerprint,
+    portable_runtime_api_operations,
+    runtime_api_catalog,
+)
 
 
 def _operation(name: str = "snapshot") -> RuntimeApiOperation:
@@ -19,6 +25,22 @@ def test_runtime_api_catalog_binds_default_capability_to_provider_kind() -> None
 
     assert declarations[0].api_id == "event.snapshot"
     assert declarations[0].capabilities == ("runtime.astrbot.event.snapshot",)
+
+
+def test_portable_runtime_catalog_is_complete_and_fingerprinted() -> None:
+    operations = portable_runtime_api_operations()
+    declarations = portable_runtime_api_catalog("astrbot")
+
+    operation_ids = tuple(f"{operation.namespace}.{operation.operation}" for operation in operations)
+    assert operation_ids == (
+        "event.snapshot",
+        "event.send",
+        "bot.snapshot",
+        "bot.send",
+    )
+    assert tuple(declaration.api_id for declaration in declarations) == operation_ids
+    fingerprint = portable_runtime_api_catalog_fingerprint("astrbot")
+    assert len(fingerprint) == 64
 
 
 def test_runtime_api_operation_accepts_provider_specific_extra_capabilities() -> None:

--- a/tests/test_runtime_facade_contract.py
+++ b/tests/test_runtime_facade_contract.py
@@ -9,7 +9,11 @@ from liteyukibot_runtime_nonebot.host import _runtime_api_declarations as nonebo
 from liteyukibot_runtime_nonebot_api import NoneBotBotSnapshot, NoneBotEventSnapshot
 from pydantic import ValidationError
 
-from liteyukibot.broker import PORTABLE_RUNTIME_API_VERSION
+from liteyukibot.broker import (
+    PORTABLE_RUNTIME_API_VERSION,
+    portable_runtime_api_catalog,
+    runtime_api_catalog_fingerprint,
+)
 from liteyukibot.events import ActorRef, ConversationRef, JsonValue, Message, Segment
 from liteyukibot.runtime_api import BotSnapshot, EventSnapshot, SendResult
 
@@ -50,6 +54,12 @@ def test_provider_catalogs_share_the_canonical_portable_contract() -> None:
 
     assert set(nonebot) == {"event.snapshot", "event.send", "bot.snapshot", "bot.send"}
     assert set(astrbot) == set(nonebot)
+    assert tuple(nonebot.values()) == portable_runtime_api_catalog("nonebot")
+    assert tuple(astrbot.values()) == portable_runtime_api_catalog("astrbot")
+    nonebot_fingerprint = runtime_api_catalog_fingerprint(tuple(nonebot.values()))
+    astrbot_fingerprint = runtime_api_catalog_fingerprint(tuple(astrbot.values()))
+    assert nonebot_fingerprint == runtime_api_catalog_fingerprint(tuple(reversed(tuple(nonebot.values()))))
+    assert astrbot_fingerprint == runtime_api_catalog_fingerprint(tuple(reversed(tuple(astrbot.values()))))
     for api_id in nonebot:
         assert nonebot[api_id].version == PORTABLE_RUNTIME_API_VERSION
         assert astrbot[api_id].version == PORTABLE_RUNTIME_API_VERSION


### PR DESCRIPTION
Summary:
- Canonical runtime API catalog with deterministic fingerprints and provider conformance checks.
- Add installable B7 broker-peer lifecycle example plus Native/Cordis optional runtime facade example.
- Add isolated API/example verifiers, CI coverage, docs, and roadmap updates.

Validation:
- uv run pytest (743 passed, 11 skipped)
- uv run ruff check src tests scripts examples packages
- uv run mypy
- External F:\tmp\liteyukibot pytest/builds/verifiers passed; online verifier retries were TLS-blocked and offline cache retries passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a broker-peer integration example demonstrating registration, event handling, runtime calls, completion, and shutdown.
  * Added portable runtime API support for event and bot snapshots and messaging operations.
  * Added deterministic runtime API compatibility fingerprints for bridge manifests.
  * Added an optional runtime facade example for provider-specific integrations.

* **Documentation**
  * Expanded runtime integration, conformance, roadmap, and example guides.

* **Tests**
  * Added installation and end-to-end verification for broker-peer and runtime facade examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->